### PR TITLE
feat(api): rate limiting on sensitive endpoints (#23)

### DIFF
--- a/services/api/.env.example
+++ b/services/api/.env.example
@@ -18,3 +18,7 @@ NODE_ENV=development
 # JWT_ACCESS_TTL=15m
 # JWT_ISSUER=trotxi
 # JWT_AUDIENCE=trotxi-api
+
+# Rate limiting (fixed window) — defaults shown.
+# RATE_LIMIT_MAX=100
+# RATE_LIMIT_WINDOW_SECONDS=60

--- a/services/api/src/app.ts
+++ b/services/api/src/app.ts
@@ -1,10 +1,15 @@
 import fastifySwagger from '@fastify/swagger';
 import fastifySwaggerUi from '@fastify/swagger-ui';
 import Fastify, { type FastifyInstance } from 'fastify';
+import { InMemoryKvStore, type KvStore } from './kv/kv.store';
 import { authPlugin } from './modules/auth/auth.plugin';
 import { authRoutes } from './modules/auth/auth.routes';
-import type { KvStore } from './kv/kv.store';
 import { DEV_AUTH_CONFIG, type AuthConfig } from './modules/auth/jwt';
+import {
+  DEFAULT_RATE_LIMIT,
+  rateLimitPlugin,
+  type RateLimitConfig,
+} from './modules/ratelimit/ratelimit.plugin';
 import type { UserRepository } from './modules/users/user.repository';
 
 /**
@@ -21,6 +26,8 @@ export interface AppDeps {
   kv?: KvStore;
   /** JWT/auth settings. Defaults to a dev-only config when unset (tests, local). */
   auth?: AuthConfig;
+  /** Rate-limit thresholds (from env). Defaults applied when unset. */
+  rateLimit?: RateLimitConfig;
   logger?: boolean;
 }
 
@@ -41,9 +48,14 @@ export async function buildApp(deps: AppDeps = {}): Promise<FastifyInstance> {
   });
   await app.register(fastifySwaggerUi, { routePrefix: '/docs' });
 
-  // Auth guard first (decorators on the root instance), then routes that use it.
+  // Guards first (decorators on the root instance), then routes that use them.
+  const kv = deps.kv ?? new InMemoryKvStore();
   await app.register(authPlugin, { config: deps.auth ?? DEV_AUTH_CONFIG });
