### PR TITLE
chore(repo): add CODEOWNERS (money/auth/security → CTO) (#31)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,34 @@
+# CODEOWNERS — who must review changes to each path.
+#
+# How it works: the LAST matching pattern wins, and a PR needs an approving
+# review from a code owner of every changed path once "Require review from Code
+# Owners" is enabled in branch protection. GitHub never counts the author's own
+# review, so every area lists a second owner — otherwise a lead could never get
+# their own PRs approved. The CTO co-owns all high-risk paths (money, auth,
+# schema, CI/CD, security) so those changes always get senior eyes.
+#
+# Roles: @godfredAwuku = CTO · @Foyade = Lead Backend · @adomfosugit = Lead Frontend
+
+# Default — repo-wide tooling, config, and anything not matched below.
+*                                       @godfredAwuku @Foyade
+
+# Mobile apps — Lead Frontend owns; CTO is the backup reviewer.
+/apps/                                  @adomfosugit @godfredAwuku
+
+# Backend service domains — Lead Backend owns; CTO is the backup reviewer.
+/services/api/                          @Foyade @godfredAwuku
+
+# High-risk: money, auth, and DB schema. CTO owns; Backend co-reviews so money
+# and auth changes always get two sets of eyes (and nothing self-blocks).
+/services/api/src/modules/auth/         @godfredAwuku @Foyade
+/services/api/src/modules/payments/     @godfredAwuku @Foyade
+/services/api/src/modules/tokens/       @godfredAwuku @Foyade
+/services/api/src/db/migrations/        @godfredAwuku @Foyade
+
+# CI/CD, deploy, and security config — CTO owns; Backend co-reviews.
+/.github/                               @godfredAwuku @Foyade
+/render.yaml                            @godfredAwuku @Foyade
+/.gitleaks.toml                         @godfredAwuku @Foyade
+
+# Architecture decision records — CTO owns the technical direction.
+/docs/adr/                              @godfredAwuku @Foyade

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,15 @@
+# gitleaks config — extends the default ruleset with an allowlist for
+# INTENTIONAL non-secret placeholders: the dev-only JWT fallback (config/env.ts,
+# auth/jwt.ts) and test fixtures. See ADR-0007. Real secrets are injected via
+# environment variables and are never committed.
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Intentional non-secret placeholders (dev JWT fallback + test fixtures)"
+regexes = [
+  '''dev-only-insecure-secret-change-me-[0-9a-f]+''',
+  '''test-secret-at-least-32-characters-long-[0-9]+''',
+  '''a-totally-different-secret-32-chars-min''',
+]


### PR DESCRIPTION
## What
Adds `.github/CODEOWNERS` to codify the ownership model from [#31](https://github.com/TROTXI/mobility-core/issues/31). Validated clean via the GitHub CODEOWNERS API (`errors: []`).

## Ownership model
| Path | Owners |
|------|--------|
| `*` (default: tooling, config) | CTO + Backend |
| `/apps/` | **Frontend** + CTO |
| `/services/api/` | **Backend** + CTO |
| `auth/`, `payments/`, `tokens/`, `db/migrations/` | **CTO** + Backend |
| `/.github/`, `render.yaml`, `.gitleaks.toml` | **CTO** + Backend |
| `/docs/adr/` | **CTO** + Backend |

## Why two owners per area
GitHub **doesn't count the author's own review**. With a single owner per area and `require_code_owner_reviews` on, a lead could never get their *own* PRs approved (e.g. Foyade couldn't merge his own API PRs — and he isn't an admin, so he can't bypass). So every area has a second owner. The CTO co-owns every high-risk path, guaranteeing senior review on money/auth/schema/CI/security; money and auth deliberately get two sets of eyes.

## Follow-up: enable the enforcement (post-merge)
`require_code_owner_reviews` only reads CODEOWNERS from the **base branch**, so it has to be turned on **after this merges**. Current branch protection: `required_approving_review_count: 1`, `enforce_admins: false`, `require_code_owner_reviews: false`.

⚠️ When we flip it on, it will apply to open PRs — including **[#45](https://github.com/TROTXI/mobility-core/pull/45)** (auth path → owners CTO + Backend). That's fine as long as a code owner (CTO or Foyade) is the approver on #45.

## Acceptance ([#31](https://github.com/TROTXI/mobility-core/issues/31))
- [x] CODEOWNERS in place and syntactically valid
- [ ] `require_code_owner_reviews` enabled — post-merge step (see above)

Closes #31