### PR TITLE
fix(deploy): force TLS for migrate-on-deploy (DATABASE_SSL)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,9 +44,10 @@ jobs:
       - name: Run DB migrations
         env:
           DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
+          DATABASE_SSL: 'true' # external connection from CI requires TLS
         run: |
           if [ -z "$DATABASE_URL" ]; then
-            echo "::error::STAGING_DATABASE_URL is not set. Add it as a repo secret: the staging DB's EXTERNAL connection string with ?sslmode=no-verify appended (see docs/DEPLOY.md)."
+            echo "::error::STAGING_DATABASE_URL is not set. Add it as a repo secret: the staging DB's EXTERNAL connection string (see docs/DEPLOY.md)."
             exit 1
           fi
           pnpm --filter @trotxi/api run migrate
@@ -88,9 +89,10 @@ jobs:
       - name: Run DB migrations
         env:
           DATABASE_URL: ${{ secrets.PRODUCTION_DATABASE_URL }}
+          DATABASE_SSL: 'true' # external connection from CI requires TLS
         run: |
           if [ -z "$DATABASE_URL" ]; then
-            echo "::error::PRODUCTION_DATABASE_URL is not set. Add it as a repo secret: the production DB's EXTERNAL connection string with ?sslmode=no-verify appended (see docs/DEPLOY.md)."
+            echo "::error::PRODUCTION_DATABASE_URL is not set. Add it as a repo secret: the production DB's EXTERNAL connection string (see docs/DEPLOY.md)."
             exit 1
           fi
           pnpm --filter @trotxi/api run migrate

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -47,14 +47,16 @@ new code ships.
    `JWT_SECRET` = `openssl rand -base64 48`. (Declared `sync: false` in
    `render.yaml`; the value is entered here, never committed.)
 5. **`STAGING_DATABASE_URL`** (required for migrate-on-deploy). Render → DB →
-   **Connections** → copy the **External** connection string, append
-   `?sslmode=no-verify`, then:
+   **Connections** → copy the **External Database URL** (hostname ends in
+   `…frankfurt-postgres.render.com` — _not_ the Internal one, which only resolves
+   inside Render). Paste it interactively so the shell doesn't mangle the
+   password:
    ```bash
-   gh secret set STAGING_DATABASE_URL -R TROTXI/mobility-core \
-     --body "postgres://USER:PASS@HOST.frankfurt-postgres.render.com/DB?sslmode=no-verify"
+   gh secret set STAGING_DATABASE_URL -R TROTXI/mobility-core   # then paste at the prompt
    ```
-   (External + SSL because migrations run from CI, outside Render's network.
-   `no-verify` keeps the connection encrypted without needing Render's CA cert.)
+   It must be the **External** URL because migrations run from CI, outside
+   Render's network. TLS is handled by the workflow (`DATABASE_SSL=true`), so no
+   `sslmode` suffix is needed.
 6. Done — the next merge to main migrates + deploys staging automatically. The
    GitHub environments `staging` and `production` already exist; production
    requires approval before its job runs (and its own `PRODUCTION_DATABASE_URL`

--- a/services/api/src/db/migrate.ts
+++ b/services/api/src/db/migrate.ts
@@ -19,7 +19,12 @@ async function migrate(): Promise<void> {
     throw new Error('DATABASE_URL is required to run migrations');
   }
 
-  const pool = new Pool({ connectionString });
+  // Deploy-time migrations connect to the managed DB over the public network,
+  // which requires TLS. Render's server cert isn't in Node's default CA bundle,
+  // so we encrypt without verifying the chain. Local/CI runs against an internal
+  // or container DB leave DATABASE_SSL unset and connect without TLS.
+  const ssl = process.env['DATABASE_SSL'] === 'true' ? { rejectUnauthorized: false } : undefined;
+  const pool = new Pool({ connectionString, ssl });
   try {
     await pool.query(
       `CREATE TABLE IF NOT EXISTS _migrations (


### PR DESCRIPTION
## What
The first real migrate-on-deploy run failed with **`SSL/TLS required`** — Render requires TLS for external DB connections, and relying on a `?sslmode=` suffix in the secret URL proved error-prone (we hit both a wrong-host and a missing-SSL failure).

This makes TLS deterministic: the migrate runner enables TLS (`rejectUnauthorized: false` — encrypt without verifying Render's non-public CA) when **`DATABASE_SSL=true`**, which the deploy workflow now sets for the staging and production migrate steps. Local dev and CI (internal/container DB) leave it unset and connect without TLS, unchanged.

Bonus: the `STAGING_DATABASE_URL` secret is now just the plain **external** URL — no `sslmode` suffix to get wrong.

## Changes
- `services/api/src/db/migrate.ts` — `ssl` from `DATABASE_SSL`.
- `.github/workflows/deploy.yml` — `DATABASE_SSL: 'true'` on both migrate steps.
- `docs/DEPLOY.md` — external-URL + interactive-paste instructions; SSL handled by the workflow.

Follow-up to #29. No app/runtime behavior change (server still connects to the internal DB without TLS).