### PR TITLE
feat(auth): token service + auth guard + GET /me (auth spine, slice 1)

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,15 @@
+# gitleaks config — extends the default ruleset with an allowlist for
+# INTENTIONAL non-secret placeholders: the dev-only JWT fallback (config/env.ts,
+# auth/jwt.ts) and test fixtures. See ADR-0007. Real secrets are injected via
+# environment variables and are never committed.
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Intentional non-secret placeholders (dev JWT fallback + test fixtures)"
+regexes = [
+  '''dev-only-insecure-secret-change-me-[0-9a-f]+''',
+  '''test-secret-at-least-32-characters-long-[0-9]+''',
+  '''a-totally-different-secret-32-chars-min''',
+]

--- a/docs/adr/0007-jwt-auth-guard.md
+++ b/docs/adr/0007-jwt-auth-guard.md
@@ -1,0 +1,110 @@
+# ADR-0007 — JWT access tokens & route authorization guard
+
+**Status:** accepted · **Date:** 2026-06-24
+
+## Context
+
+The auth spine ([#16](https://github.com/TROTXI/mobility-core/issues/16)) needs a
+way to (a) prove who is calling and (b) decide what they may do, on every
+request. The design docs (`docs/security.md`) already chose **social-first
+sign-in**, **JWT access tokens + rotated refresh tokens**, and **RBAC plus
+per-route ownership checks** (no ReBAC/ABAC engine).
+
+This ADR records the **implementation of the token + guard foundation only**
+("slice 1"): the access-token contract and the route guard that the rest of the
+team builds on. Sign-in (Google/Apple) and refresh tokens are a follow-up
+("slice 2") and will get their own notes; they do not change what is decided
+here.
+
+Constraints that shaped this:
+
+- **Stateless verification** — no database round-trip to authenticate a request.
+- **Reusable, testable token logic** — slice 2 must verify Google/Apple ID
+  tokens, so the token code should not be welded to the web framework.
+- **Zero-infra locally** — the API and its tests must run with no secret set.
+- **Secure by default in production** — a missing secret must fail loudly, not
+  silently fall back to something insecure.
+
+## Decision
+
+**Access tokens are short-lived signed JWTs (HS256), verified statelessly.**
+
+- **Claims:** `sub` = user id, `role` = the user's role, plus `iss` / `aud` /
+  `iat` / `exp`. Default lifetime **15 minutes** (`JWT_ACCESS_TTL`).
+- **Library: `jose`, not `@fastify/jwt`.** It is framework-agnostic (so the
+  token service is a plain, unit-testable module) and ships JWKS verification,
+  which slice 2 needs to validate Google/Apple ID tokens. See ADR-0003 for the
+  Fastify/TypeScript baseline this sits on.
+- **Token service** (`modules/auth/jwt.ts`): `createJwtService(config)` exposes
+  `signAccessToken` / `verifyAccessToken`. Verification **validates the decoded
+  payload with zod** — a structurally valid token carrying an unknown role or no
+  subject is rejected, not trusted.
+- **Guard** (`modules/auth/auth.plugin.ts`, registered via `fastify-plugin` so
+  decorators live on the root instance):
+  - `app.authenticate` — preHandler; **401** if the bearer token is missing,
+    malformed, expired, or invalid. On success sets `request.user`.
+  - `app.requireRole(...roles)` — preHandler factory for **RBAC**; **403** on a
+    role mismatch. Composed _after_ `authenticate`.
+  - `request.user` — the authenticated principal `{ id, role }`.
+  - `app.jwt` — the token service, for the sign-in routes in slice 2.
+- **RBAC via the role embedded in the token** (stateless). **Ownership /
+  relationship checks stay per-route**, not in the guard (per `docs/security.md`
+  — we deliberately do not run a ReBAC/ABAC engine).
+- **Secret is environment-gated** (`config/env.ts`): `JWT_SECRET` is **required
+  when `NODE_ENV=production`** (min 32 chars). Outside production a dev-only
+  fallback is used and a startup warning is logged.
+
+## How to use it
+
+Protect a route (must be logged in):
+
+```ts
+app.get('/account', { preHandler: app.authenticate }, async (req) => {
+  return getAccount(req.user!.id); // req.user is { id, role }
+});
+```
+
+Require a role (RBAC) — note the order, `authenticate` first:
+
+```ts
+app.post('/admin/routes', { preHandler: [app.authenticate, app.requireRole('admin')] }, handler);
+```
+
+Per-route ownership check (the guard does **not** do this for you):
+
+```ts
+app.get('/trips/:id', { preHandler: app.authenticate }, async (req, reply) => {
+  const trip = await trips.findById(req.params.id);
+  if (trip?.driverId !== req.user!.id) return reply.code(403).send();
+  return trip;
+});
+```
+
+Issue a token (sign-in routes in slice 2, and tests):
+
+```ts
+const token = await app.jwt.signAccessToken({ userId, role });
+// client then sends:  Authorization: Bearer <token>
+```
+
+`GET /me` is the worked example of all of the above in `modules/auth/auth.routes.ts`.
+
+## Consequences
+
+- **Deployed environments must set `JWT_SECRET`.** Staging and production run
+  `NODE_ENV=production`, so the API **refuses to boot without it** — intentional
+  fail-closed behaviour. It is declared `sync: false` in `render.yaml` and the
+  value is set in the Render dashboard (never committed). Local/CI need nothing.
+- **Access tokens cannot be revoked before they expire.** This is why the TTL is
+  short. Real revocation (logout, "sign out everywhere", reuse detection) is a
+  **refresh-token / `sessions`** concern handled in slice 2.
+- **Role changes are eventually consistent** — a promotion/demotion takes effect
+  on the next token refresh, not instantly. Long-lived or destructive actions
+  must re-check authority server-side rather than trusting a possibly-stale role.
+- **HS256 (shared secret) is correct while one service both signs and verifies.**
+  If we ever split the issuer from verifiers, or expose verification to external
+  parties, switch to an asymmetric algorithm (RS256/EdDSA) — that would
+  **supersede** this ADR.
+- Slices 2 (sign-in + refresh) and 3 (JWKS caching, refresh-reuse detection,
+  auth rate limiting — [#23](https://github.com/TROTXI/mobility-core/issues/23))
+  build directly on these decorators and the token service.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,12 @@ importers:
       fastify:
         specifier: ^5.2.0
         version: 5.8.5
+      fastify-plugin:
+        specifier: ^6.0.0
+        version: 6.0.0
+      jose:
+        specifier: ^6.2.3
+        version: 6.2.3
       pg:
         specifier: ^8.13.1
         version: 8.22.0
@@ -1243,6 +1249,9 @@ packages:
   fastify-plugin@5.1.0:
     resolution: {integrity: sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==}
 
+  fastify-plugin@6.0.0:
+    resolution: {integrity: sha512-fZOty7z3O7vOliF6d8bHE3wiEh1KcNnKEQensSgTk9C1DvN6nRLS++XVd86v33Hw/8u9Un8A1zDrQ8ujcQDHEg==}
+
   fastify@5.8.5:
     resolution: {integrity: sha512-Yqptv59pQzPgQUSIm87hMqHJmdkb1+GPxdE6vW6FRyVE9G86mt7rOghitiU4JHRaTyDUk9pfeKmDeu70lAwM4Q==}
 
@@ -1419,6 +1428,9 @@ packages:
 
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
@@ -3146,6 +3158,8 @@ snapshots:
 
   fastify-plugin@5.1.0: {}
 
+  fastify-plugin@6.0.0: {}
+
   fastify@5.8.5:
     dependencies:
       '@fastify/ajv-compiler': 4.0.5
@@ -3319,6 +3333,8 @@ snapshots:
       '@isaacs/cliui': 8.0.2
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
+
+  jose@6.2.3: {}
 
   joycon@3.1.1: {}
 

--- a/render.yaml
+++ b/render.yaml
@@ -31,6 +31,10 @@ services:
         fromDatabase:
           name: trotxi-db-staging
           property: connectionString
+      # Required because NODE_ENV=production (see ADR-0007). Set the value in the
+      # Render dashboard; never commit it. Generate: openssl rand -base64 48
+      - key: JWT_SECRET
+        sync: false
 
   # ---- Production (uncomment when going live) ----
   # Needs a paid Postgres plan so data doesn't expire. After applying, set the
@@ -55,6 +59,8 @@ services:
   #       fromDatabase:
   #         name: trotxi-db-production
   #         property: connectionString
+  #     - key: JWT_SECRET
+  #       sync: false   # required; set in dashboard (ADR-0007)
   #
   # …and add under `databases:`
   # - name: trotxi-db-production

--- a/services/api/.env.example
+++ b/services/api/.env.example
@@ -6,3 +6,10 @@ NODE_ENV=development
 # Database — leave unset to run with in-memory repositories (zero infra).
 # Set it to use Postgres (run `pnpm infra:up` first, then `pnpm migrate`).
 # DATABASE_URL=postgres://trotxi:trotxi@localhost:5432/trotxi
+
+# Auth (JWT) — leave unset for a dev-only secret (local/tests).
+# REQUIRED in production (min 32 chars). Generate: openssl rand -base64 48
+# JWT_SECRET=
+# JWT_ACCESS_TTL=15m
+# JWT_ISSUER=trotxi
+# JWT_AUDIENCE=trotxi-api

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -22,6 +22,8 @@
     "@fastify/swagger": "^9.7.0",
     "@fastify/swagger-ui": "^6.0.0",
     "fastify": "^5.2.0",
+    "fastify-plugin": "^6.0.0",
+    "jose": "^6.2.3",
     "pg": "^8.13.1",
     "zod": "^3.24.1"
   },

--- a/services/api/src/app.ts
+++ b/services/api/src/app.ts
@@ -1,6 +1,9 @@
 import fastifySwagger from '@fastify/swagger';
 import fastifySwaggerUi from '@fastify/swagger-ui';
 import Fastify, { type FastifyInstance } from 'fastify';
+import { authPlugin } from './modules/auth/auth.plugin';
+import { authRoutes } from './modules/auth/auth.routes';
+import { DEV_AUTH_CONFIG, type AuthConfig } from './modules/auth/jwt';
 import type { UserRepository } from './modules/users/user.repository';
 
 /**
@@ -13,6 +16,8 @@ export interface AppDeps {
   isReady?: () => Promise<boolean>;
   /** Selected by DATABASE_URL (in-memory vs Postgres). Consumed by routes/services. */
   users?: UserRepository;
+  /** JWT/auth settings. Defaults to a dev-only config when unset (tests, local). */
+  auth?: AuthConfig;
   logger?: boolean;
 }
 
@@ -32,6 +37,10 @@ export async function buildApp(deps: AppDeps = {}): Promise<FastifyInstance> {
     },
   });
   await app.register(fastifySwaggerUi, { routePrefix: '/docs' });
