### PR TITLE
Chore/flutter scaffold

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,14 @@
+{
+  "name": "Flutter",
+  "image": "ghcr.io/cirruslabs/flutter:stable",
+  "forwardPorts": [],
+  "postCreateCommand": "flutter doctor",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "Dart-Code.flutter",
+        "Dart-Code.dart-code"
+      ]
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,10 +5,7 @@
   "postCreateCommand": "flutter doctor",
   "customizations": {
     "vscode": {
-      "extensions": [
-        "Dart-Code.flutter",
-        "Dart-Code.dart-code"
-      ]
+      "extensions": ["Dart-Code.flutter", "Dart-Code.dart-code"]
     }
   }
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,6 @@ immutable once accepted (supersede instead of editing). If your PR makes or
 changes an architectural decision, it includes an ADR. See
 [docs/adr/0001-record-architecture-decisions.md](docs/adr/0001-record-architecture-decisions.md).
 
-
 ## Codespaces / dev container
 
 A `.devcontainer/devcontainer.json` is provided for contributors who prefer
@@ -71,7 +70,6 @@ The container builds automatically on first open and on any change to
 **To use it in VS Code locally:**
 Install the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers),
 then **Reopen in Container** from the command palette.
-
 
 ## Local setup
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,26 @@ immutable once accepted (supersede instead of editing). If your PR makes or
 changes an architectural decision, it includes an ADR. See
 [docs/adr/0001-record-architecture-decisions.md](docs/adr/0001-record-architecture-decisions.md).
 
+
+## Codespaces / dev container
+
+A `.devcontainer/devcontainer.json` is provided for contributors who prefer
+not to install Flutter locally, or who work in GitHub Codespaces.
+
+The container is based on `ghcr.io/cirruslabs/flutter:stable` and runs
+`flutter doctor` on creation. Workspace dependencies are **not** installed
+automatically — follow the local setup steps below once the container is ready.
+
+**To use it in Codespaces:**
+Open the repo on GitHub → **Code → Codespaces → Create codespace on main**.
+The container builds automatically on first open and on any change to
+`.devcontainer/`.
+
+**To use it in VS Code locally:**
+Install the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers),
+then **Reopen in Container** from the command palette.
+
+
 ## Local setup
 
 ```bash


### PR DESCRIPTION
## What
Adds `.devcontainer/devcontainer.json` so contributors can develop in GitHub
Codespaces or VS Code dev containers without installing Flutter locally.
Updates CONTRIBUTING.md to document the setup.

Closes #43

## How to verify
1. Open the repo in GitHub Codespaces — container should build automatically.
2. Once ready, run `flutter doctor` in the terminal — should return without errors.

## Checklist
- [ ] `make check` passes (typecheck + lint + unit tests) — N/A, config change only
- [ ] `make e2e` passes — N/A, config change only
- [ ] New behaviour is covered by tests (unit and/or e2e) — N/A, no logic added
- [ ] ADR added/updated if this makes an architectural decision — N/A
- [x] Docs updated if behaviour changed (README / docs/) — CONTRIBUTING.md updated