### PR TITLE
feat(db): migration runner + identity schema + repository pattern

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,39 @@ jobs:
       - run: pnpm --filter @trotxi/api run test:coverage
       - run: pnpm --filter @trotxi/api run build
 
+  migrations:
+    name: Migrations (Postgres)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    services:
+      postgres:
+        image: postgis/postgis:16-3.4
+        env:
+          POSTGRES_USER: trotxi
+          POSTGRES_PASSWORD: trotxi
+          POSTGRES_DB: trotxi
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U trotxi"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+    env:
+      DATABASE_URL: postgres://trotxi:trotxi@localhost:5432/trotxi
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter @trotxi/api run migrate
+      # Idempotency: a second run must be a clean no-op.
+      - run: pnpm --filter @trotxi/api run migrate
+
   e2e:
     name: E2E (Playwright)
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "coverage": "pnpm --filter @trotxi/api run test:coverage",
     "check": "pnpm run format:check && pnpm run typecheck && pnpm run lint && pnpm test",
     "api": "pnpm --filter @trotxi/api dev",
+    "migrate": "pnpm --filter @trotxi/api run migrate",
     "start": "pnpm -r --parallel --if-present run dev",
     "infra:up": "docker compose -f infra/docker/docker-compose.yml up -d",
     "infra:down": "docker compose -f infra/docker/docker-compose.yml down",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       fastify:
         specifier: ^5.2.0
         version: 5.8.5
+      pg:
+        specifier: ^8.13.1
+        version: 8.22.0
       zod:
         specifier: ^3.24.1
         version: 3.25.76
@@ -45,6 +48,9 @@ importers:
       '@types/node':
         specifier: ^22.10.2
         version: 22.19.21
+      '@types/pg':
+        specifier: ^8.11.10
+        version: 8.20.0
       '@vitest/coverage-v8':
         specifier: ^2.1.8
         version: 2.1.9(vitest@2.1.9(@types/node@22.19.21))
@@ -820,6 +826,9 @@ packages:
 
   '@types/node@22.19.21':
     resolution: {integrity: sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==}
+
+  '@types/pg@8.20.0':
+    resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
 
   '@typescript-eslint/eslint-plugin@8.61.0':
     resolution: {integrity: sha512-bFNvl9ZczlVb+wR2Akszf3gHfKVj/8WanXaGJ3UstTA7brNKg0cNdk6X1Psu5V7MZ2oQtzZKOEzIUehaoxbDGw==}
@@ -1623,6 +1632,40 @@ packages:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
 