+
+  // Auth guard first (decorators on the root instance), then routes that use it.
+  await app.register(authPlugin, { config: deps.auth ?? DEV_AUTH_CONFIG });
+  await app.register(authRoutes, { users: deps.users });
 
   app.get('/', async () => ({
     service: 'trotxi-api',

--- a/services/api/src/config/env.ts
+++ b/services/api/src/config/env.ts
@@ -1,12 +1,28 @@
 import { z } from 'zod';
 
-const envSchema = z.object({
-  NODE_ENV: z.enum(['development', 'test', 'production']).default('development'),
-  PORT: z.coerce.number().int().positive().default(3000),
-  HOST: z.string().default('0.0.0.0'),
-  // Unset -> in-memory repositories (zero-infra dev/tests). Set -> Postgres.
-  DATABASE_URL: z.string().optional(),
-});
+const envSchema = z
+  .object({
+    NODE_ENV: z.enum(['development', 'test', 'production']).default('development'),
+    PORT: z.coerce.number().int().positive().default(3000),
+    HOST: z.string().default('0.0.0.0'),
+    // Unset -> in-memory repositories (zero-infra dev/tests). Set -> Postgres.
+    DATABASE_URL: z.string().optional(),
+    // Auth (JWT). Unset -> a dev-only secret is used (local/tests). Required in
+    // production (enforced below). Access tokens are short-lived; see auth/jwt.ts.
+    JWT_SECRET: z.string().min(32).optional(),
+    JWT_ACCESS_TTL: z.string().default('15m'),
+    JWT_ISSUER: z.string().default('trotxi'),
+    JWT_AUDIENCE: z.string().default('trotxi-api'),
+  })
+  .superRefine((env, ctx) => {
+    if (env.NODE_ENV === 'production' && !env.JWT_SECRET) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['JWT_SECRET'],
+        message: 'JWT_SECRET is required in production (min 32 chars)',
+      });
+    }
+  });
 
 export type Env = z.infer<typeof envSchema>;
 

