### PR TITLE
feat(api): load .env in local development

### DIFF
--- a/services/api/src/config/dotenv.ts
+++ b/services/api/src/config/dotenv.ts
@@ -1,0 +1,13 @@
+import { existsSync } from 'node:fs';
+
+/**
+ * Load a local `.env` file if present, using Node's built-in `process.loadEnvFile`
+ * (Node 20.12+ / 22). Production injects env vars directly, so a missing file is
+ * a no-op. The path is overridable to keep this testable without touching a real
+ * project `.env`.
+ */
+export function loadDotenv(path = '.env'): void {
+  if (existsSync(path)) {
+    process.loadEnvFile(path);
+  }
+}

--- a/services/api/src/server.ts
+++ b/services/api/src/server.ts
@@ -1,7 +1,9 @@
 import { buildApp } from './app';
+import { loadDotenv } from './config/dotenv';
 import { loadEnv } from './config/env';
 
 async function main(): Promise<void> {
+  loadDotenv();
   const env = loadEnv();
   const app = await buildApp({ logger: true });
 

--- a/services/api/tests/dotenv.test.ts
+++ b/services/api/tests/dotenv.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { loadDotenv } from '../src/config/dotenv';
+
+// NOTE: tests operate on a throwaway temp directory, never the project's real
+// `.env`, so running the suite can't clobber a developer's local config.
+describe('loadDotenv', () => {
+  const KEY = 'TROTXI_DOTENV_TEST_VAR';
+  afterEach(() => {
+    delete process.env[KEY];
+  });
+
+  it('loads variables from a .env file when present', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'trotxi-dotenv-'));
+    const file = join(dir, '.env');
+    writeFileSync(file, `${KEY}=hello\n`);
+    try {
+      loadDotenv(file);
+      expect(process.env[KEY]).toBe('hello');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('is a no-op when the file is absent', () => {
+    const missing = join(tmpdir(), 'trotxi-definitely-missing.env');
+    expect(() => loadDotenv(missing)).not.toThrow();
+    expect(process.env[KEY]).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Implements **#2**.

- `src/config/dotenv.ts` — `loadDotenv()` using Node's built-in `process.loadEnvFile`, guarded by `existsSync` (missing file = no-op; production injects env directly). Path is overridable so it's testable.
- `server.ts` calls `loadDotenv()` before `loadEnv()`.
- `tests/dotenv.test.ts` — covers present + absent using a **temp dir** (never the real project `.env`).

`pnpm check` passes locally (12 tests). Merging this is also the first end-to-end test of the CD chain: CI on main -> Deploy -> staging.

Closes #2