### PR TITLE
feat(infra): Redis KV store with in-memory fallback (#22)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       fastify-plugin:
         specifier: ^6.0.0
         version: 6.0.0
+      ioredis:
+        specifier: ^5.11.1
+        version: 5.11.1
       jose:
         specifier: ^6.2.3
         version: 6.2.3
@@ -649,6 +652,9 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@ioredis/commands@1.10.0':
+    resolution: {integrity: sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q==}
+
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
@@ -1060,6 +1066,10 @@ packages:
     resolution: {integrity: sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==}
     engines: {node: '>=18'}
 
+  cluster-key-slot@1.1.1:
+    resolution: {integrity: sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw==}
+    engines: {node: '>=0.10.0'}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -1115,6 +1125,10 @@ packages:
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  denque@2.1.0:
+    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
+    engines: {node: '>=0.10'}
 
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
@@ -1374,6 +1388,10 @@ packages:
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ioredis@5.11.1:
+    resolution: {integrity: sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A==}
+    engines: {node: '>=12.22.0'}
 
   ipaddr.js@2.4.0:
     resolution: {integrity: sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==}
@@ -1792,6 +1810,14 @@ packages:
   real-require@1.0.0:
     resolution: {integrity: sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==}
 
+  redis-errors@1.2.0:
+    resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
+    engines: {node: '>=4'}
+
+  redis-parser@3.0.0:
+    resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
+    engines: {node: '>=4'}
+
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
@@ -1886,6 +1912,9 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  standard-as-callback@2.1.0:
+    resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
 
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
@@ -2518,6 +2547,8 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
+  '@ioredis/commands@1.10.0': {}
+
   '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
@@ -2905,6 +2936,8 @@ snapshots:
       slice-ansi: 5.0.0
       string-width: 7.2.0
 
+  cluster-key-slot@1.1.1: {}
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -2940,6 +2973,8 @@ snapshots:
   deep-eql@5.0.2: {}
 
   deep-is@0.1.4: {}
+
+  denque@2.1.0: {}
 
   depd@2.0.0: {}
 
@@ -3284,6 +3319,18 @@ snapshots:
   imurmurhash@0.1.4: {}
 
   inherits@2.0.4: {}
+
+  ioredis@5.11.1:
+    dependencies:
+      '@ioredis/commands': 1.10.0
+      cluster-key-slot: 1.1.1
+      debug: 4.4.3
+      denque: 2.1.0
+      redis-errors: 1.2.0
+      redis-parser: 3.0.0
+      standard-as-callback: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
 
   ipaddr.js@2.4.0: {}
 
@@ -3671,6 +3718,12 @@ snapshots:
 
   real-require@1.0.0: {}
 
+  redis-errors@1.2.0: {}
+
+  redis-parser@3.0.0:
+    dependencies:
+      redis-errors: 1.2.0
+
   require-from-string@2.0.2: {}
 
   resolve-from@4.0.0: {}
@@ -3764,6 +3817,8 @@ snapshots:
   split2@4.2.0: {}
 
   stackback@0.0.2: {}
+
+  standard-as-callback@2.1.0: {}
 
   statuses@2.0.2: {}
 

--- a/services/api/.env.example
+++ b/services/api/.env.example
@@ -7,6 +7,11 @@ NODE_ENV=development
 # Set it to use Postgres (run `pnpm infra:up` first, then `pnpm migrate`).
 # DATABASE_URL=postgres://trotxi:trotxi@localhost:5432/trotxi
 
+# Redis — leave unset to run with an in-memory KV store (zero infra).
+# Set it to use Redis (run `pnpm infra:up` first). Used for rate limits,
+# idempotency keys, and caching.
+# REDIS_URL=redis://localhost:6379
+
 # Auth (JWT) — leave unset for a dev-only secret (local/tests).
 # REQUIRED in production (min 32 chars). Generate: openssl rand -base64 48
 # JWT_SECRET=

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -23,6 +23,7 @@
     "@fastify/swagger-ui": "^6.0.0",
     "fastify": "^5.2.0",
     "fastify-plugin": "^6.0.0",
+    "ioredis": "^5.11.1",
     "jose": "^6.2.3",
     "pg": "^8.13.1",
     "zod": "^3.24.1"

--- a/services/api/src/app.ts
+++ b/services/api/src/app.ts
@@ -3,6 +3,7 @@ import fastifySwaggerUi from '@fastify/swagger-ui';
 import Fastify, { type FastifyInstance } from 'fastify';
 import { authPlugin } from './modules/auth/auth.plugin';
 import { authRoutes } from './modules/auth/auth.routes';
+import type { KvStore } from './kv/kv.store';
 import { DEV_AUTH_CONFIG, type AuthConfig } from './modules/auth/jwt';
 import type { UserRepository } from './modules/users/user.repository';
 
@@ -16,6 +17,8 @@ export interface AppDeps {
   isReady?: () => Promise<boolean>;
   /** Selected by DATABASE_URL (in-memory vs Postgres). Consumed by routes/services. */
   users?: UserRepository;
+  /** Selected by REDIS_URL (in-memory vs Redis). For rate limits, idempotency, cache. */
+  kv?: KvStore;
   /** JWT/auth settings. Defaults to a dev-only config when unset (tests, local). */
   auth?: AuthConfig;
   logger?: boolean;

--- a/services/api/src/config/env.ts
+++ b/services/api/src/config/env.ts
@@ -7,6 +7,8 @@ const envSchema = z
     HOST: z.string().default('0.0.0.0'),
     // Unset -> in-memory repositories (zero-infra dev/tests). Set -> Postgres.
     DATABASE_URL: z.string().optional(),
+    // Unset -> in-memory KV (zero-infra dev/tests). Set -> Redis.
+    REDIS_URL: z.string().optional(),
     // Auth (JWT). Unset -> a dev-only secret is used (local/tests). Required in
     // production (enforced below). Access tokens are short-lived; see auth/jwt.ts.
     JWT_SECRET: z.string().min(32).optional(),

--- a/services/api/src/kv/kv.store.redis.ts
+++ b/services/api/src/kv/kv.store.redis.ts
@@ -1,0 +1,53 @@
+// Redis-backed KvStore (ioredis). Selected when REDIS_URL is set. Covered by
+// real-infra/e2e rather than unit tests — see vitest.config.ts excludes.
+
+import { Redis } from 'ioredis';
+import type { KvStore } from './kv.store';
+
+export class RedisKvStore implements KvStore {
+  private readonly redis: Redis;
+
+  constructor(url: string) {
+    this.redis = new Redis(url, {
+      // Surface connection problems instead of queueing forever.
+      maxRetriesPerRequest: 3,
+    });
+  }
+
+  async get(key: string): Promise<string | null> {
+    return this.redis.get(key);
+  }
+
+  async set(key: string, value: string, ttlSeconds?: number): Promise<void> {
+    if (ttlSeconds === undefined) {
+      await this.redis.set(key, value);
+    } else {
+      await this.redis.set(key, value, 'EX', ttlSeconds);
+    }
+  }
+
+  async del(key: string): Promise<void> {
+    await this.redis.del(key);
+  }
+
+  async increment(key: string, ttlSeconds: number): Promise<number> {
+    const count = await this.redis.incr(key);
+    // Set the expiry only on first creation so the window doesn't slide.
+    if (count === 1) {
+      await this.redis.expire(key, ttlSeconds);
+    }
+    return count;
+  }
+
+  async ping(): Promise<boolean> {
+    try {
+      return (await this.redis.ping()) === 'PONG';
+    } catch {
+      return false;
+    }
+  }
+
+  async close(): Promise<void> {
+    await this.redis.quit();
+  }
+}

--- a/services/api/src/kv/kv.store.ts
+++ b/services/api/src/kv/kv.store.ts
@@ -1,0 +1,71 @@
+// Key-value store abstraction with two implementations — InMemory (tests +
+// zero-infra dev) and Redis (real runs, see kv.store.redis.ts). The server picks
+// one by REDIS_URL, mirroring the repository pattern. Consumers (rate limiting,
+// idempotency keys, caching) depend on this interface, not on Redis directly.
+
+export interface KvStore {
+  get(key: string): Promise<string | null>;
+  /** Set a value, optionally expiring after `ttlSeconds`. */
+  set(key: string, value: string, ttlSeconds?: number): Promise<void>;
+  del(key: string): Promise<void>;
+  /**
+   * Atomically increment a counter, returning the new value. The TTL is set
+   * only when the counter is first created, so the window does not slide on each
+   * hit — the building block for fixed-window rate limiting.
+   */
+  increment(key: string, ttlSeconds: number): Promise<number>;
+  /** Liveness check for the readiness probe. */
+  ping(): Promise<boolean>;
+  close(): Promise<void>;
+}
+
+interface Entry {
+  value: string;
+  /** Epoch ms when this entry expires, or null for no expiry. */
+  expiresAt: number | null;
+}
+
+export class InMemoryKvStore implements KvStore {
+  private readonly store = new Map<string, Entry>();
+
+  /** Return a live entry, lazily evicting it if it has expired. */
+  private read(key: string): Entry | undefined {
+    const entry = this.store.get(key);
+    if (!entry) return undefined;
+    if (entry.expiresAt !== null && entry.expiresAt <= Date.now()) {
+      this.store.delete(key);
+      return undefined;
+    }
+    return entry;
+  }
+
+  async get(key: string): Promise<string | null> {
+    return this.read(key)?.value ?? null;
+  }
+
+  async set(key: string, value: string, ttlSeconds?: number): Promise<void> {
+    const expiresAt = ttlSeconds === undefined ? null : Date.now() + ttlSeconds * 1000;
+    this.store.set(key, { value, expiresAt });
+  }
+
+  async del(key: string): Promise<void> {
+    this.store.delete(key);
+  }
+
+  async increment(key: string, ttlSeconds: number): Promise<number> {
+    const existing = this.read(key);
+    const count = existing ? Number(existing.value) + 1 : 1;
+    // Keep the original expiry across increments (fixed window).
+    const expiresAt = existing ? existing.expiresAt : Date.now() + ttlSeconds * 1000;
+    this.store.set(key, { value: String(count), expiresAt });
+    return count;
+  }
+
+  async ping(): Promise<boolean> {
+    return true;
+  }
+
+  async close(): Promise<void> {
+    this.store.clear();
+  }
+}

--- a/services/api/src/server.ts
+++ b/services/api/src/server.ts
@@ -1,10 +1,12 @@
 import type { Pool } from 'pg';
-import { buildApp, type AppDeps } from './app';
+import { buildApp } from './app';
 import { loadDotenv } from './config/dotenv';
 import { loadEnv } from './config/env';
 import { createPool } from './db/pool';
+import { InMemoryKvStore, type KvStore } from './kv/kv.store';
+import { RedisKvStore } from './kv/kv.store.redis';
 import { DEV_AUTH_CONFIG, type AuthConfig } from './modules/auth/jwt';
-import { InMemoryUserRepository } from './modules/users/user.repository';
+import { InMemoryUserRepository, type UserRepository } from './modules/users/user.repository';
 import { PgUserRepository } from './modules/users/user.repository.pg';
 
 async function main(): Promise<void> {
@@ -23,35 +25,43 @@ async function main(): Promise<void> {
     audience: env.JWT_AUDIENCE,
   };
 
-  // Pick repositories by environment: Postgres when DATABASE_URL is set, else
-  // in-memory (zero infra). New modules follow this same pattern.
+  // KV store: Redis when REDIS_URL is set, else in-memory (zero infra).
+  const kv: KvStore = env.REDIS_URL ? new RedisKvStore(env.REDIS_URL) : new InMemoryKvStore();
+  console.log(
+    env.REDIS_URL ? 'Using Redis KV store' : 'Using in-memory KV store (no REDIS_URL set)',
+  );
+
+  // Repositories: Postgres when DATABASE_URL is set, else in-memory (zero infra).
   let pool: Pool | undefined;
-  let deps: Pick<AppDeps, 'users' | 'isReady'>;
+  let users: UserRepository;
   if (env.DATABASE_URL) {
     pool = createPool(env.DATABASE_URL);
-    deps = {
-      users: new PgUserRepository(pool),
-      isReady: async () => {
-        try {
-          await pool!.query('SELECT 1');
-          return true;
-        } catch {
-          return false;
-        }
-      },
-    };
+    users = new PgUserRepository(pool);
     console.log('Using Postgres repositories');
   } else {
-    deps = { users: new InMemoryUserRepository(), isReady: async () => true };
+    users = new InMemoryUserRepository();
     console.log('Using in-memory repositories (no DATABASE_URL set)');
   }
 
-  const app = await buildApp({ ...deps, auth, logger: true });
+  // Readiness pings every configured backing service (DB + KV).
+  const isReady = async (): Promise<boolean> => {
+    if (pool) {
+      try {
+        await pool.query('SELECT 1');
+      } catch {
+        return false;
+      }
+    }
+    return kv.ping();
+  };
+
+  const app = await buildApp({ users, kv, isReady, auth, logger: true });
 
   const shutdown = async (signal: string): Promise<void> => {
     app.log.info(`Received ${signal}, shutting down`);
     await app.close();
     await pool?.end();
+    await kv.close();
     process.exit(0);
   };
   process.on('SIGINT', () => void shutdown('SIGINT'));

--- a/services/api/tests/kv.store.test.ts
+++ b/services/api/tests/kv.store.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { InMemoryKvStore } from '../src/kv/kv.store';
+
+describe('InMemoryKvStore', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('stores and retrieves a value', async () => {
+    const kv = new InMemoryKvStore();
+    await kv.set('k', 'v');
+    expect(await kv.get('k')).toBe('v');
+  });
+
+  it('returns null for a missing key', async () => {
+    const kv = new InMemoryKvStore();
+    expect(await kv.get('nope')).toBeNull();
+  });
+
+  it('deletes a key', async () => {
+    const kv = new InMemoryKvStore();
+    await kv.set('k', 'v');
+    await kv.del('k');
+    expect(await kv.get('k')).toBeNull();
+  });
+
+  it('expires a value after its TTL', async () => {
+    vi.useFakeTimers();
+    const kv = new InMemoryKvStore();
+    await kv.set('k', 'v', 10);
+
+    vi.advanceTimersByTime(9_000);
+    expect(await kv.get('k')).toBe('v');
+
+    vi.advanceTimersByTime(2_000);
+    expect(await kv.get('k')).toBeNull();
+  });
+
+  it('increments a counter from zero', async () => {
+    const kv = new InMemoryKvStore();
+    expect(await kv.increment('c', 60)).toBe(1);
+    expect(await kv.increment('c', 60)).toBe(2);
+    expect(await kv.get('c')).toBe('2');
+  });
+
+  it('keeps the original TTL across increments (fixed window)', async () => {
+    vi.useFakeTimers();
+    const kv = new InMemoryKvStore();
+
+    await kv.increment('c', 10); // window opens, expires at t+10s
+    vi.advanceTimersByTime(6_000);
+    expect(await kv.increment('c', 10)).toBe(2); // does NOT extend the window
+
+    vi.advanceTimersByTime(5_000); // now past the original 10s
+    expect(await kv.get('c')).toBeNull();
+    // A fresh increment starts a new window at 1.
+    expect(await kv.increment('c', 10)).toBe(1);
+  });
+
+  it('reports ready and clears on close', async () => {
+    const kv = new InMemoryKvStore();
+    expect(await kv.ping()).toBe(true);
+    await kv.set('k', 'v');
+    await kv.close();
+    expect(await kv.get('k')).toBeNull();
+  });
+});

--- a/services/api/vitest.config.ts
+++ b/services/api/vitest.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
       // The entrypoint, *.pg.ts repositories, and db scripts run only against
       // real infrastructure — the e2e suite covers those. The unit gate applies
       // to the logic layer (services + in-memory repos).
-      exclude: ['src/server.ts', 'src/db/**', 'src/**/*.pg.ts'],
+      exclude: ['src/server.ts', 'src/db/**', 'src/**/*.pg.ts', 'src/**/*.redis.ts'],
       thresholds: {
         lines: 80,
         functions: 80,


### PR DESCRIPTION
## What
Adds a **`KvStore`** abstraction — the Redis foundation for rate limiting (#23), idempotency keys, and caching — following the same pattern as our repositories: in-memory by default (zero infra), Redis when `REDIS_URL` is set.

- **`kv/kv.store.ts`** — `KvStore` interface + **`InMemoryKvStore`** (lazy TTL expiry; `increment` uses fixed-window semantics — TTL set once, doesn't slide). 100% unit-tested.
- **`kv/kv.store.redis.ts`** — **`RedisKvStore`** (ioredis). Excluded from unit coverage like the `*.pg.ts` adapters; validated by real infra (CI service container + e2e land with #23).
- **`env`** — `REDIS_URL` (optional). Selected at startup in `server.ts`.
- **Readiness** — `/readyz` now pings the KV store too (`InMemoryKvStore.ping()` is always true; `RedisKvStore.ping()` checks the connection). Closed cleanly on shutdown.
- `.env.example` documents `REDIS_URL=redis://localhost:6379` (already in our docker-compose).

## Interface
```ts
get(key): Promise<string | null>
set(key, value, ttlSeconds?): Promise<void>
del(key): Promise<void>
increment(key, ttlSeconds): Promise<number>   // atomic counter (rate limiting)
ping(): Promise<boolean>                       // readiness
close(): Promise<void>
```

## Cost / ops note
**Nothing to pay or set up to merge this** — no `REDIS_URL` ⇒ in-memory (dev/tests/CI). A real Redis is only needed once we flip on rate limiting in staging, and the free tier (Render Key Value / Upstash) covers the pilot. Redis here holds only ephemeral data (counters, idempotency, cache) — sessions/refresh tokens live in Postgres — so the no-persistence free tier is safe.

## Verification
- `pnpm check` green; **40 tests, 100% coverage** (incl. `kv.store.ts` TTL + fixed-window increment).
- Live boot without `REDIS_URL`: `/healthz` ok, `/readyz` ready, logs "Using in-memory KV store".

## Acceptance ([#22](https://github.com/TROTXI/mobility-core/issues/22))
- [x] `REDIS_URL` env; client + health (`/readyz` ping)
- [x] cache/KV helper, unit-tested (in-memory) + a Redis path
- [x] in-memory fallback when unset

Closes #22