--- a/services/api/src/modules/auth/auth.plugin.ts
+++ b/services/api/src/modules/auth/auth.plugin.ts
@@ -1,0 +1,64 @@
+// Auth guard. Registered with fastify-plugin so the decorators live on the root
+// instance and are available to every route. Provides:
+//   - request.user        the authenticated principal (set by `authenticate`)
+//   - app.authenticate    preHandler: require a valid bearer token -> 401 if not
+//   - app.requireRole(..) preHandler factory: RBAC check -> 403 if role mismatch
+//   - app.jwt             the token service (used by sign-in routes in Slice 2)
+
+import type { FastifyReply, FastifyRequest, preHandlerHookHandler } from 'fastify';
+import fp from 'fastify-plugin';
+import type { UserRole } from '../users/user.repository';
+import { createJwtService, type AuthConfig, type JwtService } from './jwt';
+
+/** The authenticated principal attached to each request after `authenticate`. */
+export interface AuthUser {
+  id: string;
+  role: UserRole;
+}
+
+declare module 'fastify' {
+  interface FastifyRequest {
+    user?: AuthUser;
+  }
+  interface FastifyInstance {
+    jwt: JwtService;
+    authenticate: preHandlerHookHandler;
+    requireRole: (...roles: UserRole[]) => preHandlerHookHandler;
+  }
+}
+
+const BEARER_PREFIX = 'Bearer ';
+
+export const authPlugin = fp<{ config: AuthConfig }>(async (app, opts) => {
+  const jwt = createJwtService(opts.config);
+  app.decorate('jwt', jwt);
+  app.decorateRequest('user', undefined);
+
+  // Roles live in the (short-lived) token, so a role change takes effect on the
+  // next token refresh rather than instantly — an accepted trade-off for keeping
+  // the guard stateless. Long-lived/destructive actions re-check server-side.
+  app.decorate('authenticate', async function (request: FastifyRequest, reply: FastifyReply) {
+    const header = request.headers.authorization;
+    if (!header || !header.startsWith(BEARER_PREFIX)) {
+      return reply.code(401).send({ error: 'unauthorized', message: 'Missing bearer token' });
+    }
+    try {
+      const claims = await jwt.verifyAccessToken(header.slice(BEARER_PREFIX.length).trim());
+      request.user = { id: claims.userId, role: claims.role };
+    } catch {
+      return reply.code(401).send({ error: 'unauthorized', message: 'Invalid or expired token' });
+    }
+  });
+
+  // Compose after `authenticate`: preHandler: [app.authenticate, app.requireRole('admin')]
+  app.decorate('requireRole', (...roles: UserRole[]): preHandlerHookHandler => {
+    return async function (request: FastifyRequest, reply: FastifyReply) {
+      if (!request.user) {
+        return reply.code(401).send({ error: 'unauthorized', message: 'Authentication required' });
+      }
+      if (!roles.includes(request.user.role)) {
+        return reply.code(403).send({ error: 'forbidden', message: 'Insufficient role' });
+      }
+    };
+  });
+});

