### PR TITLE
ci(security): secret scanning, CodeQL, dependency audit + Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  # pnpm workspace — one lockfile at the root covers every package
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      npm-minor-patch:
+        update-types: ['minor', 'patch']
+
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        update-types: ['minor', 'patch']

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,63 @@
+name: Security
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1' # weekly, Monday 06:00 UTC — catch newly-disclosed issues
+
+permissions:
+  contents: read
+
+concurrency:
+  group: security-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  secret-scan:
+    name: Secret scan (gitleaks)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # full history so secrets in past commits are caught
+      - name: gitleaks detect
+        run: |
+          docker run --rm -v "$PWD:/repo" ghcr.io/gitleaks/gitleaks:latest \
+            detect --source=/repo --redact --verbose --exit-code=1
+
+  codeql:
+    name: CodeQL (JS/TS)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+          queries: security-extended
+      - uses: github/codeql-action/analyze@v3
+
+  audit:
+    name: Dependency audit (pnpm)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      # Gate on what we SHIP (production deps). Dev-tooling advisories (vitest,
+      # vite, esbuild dev servers we never run in CI/prod) are handled by
+      # Dependabot PRs instead of blocking every merge.
+      - run: pnpm audit --prod --audit-level=high

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -54,7 +54,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       # Gate on what we SHIP (production deps). Dev-tooling advisories (vitest,


### PR DESCRIPTION
Implements the CI security gates from security.md §9.

- **Secret scanning** — gitleaks over full git history (`security.yml`)
- **SAST** — CodeQL (JS/TS, security-extended) → results in the Security tab
- **Dependency audit** — `pnpm audit --prod --audit-level=high` (gates **shipped** deps; prod tree is clean). Dev-tooling advisories (vitest/vite/esbuild dev servers we never run) are handled by Dependabot, not by blocking merges.
- **Dependabot** (`dependabot.yml`) — weekly npm (pnpm workspace) + github-actions updates, grouped to reduce noise.

Runs on push/PR to main + weekly schedule. Not added to required checks yet — once green a couple of times, we can make them blockers.