+  pg-cloudflare@1.4.0:
+    resolution: {integrity: sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==}
+
+  pg-connection-string@2.14.0:
+    resolution: {integrity: sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==}
+
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-pool@3.14.0:
+    resolution: {integrity: sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==}
+    peerDependencies:
+      pg: '>=8.0'
+
+  pg-protocol@1.15.0:
+    resolution: {integrity: sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
+  pg@8.22.0:
+    resolution: {integrity: sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -1687,6 +1730,22 @@ packages:
   postcss@8.5.15:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
+
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-bytea@1.0.1:
+    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -2061,6 +2120,10 @@ packages:
   wrap-ansi@9.0.2:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
+
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
 
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
@@ -2561,6 +2624,12 @@ snapshots:
   '@types/node@22.19.21':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/pg@8.20.0':
+    dependencies:
+      '@types/node': 22.19.21
+      pg-protocol: 1.15.0
+      pg-types: 2.2.0
 
   '@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)':
     dependencies:
@@ -3465,6 +3534,41 @@ snapshots:
 
   pathval@2.0.1: {}
 
+  pg-cloudflare@1.4.0:
+    optional: true
+
+  pg-connection-string@2.14.0: {}
+
+  pg-int8@1.0.1: {}
+
+  pg-pool@3.14.0(pg@8.22.0):
+    dependencies:
+      pg: 8.22.0
+
+  pg-protocol@1.15.0: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.1
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
+  pg@8.22.0:
+    dependencies:
+      pg-connection-string: 2.14.0
+      pg-pool: 3.14.0(pg@8.22.0)
+      pg-protocol: 1.15.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.4.0
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.2: {}
@@ -3522,6 +3626,16 @@ snapshots:
       nanoid: 3.3.12
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  postgres-array@2.0.0: {}
+
+  postgres-bytea@1.0.1: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
 
   prelude-ls@1.2.1: {}
 
@@ -3883,6 +3997,8 @@ snapshots:
       ansi-styles: 6.2.3
       string-width: 7.2.0
       strip-ansi: 7.2.0
+
+  xtend@4.0.2: {}
 
   yaml@2.9.0: {}
 

--- a/services/api/.env.example
+++ b/services/api/.env.example
@@ -3,6 +3,6 @@ PORT=3000
 HOST=0.0.0.0
 NODE_ENV=development
 
-# Database — unset while the API has no datastore. When migrations land, point
-# this at local Postgres (make up): postgres://trotxi:trotxi@localhost:5432/trotxi
-# DATABASE_URL=
+# Database — leave unset to run with in-memory repositories (zero infra).
+# Set it to use Postgres (run `pnpm infra:up` first, then `pnpm migrate`).
+# DATABASE_URL=postgres://trotxi:trotxi@localhost:5432/trotxi

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -15,16 +15,19 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "typecheck": "tsc --noEmit",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "migrate": "tsx src/db/migrate.ts"
   },
   "dependencies": {
     "@fastify/swagger": "^9.7.0",
     "@fastify/swagger-ui": "^6.0.0",
     "fastify": "^5.2.0",
+    "pg": "^8.13.1",
     "zod": "^3.24.1"
   },
   "devDependencies": {
     "@types/node": "^22.10.2",
+    "@types/pg": "^8.11.10",
     "@vitest/coverage-v8": "^2.1.8",
     "eslint": "^9.17.0",
     "globals": "^15.14.0",

--- a/services/api/src/app.ts
+++ b/services/api/src/app.ts
@@ -1,6 +1,7 @@
 import fastifySwagger from '@fastify/swagger';
 import fastifySwaggerUi from '@fastify/swagger-ui';
 import Fastify, { type FastifyInstance } from 'fastify';
+import type { UserRepository } from './modules/users/user.repository';
 
 /**
  * Dependencies are injected here — services and repositories register as the
@@ -8,8 +9,10 @@ import Fastify, { type FastifyInstance } from 'fastify';
  * Tests pass in-memory implementations; production wires the real ones.
  */
 export interface AppDeps {
-  /** Readiness probe — wire the database ping here once a datastore exists. */
+  /** Readiness probe — wired to a DB ping when DATABASE_URL is set. */
   isReady?: () => Promise<boolean>;
+  /** Selected by DATABASE_URL (in-memory vs Postgres). Consumed by routes/services. */
+  users?: UserRepository;
   logger?: boolean;
 }
 

--- a/services/api/src/config/env.ts
+++ b/services/api/src/config/env.ts
@@ -4,6 +4,8 @@ const envSchema = z.object({
   NODE_ENV: z.enum(['development', 'test', 'production']).default('development'),
   PORT: z.coerce.number().int().positive().default(3000),
   HOST: z.string().default('0.0.0.0'),
+  // Unset -> in-memory repositories (zero-infra dev/tests). Set -> Postgres.
+  DATABASE_URL: z.string().optional(),
 });
 
 export type Env = z.infer<typeof envSchema>;

--- a/services/api/src/db/migrate.ts
+++ b/services/api/src/db/migrate.ts
@@ -1,0 +1,65 @@
+import { readdir, readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Pool } from 'pg';
+import { loadDotenv } from '../config/dotenv';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const MIGRATIONS_DIR = join(__dirname, 'migrations');
+
+/**
+ * Idempotent SQL migration runner. Applies every `*.sql` in `migrations/` in
+ * filename order, once, inside a transaction, tracking applied files in a
+ * `_migrations` table. Safe to run repeatedly (and on every deploy).
+ */
+async function migrate(): Promise<void> {
+  loadDotenv();
+  const connectionString = process.env['DATABASE_URL'];
+  if (!connectionString) {
+    throw new Error('DATABASE_URL is required to run migrations');
+  }
+
+  const pool = new Pool({ connectionString });
+  try {
+    await pool.query(
+      `CREATE TABLE IF NOT EXISTS _migrations (
+         name TEXT PRIMARY KEY,
+         applied_at TIMESTAMPTZ NOT NULL DEFAULT now()
+       )`,
+    );
+
+    const { rows } = await pool.query<{ name: string }>('SELECT name FROM _migrations');
+    const applied = new Set(rows.map((r) => r.name));
+
+    const files = (await readdir(MIGRATIONS_DIR)).filter((f) => f.endsWith('.sql')).sort();
+
+    for (const file of files) {
+      if (applied.has(file)) {
+        console.log(`= ${file} (already applied)`);
+        continue;
+      }
+      const sql = await readFile(join(MIGRATIONS_DIR, file), 'utf8');
+      const client = await pool.connect();
+      try {
+        await client.query('BEGIN');
+        await client.query(sql);
+        await client.query('INSERT INTO _migrations (name) VALUES ($1)', [file]);
+        await client.query('COMMIT');
+        console.log(`+ ${file} (applied)`);
+      } catch (err) {
+        await client.query('ROLLBACK');
+        throw err;
+      } finally {
+        client.release();
+      }
+    }
+    console.log('Migrations complete.');
+  } finally {
+    await pool.end();
+  }
+}
+
+migrate().catch((err) => {
+  console.error('Migration failed:', err);
+  process.exit(1);
+});

--- a/services/api/src/db/migrations/001_init.sql
+++ b/services/api/src/db/migrations/001_init.sql
@@ -1,0 +1,42 @@
+-- 001_init: extensions + identity core (users, auth identities, sessions).
+-- Expand/contract discipline: additive, backward-compatible changes only.
+
+CREATE EXTENSION IF NOT EXISTS postgis; -- geospatial (routes, stops, positions)
+CREATE EXTENSION IF NOT EXISTS pgcrypto; -- gen_random_uuid()
+
+-- Riders, drivers, admins. Phone is captured at profile and verified at payment
+-- time (Paystack), not by SMS at signup (auth is social-first).
+CREATE TABLE IF NOT EXISTS users (
+  id           uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  display_name text NOT NULL,
+  phone        text UNIQUE,
+  avatar_url   text,
+  role         text NOT NULL DEFAULT 'commuter' CHECK (role IN ('commuter', 'driver', 'admin')),
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  updated_at   timestamptz NOT NULL DEFAULT now()
+);
+
+-- One user can sign in via several providers (google | apple | phone). The
+-- token/session machinery is the same regardless of method.
+CREATE TABLE IF NOT EXISTS auth_identity (
+  id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id     uuid NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+  provider    text NOT NULL CHECK (provider IN ('google', 'apple', 'phone')),
+  provider_id text NOT NULL, -- provider subject id (or the phone number)
+  created_at  timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (provider, provider_id)
+);
+CREATE INDEX IF NOT EXISTS idx_auth_identity_user ON auth_identity (user_id);
+
+-- Refresh tokens are stored hashed (never the raw token) and are rotated +
+-- revocable, so a lost phone or suspended driver is cut off fast.
+CREATE TABLE IF NOT EXISTS sessions (
+  id                 uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id            uuid NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+  refresh_token_hash text NOT NULL,
+  expires_at         timestamptz NOT NULL,
+  revoked_at         timestamptz,
+  rotated_from       uuid REFERENCES sessions (id) ON DELETE SET NULL,
+  created_at         timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_sessions_user ON sessions (user_id);

--- a/services/api/src/db/pool.ts
+++ b/services/api/src/db/pool.ts
@@ -1,0 +1,8 @@
+import { Pool } from 'pg';
+
+/** A shared Postgres connection pool, created from DATABASE_URL. */
+export function createPool(connectionString: string): Pool {
+  return new Pool({ connectionString });
+}
+
+export type { Pool };

--- a/services/api/src/modules/users/user.repository.pg.ts
+++ b/services/api/src/modules/users/user.repository.pg.ts
@@ -1,0 +1,41 @@
+import type { Pool } from 'pg';
+import type { NewUser, User, UserRepository, UserRole } from './user.repository';
+
+interface UserRow {
+  id: string;
+  display_name: string;
+  phone: string | null;
+  avatar_url: string | null;
+  role: UserRole;
+  created_at: Date;
+}
+
+function toUser(row: UserRow): User {
+  return {
+    id: row.id,
+    displayName: row.display_name,
+    phone: row.phone,
+    avatarUrl: row.avatar_url,
+    role: row.role,
+    createdAt: row.created_at,
+  };
+}
+
+export class PgUserRepository implements UserRepository {
+  constructor(private readonly pool: Pool) {}
+
+  async create(input: NewUser): Promise<User> {
+    const { rows } = await this.pool.query<UserRow>(
+      `INSERT INTO users (display_name, phone, role)
+       VALUES ($1, $2, $3)
+       RETURNING *`,
+      [input.displayName, input.phone ?? null, input.role ?? 'commuter'],
+    );
+    return toUser(rows[0]!);
+  }
+
+  async findById(id: string): Promise<User | null> {
+    const { rows } = await this.pool.query<UserRow>('SELECT * FROM users WHERE id = $1', [id]);
+    return rows[0] ? toUser(rows[0]) : null;
+  }
+}

--- a/services/api/src/modules/users/user.repository.ts
+++ b/services/api/src/modules/users/user.repository.ts
@@ -1,0 +1,46 @@
+// Reference repository pattern: an interface with two implementations -
+// InMemory (tests + zero-infra dev) and Postgres (real runs, see *.pg.ts).
+// The server picks one by DATABASE_URL. Copy this shape for new domain modules.
+
+export type UserRole = 'commuter' | 'driver' | 'admin';
+
+export interface User {
+  id: string;
+  displayName: string;
+  phone: string | null;
+  avatarUrl: string | null;
+  role: UserRole;
+  createdAt: Date;
+}
+
+export interface NewUser {
+  displayName: string;
+  phone?: string | null;
+  role?: UserRole;
+}
+
+export interface UserRepository {
+  create(input: NewUser): Promise<User>;
+  findById(id: string): Promise<User | null>;
+}
+
+export class InMemoryUserRepository implements UserRepository {
+  private readonly users = new Map<string, User>();
+
+  async create(input: NewUser): Promise<User> {
+    const user: User = {
+      id: crypto.randomUUID(),
+      displayName: input.displayName,
+      phone: input.phone ?? null,
+      avatarUrl: null,
+      role: input.role ?? 'commuter',
+      createdAt: new Date(),
+    };
+    this.users.set(user.id, user);
+    return user;
+  }
+
+  async findById(id: string): Promise<User | null> {
+    return this.users.get(id) ?? null;
+  }
+}

--- a/services/api/src/server.ts
+++ b/services/api/src/server.ts
@@ -1,15 +1,44 @@
-import { buildApp } from './app';
+import type { Pool } from 'pg';
+import { buildApp, type AppDeps } from './app';
 import { loadDotenv } from './config/dotenv';
 import { loadEnv } from './config/env';
+import { createPool } from './db/pool';
+import { InMemoryUserRepository } from './modules/users/user.repository';
+import { PgUserRepository } from './modules/users/user.repository.pg';
 
 async function main(): Promise<void> {
   loadDotenv();
   const env = loadEnv();
-  const app = await buildApp({ logger: true });
+
+  // Pick repositories by environment: Postgres when DATABASE_URL is set, else
+  // in-memory (zero infra). New modules follow this same pattern.
+  let pool: Pool | undefined;
+  let deps: Pick<AppDeps, 'users' | 'isReady'>;
+  if (env.DATABASE_URL) {
+    pool = createPool(env.DATABASE_URL);
+    deps = {
+      users: new PgUserRepository(pool),
+      isReady: async () => {
+        try {
+          await pool!.query('SELECT 1');
+          return true;
+        } catch {
+          return false;
+        }
+      },
+    };
+    console.log('Using Postgres repositories');
+  } else {
+    deps = { users: new InMemoryUserRepository(), isReady: async () => true };
+    console.log('Using in-memory repositories (no DATABASE_URL set)');
+  }
+
+  const app = await buildApp({ ...deps, logger: true });
 
   const shutdown = async (signal: string): Promise<void> => {
     app.log.info(`Received ${signal}, shutting down`);
     await app.close();
+    await pool?.end();
     process.exit(0);
   };
   process.on('SIGINT', () => void shutdown('SIGINT'));

--- a/services/api/tests/user.repository.test.ts
+++ b/services/api/tests/user.repository.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { InMemoryUserRepository } from '../src/modules/users/user.repository';
+
+describe('InMemoryUserRepository', () => {
+  it('creates a user with defaults and finds it by id', async () => {
+    const repo = new InMemoryUserRepository();
+    const created = await repo.create({ displayName: 'Ama', phone: '+233200000000' });
+
+    expect(created.id).toBeTruthy();
+    expect(created.role).toBe('commuter'); // default
+    expect(created.avatarUrl).toBeNull();
+
+    const found = await repo.findById(created.id);
+    expect(found?.displayName).toBe('Ama');
+    expect(found?.phone).toBe('+233200000000');
+  });
+
+  it('honours an explicit role', async () => {
+    const repo = new InMemoryUserRepository();
+    const driver = await repo.create({ displayName: 'Kofi', role: 'driver' });
+    expect(driver.role).toBe('driver');
+  });
+
+  it('returns null for an unknown id', async () => {
+    const repo = new InMemoryUserRepository();
+    expect(await repo.findById('does-not-exist')).toBeNull();
+  });
+});

--- a/services/api/vitest.config.ts
+++ b/services/api/vitest.config.ts
@@ -7,10 +7,10 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'html'],
       include: ['src/**/*.ts'],
-      // The entrypoint and (later) *.pg.ts repositories / db scripts run only
-      // against real infrastructure — the e2e suite covers those. The unit
-      // gate applies to the logic layer.
-      exclude: ['src/server.ts'],
+      // The entrypoint, *.pg.ts repositories, and db scripts run only against
+      // real infrastructure — the e2e suite covers those. The unit gate applies
+      // to the logic layer (services + in-memory repos).
+      exclude: ['src/server.ts', 'src/db/**', 'src/**/*.pg.ts'],
       thresholds: {
         lines: 80,
         functions: 80,


### PR DESCRIPTION
## What this is

The **data-layer foundation** for `services/api`: migrations, a Postgres connection, and a repository pattern — so you can add domain models without wiring any infra yourself. This PR ships the **identity core** (`users`, `auth_identity`, `sessions`) as the worked example to copy.

> TL;DR for the backend engineer: copy the `users` module, add a SQL migration, wire it in `server.ts`, test the in-memory repo. Full recipe below.

---

## How it works (read first)

- **Repo selection is automatic.** The API runs with **in-memory** repositories by default (no DB needed) and **Postgres** repositories when `DATABASE_URL` is set — same code, chosen at startup in `server.ts`. So you can build and unit-test without a database, and CI/e2e run against real Postgres.
- **Migrations** are plain SQL files in `services/api/src/db/migrations/`, applied **in filename order, once, in a transaction**, tracked in a `_migrations` table. Runner: `pnpm migrate`.
- **`/readyz`** pings the DB when `DATABASE_URL` is set.

## Local setup

```bash
corepack enable        # one-time (Node 24 — see .nvmrc)
pnpm install
pnpm infra:up          # Postgres + Redis via Docker
cp services/api/.env.example services/api/.env   # then set DATABASE_URL in it
pnpm migrate           # apply migrations
pnpm api               # run the API → http://localhost:3000/docs
pnpm check             # format + typecheck + lint + unit tests (run before pushing)
```

---

## How to add a data model (the recipe)

Copy the `users` module. Worked example: adding `subscriptions`.

**1. Write a migration** — `src/db/migrations/002_subscriptions.sql`:

```sql
CREATE TABLE IF NOT EXISTS subscriptions (
  id         uuid PRIMARY KEY DEFAULT gen_random_uuid(),
  user_id    uuid NOT NULL REFERENCES users (id) ON DELETE CASCADE,
  plan       text NOT NULL,
  status     text NOT NULL DEFAULT 'active',
  created_at timestamptz NOT NULL DEFAULT now()
);
CREATE INDEX IF NOT EXISTS idx_subscriptions_user ON subscriptions (user_id);
```

Rules: **additive / expand-contract only** (never break existing readers), `IF NOT EXISTS`, snake_case, `uuid` PKs via `gen_random_uuid()`, `timestamptz`. A migration is **immutable once merged** — to change schema, add a new file; never edit an applied one.

**2. Interface + in-memory repo** — `src/modules/subscriptions/subscription.repository.ts` (copy `users/user.repository.ts`):

```ts
export interface Subscription {
  id: string;
  userId: string;
  plan: string;
  status: string;
  createdAt: Date;
}
export interface SubscriptionRepository {
  create(input: { userId: string; plan: string }): Promise<Subscription>;
  findActiveByUser(userId: string): Promise<Subscription | null>;
}
export class InMemorySubscriptionRepository implements SubscriptionRepository {
  /* Map-backed, mirror InMemoryUserRepository */
}
```

**3. Postgres impl** — `subscription.repository.pg.ts` (copy `user.repository.pg.ts`): map snake_case rows → camelCase with a `toX(row)` helper, and use **parameterized queries only** (`$1, $2` — never string-concatenate values; this is the SQL-injection guard).

**4. Wire it** in `src/server.ts` — add the repo to **both** branches (Postgres and in-memory) right next to `users`, and to `AppDeps` in `app.ts`.

**5. Test** — `tests/subscription.repository.test.ts` unit-tests the **in-memory** repo (this is the coverage gate). The pg adapter is covered by infra, not unit tests.

**6. Run** `pnpm migrate && pnpm check`, then open a PR. CI re-runs everything, incl. the **Migrations** job against PostGIS.

---

## Conventions

| Area | Rule |
| --- | --- |
| SQL | snake_case, `uuid` PKs, `timestamptz`, FKs with `ON DELETE`, `IF NOT EXISTS` |
| TS | camelCase; one `toX(row)` mapper per repo; parameterized queries only |
| Migrations | one file per change, filename-ordered, immutable once merged |

## Suggested build order (one small PR each)

- `subscriptions` **(BE)** → mobility: `routes` / `stops` / `route_stops` / `trips` / `vehicles` **(BE)** → `boardings` / `passes` / `scan_events` **(BE)**

## Heads Up

- `*.pg.ts` adapters and `db/**` are **excluded from unit coverage** (they run only against real Postgres / e2e) — don't be surprised they show 0% in the unit report.
- **No production migrate-on-deploy yet** — separate follow-up for when staging cuts over to the DB.
- Local only: this repo's Docker Postgres shares a volume name with the old `trotxi` prototype if you have both repos on one machine — `pnpm infra:down -v` when switching between them.

Validated locally against PostGIS (extensions created, all tables present, runner idempotent) and green in CI including the Migrations job.