--- a/services/api/src/modules/auth/auth.routes.ts
+++ b/services/api/src/modules/auth/auth.routes.ts
@@ -1,0 +1,21 @@
+// Auth routes. `GET /me` is the first protected endpoint — it proves the guard
+// end-to-end (token -> request.user -> repository lookup). Sign-in/refresh land
+// in Slice 2. Registered after authPlugin so `app.authenticate` is available.
+
+import type { FastifyInstance } from 'fastify';
+import type { UserRepository } from '../users/user.repository';
+
+export async function authRoutes(
+  app: FastifyInstance,
+  opts: { users?: UserRepository },
+): Promise<void> {
+  app.get('/me', { preHandler: app.authenticate }, async (request, reply) => {
+    // `authenticate` guarantees request.user is set before we reach here.
+    const principal = request.user!;
+    const user = opts.users ? await opts.users.findById(principal.id) : null;
+    if (!user) {
+      return reply.code(404).send({ error: 'not_found', message: 'User not found' });
+    }
+    return user;
+  });
+}

--- a/services/api/src/modules/auth/jwt.ts
+++ b/services/api/src/modules/auth/jwt.ts
@@ -1,0 +1,72 @@
+// Framework-agnostic access-token service. Kept free of Fastify so it can be
+// unit-tested directly and reused (Slice 2 adds refresh tokens + social
+// sign-in, which verify Google/Apple ID tokens via jose's JWKS support).
+
+import { SignJWT, jwtVerify } from 'jose';
+import { z } from 'zod';
+import { USER_ROLES, type UserRole } from '../users/user.repository';
+
+const ALG = 'HS256';
+
+/** Auth configuration. The secret is required in production (see config/env.ts). */
+export interface AuthConfig {
+  secret: string;
+  /** Access-token lifetime, e.g. '15m' (jose duration syntax). */
+  accessTtl: string;
+  issuer: string;
+  audience: string;
+}
+
+/** Claims we put in (and read back out of) an access token. */
+export interface AccessTokenClaims {
+  userId: string;
+  role: UserRole;
+}
+
+// Validate the decoded payload before trusting it: a structurally valid but
+// semantically wrong token (unknown role, missing subject) is treated as invalid.
+const accessPayloadSchema = z.object({
+  sub: z.string().min(1),
+  role: z.enum(USER_ROLES),
+});
+
+export interface JwtService {
+  signAccessToken(claims: AccessTokenClaims): Promise<string>;
+  /** Resolves with the claims, or rejects if the token is invalid/expired. */
+  verifyAccessToken(token: string): Promise<AccessTokenClaims>;
+}
+
+/**
+ * Dev-only fallback so the API and tests run with zero config. Production must
+ * supply a real JWT_SECRET — env validation enforces this (config/env.ts).
+ */
+export const DEV_AUTH_CONFIG: AuthConfig = {
+  secret: 'dev-only-insecure-secret-change-me-0123456789abcdef',
+  accessTtl: '15m',
+  issuer: 'trotxi',
+  audience: 'trotxi-api',
+};
+
+export function createJwtService(config: AuthConfig): JwtService {
+  const key = new TextEncoder().encode(config.secret);
+  const verifyOptions = { issuer: config.issuer, audience: config.audience };
+
+  return {
+    async signAccessToken({ userId, role }) {
+      return new SignJWT({ role })
+        .setProtectedHeader({ alg: ALG })
+        .setSubject(userId)
+        .setIssuedAt()
+        .setIssuer(config.issuer)
+        .setAudience(config.audience)
+        .setExpirationTime(config.accessTtl)
+        .sign(key);
+    },
+
+    async verifyAccessToken(token) {
+      const { payload } = await jwtVerify(token, key, verifyOptions);
+      const { sub, role } = accessPayloadSchema.parse(payload);
+      return { userId: sub, role };
+    },
+  };
+}