-  await app.register(authRoutes, { users: deps.users });
+  await app.register(rateLimitPlugin, { kv });
+  await app.register(authRoutes, {
+    users: deps.users,
+    rateLimit: deps.rateLimit ?? DEFAULT_RATE_LIMIT,
+  });
 
   app.get('/', async () => ({
     service: 'trotxi-api',

--- a/services/api/src/config/env.ts
+++ b/services/api/src/config/env.ts
@@ -15,6 +15,9 @@ const envSchema = z
     JWT_ACCESS_TTL: z.string().default('15m'),
     JWT_ISSUER: z.string().default('trotxi'),
     JWT_AUDIENCE: z.string().default('trotxi-api'),
+    // Rate limiting (fixed window). Tunable without a code change.
+    RATE_LIMIT_MAX: z.coerce.number().int().positive().default(100),
+    RATE_LIMIT_WINDOW_SECONDS: z.coerce.number().int().positive().default(60),
   })
   .superRefine((env, ctx) => {
     if (env.NODE_ENV === 'production' && !env.JWT_SECRET) {

--- a/services/api/src/modules/auth/auth.routes.ts
+++ b/services/api/src/modules/auth/auth.routes.ts
@@ -3,19 +3,25 @@
 // in Slice 2. Registered after authPlugin so `app.authenticate` is available.
 
 import type { FastifyInstance } from 'fastify';
+import type { RateLimitConfig } from '../ratelimit/ratelimit.plugin';
 import type { UserRepository } from '../users/user.repository';
 
 export async function authRoutes(
   app: FastifyInstance,
-  opts: { users?: UserRepository },
+  opts: { users?: UserRepository; rateLimit: RateLimitConfig },
 ): Promise<void> {
-  app.get('/me', { preHandler: app.authenticate }, async (request, reply) => {
-    // `authenticate` guarantees request.user is set before we reach here.
-    const principal = request.user!;
-    const user = opts.users ? await opts.users.findById(principal.id) : null;
-    if (!user) {
-      return reply.code(404).send({ error: 'not_found', message: 'User not found' });
-    }
-    return user;
-  });
+  // Authenticate first (sets request.user), then rate-limit per user.
+  app.get(
+    '/me',
+    { preHandler: [app.authenticate, app.rateLimit({ ...opts.rateLimit, by: 'user' })] },
+    async (request, reply) => {
+      // `authenticate` guarantees request.user is set before we reach here.
+      const principal = request.user!;
+      const user = opts.users ? await opts.users.findById(principal.id) : null;
+      if (!user) {
+        return reply.code(404).send({ error: 'not_found', message: 'User not found' });
+      }
+      return user;
+    },
+  );
 }

--- a/services/api/src/modules/ratelimit/ratelimit.plugin.ts
+++ b/services/api/src/modules/ratelimit/ratelimit.plugin.ts
@@ -1,0 +1,63 @@
+// Rate limiting. Decorates the app with `rateLimit(opts)` — a preHandler factory
+// backed by the KV store (Redis in prod, in-memory in dev/tests). Fixed-window
+// counting via KvStore.increment. Routes opt in:
+//   preHandler: [app.rateLimit({ max, windowSeconds })]                 // by IP
+//   preHandler: [app.authenticate, app.rateLimit({ ..., by: 'user' })]  // by user
+// Sign-in/refresh (slice 2) and sensitive writes use the strict per-IP variant.
+
+import type { FastifyReply, FastifyRequest, preHandlerHookHandler } from 'fastify';
+import fp from 'fastify-plugin';
+import type { KvStore } from '../../kv/kv.store';
+
+export interface RateLimitConfig {
+  max: number;
+  windowSeconds: number;
+}
+
+export interface RateLimitOptions extends RateLimitConfig {
+  /** Bucket by client IP (default) or by authenticated user id. */
+  by?: 'ip' | 'user';
+}
+
+/** Default thresholds; overridden per route and from env (config/env.ts). */
+export const DEFAULT_RATE_LIMIT: RateLimitConfig = { max: 100, windowSeconds: 60 };
+
+declare module 'fastify' {
+  interface FastifyInstance {
+    rateLimit: (options: RateLimitOptions) => preHandlerHookHandler;
+  }
+}
+
+export const rateLimitPlugin = fp<{ kv: KvStore }>(async (app, opts) => {
+  const { kv } = opts;
+
+  app.decorate('rateLimit', (options: RateLimitOptions): preHandlerHookHandler => {
+    const by = options.by ?? 'ip';
+
+    return async function (request: FastifyRequest, reply: FastifyReply) {
+      // Per-user limits assume `authenticate` ran first; fall back to IP if no
+      // principal so the limit is never silently skipped.
+      const subject = by === 'user' ? (request.user?.id ?? request.ip) : request.ip;
+      const key = `ratelimit:${request.routeOptions.url}:${by}:${subject}`;
+
+      let count: number;
+      try {
+        count = await kv.increment(key, options.windowSeconds);
+      } catch (err) {
+        // Fail open: a KV/Redis outage must not take the API down.
+        request.log.warn({ err }, 'rate limit check failed; allowing request');
+        return;
+      }
+
+      reply.header('X-RateLimit-Limit', String(options.max));
+      reply.header('X-RateLimit-Remaining', String(Math.max(0, options.max - count)));
+
+      if (count > options.max) {
+        reply.header('Retry-After', String(options.windowSeconds));
+        return reply
+          .code(429)
+          .send({ error: 'rate_limited', message: 'Too many requests. Try again later.' });
+      }
+    };
+  });
+});

--- a/services/api/src/server.ts
+++ b/services/api/src/server.ts
@@ -6,6 +6,7 @@ import { createPool } from './db/pool';
 import { InMemoryKvStore, type KvStore } from './kv/kv.store';
 import { RedisKvStore } from './kv/kv.store.redis';
 import { DEV_AUTH_CONFIG, type AuthConfig } from './modules/auth/jwt';
+import type { RateLimitConfig } from './modules/ratelimit/ratelimit.plugin';
 import { InMemoryUserRepository, type UserRepository } from './modules/users/user.repository';
 import { PgUserRepository } from './modules/users/user.repository.pg';
 
@@ -55,7 +56,12 @@ async function main(): Promise<void> {
     return kv.ping();
   };
 
-  const app = await buildApp({ users, kv, isReady, auth, logger: true });
+  const rateLimit: RateLimitConfig = {
+    max: env.RATE_LIMIT_MAX,
+    windowSeconds: env.RATE_LIMIT_WINDOW_SECONDS,
+  };
+
+  const app = await buildApp({ users, kv, isReady, auth, rateLimit, logger: true });
 
   const shutdown = async (signal: string): Promise<void> => {
     app.log.info(`Received ${signal}, shutting down`);

--- a/services/api/tests/env.test.ts
+++ b/services/api/tests/env.test.ts
@@ -1,21 +1,29 @@
 import { describe, expect, it } from 'vitest';
 import { loadEnv } from '../src/config/env';
 
-const JWT_DEFAULTS = {
+const DEFAULTS = {
   JWT_ACCESS_TTL: '15m',
   JWT_ISSUER: 'trotxi',
   JWT_AUDIENCE: 'trotxi-api',
+  RATE_LIMIT_MAX: 100,
+  RATE_LIMIT_WINDOW_SECONDS: 60,
 };
 
 describe('loadEnv', () => {
   it('applies defaults for an empty environment', () => {
     const env = loadEnv({});
-    expect(env).toEqual({ NODE_ENV: 'development', PORT: 3000, HOST: '0.0.0.0', ...JWT_DEFAULTS });
+    expect(env).toEqual({ NODE_ENV: 'development', PORT: 3000, HOST: '0.0.0.0', ...DEFAULTS });
   });
 
   it('parses provided values', () => {
     const env = loadEnv({ NODE_ENV: 'test', PORT: '3100', HOST: '127.0.0.1' });
-    expect(env).toEqual({ NODE_ENV: 'test', PORT: 3100, HOST: '127.0.0.1', ...JWT_DEFAULTS });
+    expect(env).toEqual({ NODE_ENV: 'test', PORT: 3100, HOST: '127.0.0.1', ...DEFAULTS });
+  });
+
+  it('parses configurable rate-limit thresholds', () => {
+    const env = loadEnv({ RATE_LIMIT_MAX: '5', RATE_LIMIT_WINDOW_SECONDS: '30' });
+    expect(env.RATE_LIMIT_MAX).toBe(5);
+    expect(env.RATE_LIMIT_WINDOW_SECONDS).toBe(30);
   });
 
   it('rejects invalid values with a readable message', () => {

--- a/services/api/tests/ratelimit.test.ts
+++ b/services/api/tests/ratelimit.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+import { buildApp } from '../src/app';
+import type { KvStore } from '../src/kv/kv.store';
+import { createJwtService, type AuthConfig } from '../src/modules/auth/jwt';
+
+const auth: AuthConfig = {
+  secret: 'test-secret-at-least-32-characters-long-0000',
+  accessTtl: '15m',
+  issuer: 'trotxi',
+  audience: 'trotxi-api',
+};
+const jwt = createJwtService(auth);
+const bearer = (token: string) => ({ authorization: `Bearer ${token}` });
+
+describe('rateLimit (per IP)', () => {
+  it('allows up to the limit, then returns 429 with Retry-After', async () => {
+    const app = await buildApp({ auth });
+    await app.register(async (i) => {
+      i.get('/limited', { preHandler: [i.rateLimit({ max: 2, windowSeconds: 60 })] }, async () => ({
+        ok: true,
+      }));
+    });
+
+    const r1 = await app.inject({ method: 'GET', url: '/limited' });
+    const r2 = await app.inject({ method: 'GET', url: '/limited' });
+    const r3 = await app.inject({ method: 'GET', url: '/limited' });
+
+    expect([r1.statusCode, r2.statusCode, r3.statusCode]).toEqual([200, 200, 429]);
+    expect(r1.headers['x-ratelimit-limit']).toBe('2');
+    expect(r1.headers['x-ratelimit-remaining']).toBe('1');
+    expect(r3.headers['x-ratelimit-remaining']).toBe('0');
+    expect(r3.headers['retry-after']).toBe('60');
+    expect(r3.json()).toMatchObject({ error: 'rate_limited' });
+  });
+
+  it('buckets each client IP independently', async () => {
+    const app = await buildApp({ auth });
+    await app.register(async (i) => {
+      i.get('/limited', { preHandler: [i.rateLimit({ max: 1, windowSeconds: 60 })] }, async () => ({
+        ok: true,
+      }));
+    });
+
+    const a1 = await app.inject({ method: 'GET', url: '/limited', remoteAddress: '1.1.1.1' });
+    const a2 = await app.inject({ method: 'GET', url: '/limited', remoteAddress: '1.1.1.1' });
+    const b1 = await app.inject({ method: 'GET', url: '/limited', remoteAddress: '2.2.2.2' });
+
+    expect([a1.statusCode, a2.statusCode, b1.statusCode]).toEqual([200, 429, 200]);
+  });
+});
+
+describe('rateLimit (per user)', () => {
+  it('buckets each authenticated user independently', async () => {
+    const app = await buildApp({ auth });
+    await app.register(async (i) => {
+      i.get(
+        '/u',
+        { preHandler: [i.authenticate, i.rateLimit({ max: 1, windowSeconds: 60, by: 'user' })] },
+        async () => ({ ok: true }),
+      );
+    });
+    const tokenA = await jwt.signAccessToken({ userId: 'userA', role: 'commuter' });
+    const tokenB = await jwt.signAccessToken({ userId: 'userB', role: 'commuter' });
+
+    const a1 = await app.inject({ method: 'GET', url: '/u', headers: bearer(tokenA) });
+    const a2 = await app.inject({ method: 'GET', url: '/u', headers: bearer(tokenA) });
+    const b1 = await app.inject({ method: 'GET', url: '/u', headers: bearer(tokenB) });
+
+    expect([a1.statusCode, a2.statusCode, b1.statusCode]).toEqual([200, 429, 200]);
+  });
+
+  it('falls back to IP when there is no authenticated user', async () => {
+    const app = await buildApp({ auth });
+    await app.register(async (i) => {
+      // by: 'user' but no authenticate in front — must not silently skip.
+      i.get(
+        '/uf',
+        { preHandler: [i.rateLimit({ max: 5, windowSeconds: 60, by: 'user' })] },
+        async () => ({
+          ok: true,
+        }),
+      );
+    });
+
+    const res = await app.inject({ method: 'GET', url: '/uf' });
+    expect(res.statusCode).toBe(200);
+  });
+});
+
+describe('rateLimit (resilience)', () => {
+  it('fails open when the KV store errors', async () => {
+    const brokenKv: KvStore = {
+      get: async () => null,
+      set: async () => {},
+      del: async () => {},
+      increment: async () => {
+        throw new Error('kv down');
+      },
+      ping: async () => false,
+      close: async () => {},
+    };
+    const app = await buildApp({ auth, kv: brokenKv });
+    await app.register(async (i) => {
+      i.get('/f', { preHandler: [i.rateLimit({ max: 1, windowSeconds: 60 })] }, async () => ({
+        ok: true,
+      }));
+    });
+
+    const r1 = await app.inject({ method: 'GET', url: '/f' });
+    const r2 = await app.inject({ method: 'GET', url: '/f' });
+    expect([r1.statusCode, r2.statusCode]).toEqual([200, 200]);
+  });
+});


### PR DESCRIPTION
## What
Redis-backed **fixed-window rate limiting**, built on the `KvStore` from #22. Adds `app.rateLimit(opts)` — a preHandler factory routes opt into:

```ts
preHandler: [app.rateLimit({ max, windowSeconds })]                  // by IP
preHandler: [app.authenticate, app.rateLimit({ ..., by: 'user' })]   // by user
```

- **Per-IP and per-user** buckets (per the issue). Per-user falls back to IP if no principal, so the limit is never silently skipped.
- **429** with `Retry-After` + `X-RateLimit-Limit` / `X-RateLimit-Remaining` headers.
- **Fails open** — a Redis/KV outage logs a warning and allows the request (availability over strictness; a cache outage shouldn't take down the API).
- **Configurable thresholds** via env: `RATE_LIMIT_MAX` (100), `RATE_LIMIT_WINDOW_SECONDS` (60).
- Applied **per-user to `GET /me`**. Sign-in/refresh (slice 2) and sensitive writes (Foyade's admin/ops endpoints) use the strict per-IP variant — the seam is ready.

## Why fixed-window / fail-open
Fixed window via `KvStore.increment` (TTL set once, doesn't slide) is simple and correct for abuse protection. Fail-open is the standard choice for a rate limiter sitting in front of real traffic — we don't want a Redis hiccup to 500 every request.

## Verification
- `pnpm check` green; **46 tests, 100% coverage** (incl. `ratelimit.plugin.ts`): over-limit 429 + headers, per-IP isolation, per-user isolation, no-user→IP fallback, and KV-error fail-open.
- Live boot: server starts with the limiter wired; `/healthz` ok, `/me` 401 without a token.

## Cost note
Uses the KV abstraction — **in-memory in dev/tests/CI, Redis in prod**. No account needed to merge; the free Redis tier covers the pilot when we flip `REDIS_URL` on in staging.

## Acceptance ([#23](https://github.com/TROTXI/mobility-core/issues/23))
- [x] Redis-backed limits on sensitive endpoints, per-IP + per-user
- [x] 429 + `Retry-After`
- [x] thresholds in config
- [x] enforced + tested

Closes #23