### PR TITLE
feat(api): add loadDotenv helper for local development

### DIFF
--- a/services/api/src/config/dotenv.ts
+++ b/services/api/src/config/dotenv.ts
@@ -1,0 +1,21 @@
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * Loads .env file in local development using Node's built-in process.loadEnvFile
+ * No-op when .env doesn't exist (production injects env directly)
+ */
+export function loadDotenv(): void {
+  const envPath = resolve(process.cwd(), '.env');
+
+  if (existsSync(envPath)) {
+    try {
+      process.loadEnvFile(envPath);
+    } catch (error) {
+      console.error('Failed to load .env file:', error);
+      throw error;
+    }
+  }
+  // No-op when .env doesn't exist - production injects env directly
+}
+

--- a/services/api/src/server.ts
+++ b/services/api/src/server.ts
@@ -1,7 +1,9 @@
 import { buildApp } from './app';
+import { loadDotenv } from './config/dotenv';
 import { loadEnv } from './config/env';
 
 async function main(): Promise<void> {
+  loadDotenv();
   const env = loadEnv();
   const app = await buildApp({ logger: true });
 

--- a/services/api/tests/dotenv.test.ts
+++ b/services/api/tests/dotenv.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import { existsSync, writeFileSync, unlinkSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { loadDotenv } from '../src/config/dotenv';
+
+describe('loadDotenv', () => {
+  const testEnvPath = resolve(process.cwd(), '.env.test');
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    // Clean up any existing test .env file
+    if (existsSync(testEnvPath)) {
+      unlinkSync(testEnvPath);
+    }
+  });
+
+  afterEach(() => {
+    // Clean up test .env file
+    if (existsSync(testEnvPath)) {
+      unlinkSync(testEnvPath);
+    }
+    // Restore original environment
+    process.env = { ...originalEnv };
+  });
+
+  it('loads .env when present', () => {
+    // Create a test .env file
+    const envPath = resolve(process.cwd(), '.env');
+    const testContent = 'TEST_VAR=test_value\nANOTHER_VAR=another_value\n';
+    
+    // Clean up if exists
+    if (existsSync(envPath)) {
+      unlinkSync(envPath);
+    }
+
+    try {
+      writeFileSync(envPath, testContent);
+      
+      // Clear the test variables first
+      delete process.env.TEST_VAR;
+      delete process.env.ANOTHER_VAR;
+
+      loadDotenv();
+
+      // Verify environment variables were loaded
+      expect(process.env.TEST_VAR).toBe('test_value');
+      expect(process.env.ANOTHER_VAR).toBe('another_value');
+    } finally {
+      // Clean up
+      if (existsSync(envPath)) {
+        unlinkSync(envPath);
+      }
+    }
+  });
+
+  it('no-ops when .env is absent', () => {
+    const envPath = resolve(process.cwd(), '.env');
+    
+    // Ensure .env doesn't exist
+    if (existsSync(envPath)) {
+      unlinkSync(envPath);
+    }
+
+    // Should not throw
+    expect(() => loadDotenv()).not.toThrow();
+  });
+
+  it('throws when .env file is malformed', () => {
+    const envPath = resolve(process.cwd(), '.env');
+    
+    // Clean up if exists
+    if (existsSync(envPath)) {
+      unlinkSync(envPath);
+    }
+
+    try {
+      // Create a malformed .env file (this might not actually cause an error with process.loadEnvFile)
+      // but we test the error handling path
+      writeFileSync(envPath, 'INVALID LINE WITHOUT EQUALS');
+      
+      // Mock process.loadEnvFile to throw an error
+      const originalLoadEnvFile = process.loadEnvFile;
+      process.loadEnvFile = vi.fn(() => {
+        throw new Error('Malformed .env file');
+      });
+
+      expect(() => loadDotenv()).toThrow('Malformed .env file');
+
+      // Restore
+      process.loadEnvFile = originalLoadEnvFile;
+    } finally {
+      // Clean up
+      if (existsSync(envPath)) {
+        unlinkSync(envPath);
+      }
+    }
+  });
+});
+


### PR DESCRIPTION
- Add src/config/dotenv.ts with loadDotenv() helper using Node's built-in process.loadEnvFile
- Add comprehensive unit tests in tests/dotenv.test.ts covering .env present/absent cases
- Call loadDotenv() in server.ts before loadEnv() to load .env in local development
- Fixes #2

## What

This PR adds `.env` file loading support for local development. Previously, the `.env.example` file existed but wasn't actually loaded, causing local configuration to be silently ignored. Now `loadDotenv()` uses Node's built-in `process.loadEnvFile()` to load `.env` when present, with no-op behavior when absent (for production).

Closes #2 

## How to verify

1. Run `make check` - all tests pass (typecheck, lint, unit tests)
2. Create a `.env` file: `cp services/api/.env.example services/api/.env`
3. Add a test variable: `echo "TEST_VAR=loaded" >> services/api/.env`
4. Run `npm run dev` - server starts using values from `.env`
5. Verify environment variables are loaded correctly

## Checklist

- [x] `make check` passes (typecheck + lint + unit tests)
- [x] `make e2e` passes
- [x] New behaviour is covered by tests (unit and/or e2e)
- [ ] ADR added/updated if this makes an architectural decision
- [ ] Docs updated if behaviour changed (README / docs/)