--- a/services/api/src/modules/users/user.repository.ts
+++ b/services/api/src/modules/users/user.repository.ts
@@ -2,7 +2,8 @@
 // InMemory (tests + zero-infra dev) and Postgres (real runs, see *.pg.ts).
 // The server picks one by DATABASE_URL. Copy this shape for new domain modules.
 
-export type UserRole = 'commuter' | 'driver' | 'admin';
+export const USER_ROLES = ['commuter', 'driver', 'admin'] as const;
+export type UserRole = (typeof USER_ROLES)[number];
 
 export interface User {
   id: string;

--- a/services/api/src/server.ts
+++ b/services/api/src/server.ts
@@ -3,12 +3,25 @@ import { buildApp, type AppDeps } from './app';
 import { loadDotenv } from './config/dotenv';
 import { loadEnv } from './config/env';
 import { createPool } from './db/pool';
+import { DEV_AUTH_CONFIG, type AuthConfig } from './modules/auth/jwt';
 import { InMemoryUserRepository } from './modules/users/user.repository';
 import { PgUserRepository } from './modules/users/user.repository.pg';
 
 async function main(): Promise<void> {
   loadDotenv();
   const env = loadEnv();
+
+  // Auth config from env; fall back to the dev secret when unset (production is
+  // forced to provide JWT_SECRET by env validation).
+  if (!env.JWT_SECRET) {
+    console.warn('JWT_SECRET not set — using insecure dev secret. Do NOT use in production.');
+  }
+  const auth: AuthConfig = {
+    secret: env.JWT_SECRET ?? DEV_AUTH_CONFIG.secret,
+    accessTtl: env.JWT_ACCESS_TTL,
+    issuer: env.JWT_ISSUER,
+    audience: env.JWT_AUDIENCE,
+  };
 
   // Pick repositories by environment: Postgres when DATABASE_URL is set, else
   // in-memory (zero infra). New modules follow this same pattern.
@@ -33,7 +46,7 @@ async function main(): Promise<void> {
     console.log('Using in-memory repositories (no DATABASE_URL set)');
   }
 
-  const app = await buildApp({ ...deps, logger: true });
+  const app = await buildApp({ ...deps, auth, logger: true });
 
   const shutdown = async (signal: string): Promise<void> => {
     app.log.info(`Received ${signal}, shutting down`);

--- a/services/api/tests/auth.test.ts
+++ b/services/api/tests/auth.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+import { buildApp } from '../src/app';
+import { createJwtService, type AuthConfig } from '../src/modules/auth/jwt';
+import { InMemoryUserRepository } from '../src/modules/users/user.repository';
+
+const auth: AuthConfig = {
+  secret: 'test-secret-at-least-32-characters-long-0000',
+  accessTtl: '15m',
+  issuer: 'trotxi',
+  audience: 'trotxi-api',
+};
+const jwt = createJwtService(auth);
+const bearer = (token: string) => ({ authorization: `Bearer ${token}` });
+
+describe('GET /me (authenticate guard)', () => {
+  it('rejects a request with no Authorization header', async () => {
+    const app = await buildApp({ auth, users: new InMemoryUserRepository() });
+    const res = await app.inject({ method: 'GET', url: '/me' });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('rejects a non-bearer Authorization header', async () => {
+    const app = await buildApp({ auth, users: new InMemoryUserRepository() });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/me',
+      headers: { authorization: 'Basic abc' },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('rejects an invalid token', async () => {
+    const app = await buildApp({ auth, users: new InMemoryUserRepository() });
+    const res = await app.inject({ method: 'GET', url: '/me', headers: bearer('garbage') });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('returns 404 when no user repository is configured', async () => {
+    const app = await buildApp({ auth });
+    const token = await jwt.signAccessToken({ userId: 'x', role: 'commuter' });
+    const res = await app.inject({ method: 'GET', url: '/me', headers: bearer(token) });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('returns 404 when the token is valid but the user is gone', async () => {
+    const app = await buildApp({ auth, users: new InMemoryUserRepository() });
+    const token = await jwt.signAccessToken({ userId: 'missing', role: 'commuter' });
+    const res = await app.inject({ method: 'GET', url: '/me', headers: bearer(token) });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('returns the authenticated user with a valid token', async () => {
+    const users = new InMemoryUserRepository();
+    const user = await users.create({ displayName: 'Ama' });
+    const app = await buildApp({ auth, users });
+    const token = await jwt.signAccessToken({ userId: user.id, role: user.role });
+
+    const res = await app.inject({ method: 'GET', url: '/me', headers: bearer(token) });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ id: user.id, displayName: 'Ama', role: 'commuter' });
+  });
+});
+
+describe('requireRole guard', () => {
+  // Register a throwaway admin-only route as a plugin so the root decorators
+  // (authenticate/requireRole) are loaded before the route is defined.
+  async function appWithAdminRoute() {
+    const app = await buildApp({ auth, users: new InMemoryUserRepository() });
+    await app.register(async (instance) => {
+      instance.get(
+        '/admin-only',
+        { preHandler: [instance.authenticate, instance.requireRole('admin')] },
+        async () => ({ ok: true }),
+      );
+      // No authenticate in front: exercises the "no principal" branch.
+      instance.get('/role-only', { preHandler: instance.requireRole('admin') }, async () => ({
+        ok: true,
+      }));
+    });
+    return app;
+  }
+
+  it('allows a user whose role matches', async () => {
+    const app = await appWithAdminRoute();
+    const token = await jwt.signAccessToken({ userId: 'admin-1', role: 'admin' });
+    const res = await app.inject({ method: 'GET', url: '/admin-only', headers: bearer(token) });
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('forbids a user whose role does not match', async () => {
+    const app = await appWithAdminRoute();
+    const token = await jwt.signAccessToken({ userId: 'commuter-1', role: 'commuter' });
+    const res = await app.inject({ method: 'GET', url: '/admin-only', headers: bearer(token) });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('rejects when used without prior authentication', async () => {
+    const app = await appWithAdminRoute();
+    const res = await app.inject({ method: 'GET', url: '/role-only' });
+    expect(res.statusCode).toBe(401);
+  });
+});

--- a/services/api/tests/env.test.ts
+++ b/services/api/tests/env.test.ts
@@ -1,18 +1,37 @@
 import { describe, expect, it } from 'vitest';
 import { loadEnv } from '../src/config/env';
 
+const JWT_DEFAULTS = {
+  JWT_ACCESS_TTL: '15m',
+  JWT_ISSUER: 'trotxi',
+  JWT_AUDIENCE: 'trotxi-api',
+};
+
 describe('loadEnv', () => {
   it('applies defaults for an empty environment', () => {
     const env = loadEnv({});
-    expect(env).toEqual({ NODE_ENV: 'development', PORT: 3000, HOST: '0.0.0.0' });
+    expect(env).toEqual({ NODE_ENV: 'development', PORT: 3000, HOST: '0.0.0.0', ...JWT_DEFAULTS });
   });
 
   it('parses provided values', () => {
     const env = loadEnv({ NODE_ENV: 'test', PORT: '3100', HOST: '127.0.0.1' });
-    expect(env).toEqual({ NODE_ENV: 'test', PORT: 3100, HOST: '127.0.0.1' });
+    expect(env).toEqual({ NODE_ENV: 'test', PORT: 3100, HOST: '127.0.0.1', ...JWT_DEFAULTS });
   });
 
   it('rejects invalid values with a readable message', () => {
     expect(() => loadEnv({ PORT: 'not-a-port' })).toThrow(/Invalid environment configuration/);
+  });
+
+  it('requires JWT_SECRET in production', () => {
+    expect(() => loadEnv({ NODE_ENV: 'production' })).toThrow(/JWT_SECRET/);
+  });
+
+  it('accepts a production config with a valid JWT_SECRET', () => {
+    const env = loadEnv({ NODE_ENV: 'production', JWT_SECRET: 'x'.repeat(32) });
+    expect(env.JWT_SECRET).toHaveLength(32);
+  });
+
+  it('rejects a JWT_SECRET shorter than 32 chars', () => {
+    expect(() => loadEnv({ JWT_SECRET: 'too-short' })).toThrow(/Invalid environment configuration/);
   });
 });

--- a/services/api/tests/jwt.test.ts
+++ b/services/api/tests/jwt.test.ts
@@ -1,0 +1,68 @@
+import { SignJWT } from 'jose';
+import { describe, expect, it } from 'vitest';
+import { createJwtService, type AuthConfig } from '../src/modules/auth/jwt';
+
+const config: AuthConfig = {
+  secret: 'test-secret-at-least-32-characters-long-0000',
+  accessTtl: '15m',
+  issuer: 'trotxi',
+  audience: 'trotxi-api',
+};
+
+const key = new TextEncoder().encode(config.secret);
+
+// Craft a token directly (bypassing the service) to exercise the verify paths.
+function craft(opts: {
+  sub?: string;
+  role?: string;
+  issuer?: string;
+  audience?: string;
+  exp?: number | string;
+}): Promise<string> {
+  const payload = opts.role !== undefined ? { role: opts.role } : {};
+  const jwt = new SignJWT(payload)
+    .setProtectedHeader({ alg: 'HS256' })
+    .setIssuedAt()
+    .setSubject(opts.sub ?? 'user-1')
+    .setIssuer(opts.issuer ?? config.issuer)
+    .setAudience(opts.audience ?? config.audience)
+    .setExpirationTime(opts.exp ?? '15m');
+  return jwt.sign(key);
+}
+
+describe('createJwtService', () => {
+  const jwt = createJwtService(config);
+
+  it('signs and verifies an access token round-trip', async () => {
+    const token = await jwt.signAccessToken({ userId: 'user-1', role: 'driver' });
+    expect(await jwt.verifyAccessToken(token)).toEqual({ userId: 'user-1', role: 'driver' });
+  });
+
+  it('rejects a malformed token', async () => {
+    await expect(jwt.verifyAccessToken('not-a-jwt')).rejects.toThrow();
+  });
+
+  it('rejects a token signed with a different secret', async () => {
+    const other = createJwtService({
+      ...config,
+      secret: 'a-totally-different-secret-32-chars-min',
+    });
+    const token = await other.signAccessToken({ userId: 'user-1', role: 'commuter' });
+    await expect(jwt.verifyAccessToken(token)).rejects.toThrow();
+  });
+
+  it('rejects an expired token', async () => {
+    const token = await craft({ role: 'commuter', exp: Math.floor(Date.now() / 1000) - 60 });
+    await expect(jwt.verifyAccessToken(token)).rejects.toThrow();
+  });
+
+  it('rejects a token with the wrong issuer', async () => {
+    const token = await craft({ role: 'commuter', issuer: 'someone-else' });
+    await expect(jwt.verifyAccessToken(token)).rejects.toThrow();
+  });
+
+  it('rejects a token carrying an unknown role', async () => {
+    const token = await craft({ role: 'superuser' });
+    await expect(jwt.verifyAccessToken(token)).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## What

**Slice 1 of the auth spine ([#16](https://github.com/TROTXI/mobility-core/issues/16))** — the **token contract + route guard** the rest of the team builds on. This is deliberately scoped to unblock others *now*; sign-in (Google/Apple) and refresh tokens come in Slice 2.

- **`modules/auth/jwt.ts`** — framework-agnostic `createJwtService(config)` (jose, HS256). Signs short-lived access tokens and verifies them, **validating the decoded payload** (rejects expired, tampered, wrong-issuer/audience, and unknown-role tokens). Kept free of Fastify so it's trivially unit-testable and reusable (Slice 2 uses jose's JWKS for social ID-token verification).
- **`modules/auth/auth.plugin.ts`** — `fastify-plugin` decorating:
  - `request.user` — the authenticated principal `{ id, role }`
  - `app.authenticate` — preHandler, **401** if the bearer token is missing/invalid
  - `app.requireRole(...roles)` — preHandler factory, **403** on role mismatch (RBAC)
  - `app.jwt` — the token service, for the sign-in routes landing in Slice 2
- **`modules/auth/auth.routes.ts`** — `GET /me`, the first protected route (token → `request.user` → repo lookup).
- **env** — `JWT_SECRET` (**required in production**, min 32 chars; dev/test fall back to an insecure default with a startup warning), plus `JWT_ACCESS_TTL` / `JWT_ISSUER` / `JWT_AUDIENCE`.
- **users** — `USER_ROLES` const as the single source of truth for roles (drives both the token payload schema and `requireRole` typing).

### Design notes
- **jose over `@fastify/jwt`** — keeps token logic framework-agnostic and unit-testable, and we need jose's JWKS support for Google/Apple verification in Slice 2 anyway.
- **Role lives in the (short-lived) token** — the guard stays stateless; a role change takes effect on the next refresh. Destructive/long-lived actions should re-check server-side.

## What this unblocks
- We can put any endpoint behind `preHandler: [app.authenticate]` (and `app.requireRole('admin')` for ops endpoints) immediately.
- **(#34)** — has the access-token format + `GET /me` contract to build the client against; full sign-in flow follows in Slice 2.

## How to verify
```bash
pnpm install
pnpm --filter @trotxi/api test:coverage   # 32 tests, 100% coverage on new logic
pnpm api                                   # boots with a dev secret + warning
curl -i localhost:3000/me                  # 401 (no token)
```
Also smoke-tested over real HTTP: boot → `/healthz` 200, `/me` 401 with no/!invalid token.

## Follow-ups (not this PR)
- **Slice 2** — `POST /auth/google` + `/auth/apple` (server-side ID-token verify), refresh tokens (hashed in `sessions`), rotation + revoke, `POST /auth/refresh`, `POST /auth/logout`.
- **Slice 3** — JWKS caching, refresh-reuse detection, rate limiting on auth ([#23](https://github.com/TROTXI/mobility-core/issues/23), needs Redis [#22](https://github.com/TROTXI/mobility-core/issues/22)).

Part of [#16](https://github.com/TROTXI/mobility-core/issues/16) (leaving it open until the full spine lands).