### PR TITLE
ci(deploy): run DB migrations before each deploy (#29)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,6 +31,25 @@ jobs:
       url: ${{ vars.STAGING_URL }}
     steps:
       - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+
+      # Migrate BEFORE shipping new code: our migrations are additive
+      # (expand/contract), so the schema must lead the deploy. A failure here
+      # aborts the deploy before any new code goes live.
+      - name: Run DB migrations
+        env:
+          DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
+        run: |
+          if [ -z "$DATABASE_URL" ]; then
+            echo "::error::STAGING_DATABASE_URL is not set. Add it as a repo secret: the staging DB's EXTERNAL connection string with ?sslmode=no-verify appended (see docs/DEPLOY.md)."
+            exit 1
+          fi
+          pnpm --filter @trotxi/api run migrate
 
       - name: Deploy and wait until live
         run: .github/scripts/render-deploy.sh
@@ -57,6 +76,24 @@ jobs:
       url: ${{ vars.PRODUCTION_URL }}
     steps:
       - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+
+      # Migrate before shipping new code (expand/contract). Aborts the prod
+      # deploy if migrations fail.
+      - name: Run DB migrations
+        env:
+          DATABASE_URL: ${{ secrets.PRODUCTION_DATABASE_URL }}
+        run: |
+          if [ -z "$DATABASE_URL" ]; then
+            echo "::error::PRODUCTION_DATABASE_URL is not set. Add it as a repo secret: the production DB's EXTERNAL connection string with ?sslmode=no-verify appended (see docs/DEPLOY.md)."
+            exit 1
+          fi
+          pnpm --filter @trotxi/api run migrate
 
       - name: Deploy and wait until live
         run: .github/scripts/render-deploy.sh

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -9,11 +9,16 @@ blueprint (`render.yaml`), and a CD pipeline (`.github/workflows/deploy.yml`).
 push / merge to main
   → CI: all checks must pass (branch protection)
   → Deploy workflow fires on CI success:
-      staging  — deploys automatically via the Render API, waits until live,
-                 smoke-tests /healthz + /readyz
+      staging  — runs DB migrations, then deploys via the Render API, waits
+                 until live, smoke-tests /healthz + /readyz
       production — waits for a manual approval in GitHub (environment
-                 "production"), then deploys + smoke-tests the same way
+                 "production"), then migrates + deploys + smoke-tests the same way
 ```
+
+**Migrations run before the deploy** (expand/contract: our migrations are
+additive, so the schema must lead the code). They run from CI against the DB's
+**external** connection string; a migration failure aborts the deploy before any
+new code ships.
 
 - Deploys **queue in order** (no cancellation), so every green commit ships.
 - The pipeline is **dormant** until the `DEPLOY_ENABLED` repo variable is
@@ -37,9 +42,23 @@ push / merge to main
    gh variable set STAGING_URL -R TROTXI/mobility-core --body "https://trotxi-api-staging.onrender.com"
    gh variable set DEPLOY_ENABLED -R TROTXI/mobility-core --body "true"
    ```
-4. Done — the next merge to main deploys staging automatically. The GitHub
-   environments `staging` and `production` already exist; production requires
-   approval before its job runs.
+4. **`JWT_SECRET`** (required — the API refuses to boot in production without
+   it). Render dashboard → `trotxi-api-staging` → **Environment** → add
+   `JWT_SECRET` = `openssl rand -base64 48`. (Declared `sync: false` in
+   `render.yaml`; the value is entered here, never committed.)
+5. **`STAGING_DATABASE_URL`** (required for migrate-on-deploy). Render → DB →
+   **Connections** → copy the **External** connection string, append
+   `?sslmode=no-verify`, then:
+   ```bash
+   gh secret set STAGING_DATABASE_URL -R TROTXI/mobility-core \
+     --body "postgres://USER:PASS@HOST.frankfurt-postgres.render.com/DB?sslmode=no-verify"
+   ```
+   (External + SSL because migrations run from CI, outside Render's network.
+   `no-verify` keeps the connection encrypted without needing Render's CA cert.)
+6. Done — the next merge to main migrates + deploys staging automatically. The
+   GitHub environments `staging` and `production` already exist; production
+   requires approval before its job runs (and its own `PRODUCTION_DATABASE_URL`
+   secret + `JWT_SECRET` on the prod service).
 
 ## Notes
 


### PR DESCRIPTION
## What
Adds a **migrate step** to the staging and production deploy jobs ([#29](https://github.com/TROTXI/mobility-core/issues/29)). On each deploy: install deps → **`pnpm migrate`** against the DB's external connection string → trigger the Render deploy → smoke test.

## Why this approach
Our prod Docker image strips dev deps and only bundles `dist/server.js`, so the migrate runner (`tsx` + the `.sql` files) isn't in the runtime image. And Render's **Pre-Deploy Command** isn't available on our **free** staging plan. So migrations run from CI (where the dev toolchain + SQL files exist) against the DB's **external** connection string — chosen over auto-migrate-on-boot to keep migrations a discrete, observable pipeline stage.

- **Order = expand/contract:** migrations are additive, so the schema must lead the code. Migrate runs *before* the deploy; a migration failure aborts the deploy before any new code ships.
- **Fails loudly:** if the `*_DATABASE_URL` secret is missing, the step errors with a clear message instead of a cryptic pg failure.

## ⚠️ Action required before this merges
Staging will deploy on merge and the migrate step will run — it needs a secret, or the deploy fails (same shape as the `JWT_SECRET` lesson):

1. Render → **trotxi-db-staging** → Connections → copy the **External** connection string.
2. Append `?sslmode=no-verify` (encrypted; CI is outside Render's network and doesn't have Render's CA).
3. Add it:
   ```bash
   gh secret set STAGING_DATABASE_URL -R TROTXI/mobility-core \
     --body "postgres://USER:PASS@HOST.frankfurt-postgres.render.com/DB?sslmode=no-verify"
   ```

`PRODUCTION_DATABASE_URL` is only needed when the (gated) production job is activated.

## Acceptance ([#29](https://github.com/TROTXI/mobility-core/issues/29))
- [x] Migrations run on deploy (staging + production), before the app deploy
- [x] Expand/contract ordering; aborts deploy on failure
- [x] Docs updated (`docs/DEPLOY.md`)
- [ ] `STAGING_DATABASE_URL` secret added (your step above)

Closes #29