### PR TITLE
feat(api): add version endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 # OS
 .DS_Store
 
+# Editor
+.vscode/
+.idea/
+
 # Node
 node_modules/
 dist/

--- a/e2e/tests/health.spec.ts
+++ b/e2e/tests/health.spec.ts
@@ -19,4 +19,14 @@ test.describe('service health', () => {
     expect(res.status()).toBe(200);
     expect(await res.json()).toEqual({ status: 'ready' });
   });
+  test('version endpoint returns build identity', async ({ request }) => {
+    const res = await request.get('/version');
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({
+      name: 'trotxi-api',
+      version: '0.1.0',
+      commit: expect.any(String),
+    });
+  });
 });

--- a/services/api/src/app.ts
+++ b/services/api/src/app.ts
@@ -36,6 +36,11 @@ export async function buildApp(deps: AppDeps = {}): Promise<FastifyInstance> {
     docs: '/docs',
     health: '/healthz',
   }));
+  app.get('/version', async () => ({
+    name: 'trotxi-api',
+    version: '0.1.0',
+    commit: process.env['GIT_SHA'] ?? 'dev',
+  }));
 
   app.get('/healthz', async () => ({ status: 'ok' }));
 

--- a/services/api/tests/app.test.ts
+++ b/services/api/tests/app.test.ts
@@ -36,7 +36,6 @@ describe('app', () => {
     expect(res.statusCode).toBe(503);
     expect(res.json()).toEqual({ status: 'not_ready' });
   });
-
   it('serves an OpenAPI spec that lists the routes', async () => {
     const app = await buildApp();
     const res = await app.inject({ method: 'GET', url: '/docs/json' });
@@ -44,5 +43,16 @@ describe('app', () => {
     const spec = res.json();
     expect(spec.openapi).toBeTruthy();
     expect(Object.keys(spec.paths)).toContain('/healthz');
+  });
+
+  it('returns version info with name, version and commit', async () => {
+    const app = await buildApp();
+    const res = await app.inject({ method: 'GET', url: '/version' });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({
+      name: 'trotxi-api',
+      version: '0.1.0',
+      commit: 'dev',
+    });
   });
 });


### PR DESCRIPTION
## What
Adds GET /version endpoint returning service name, version, and git commit SHA. 
Read from GIT_SHA env var, falling back to "dev" for local environments.


Closes #1  

## How to verify

<!-- Commands or steps a reviewer can run. e.g. `make check`, `make e2e`, a screen to open. -->
make check
make e2e


Expected:
{
  "name": "trotxi-api",
  "version": "0.1.0",
  "commit": "dev"
}

## Checklist
- [x] make check passes (typecheck + lint + unit tests)
- [x] make e2e passes
- [x] New behaviour is covered by tests (unit and/or e2e)
- [ ] ADR added/updated if this makes an architectural decision
- [ ] Docs updated if behaviour changed (README / docs/)
