### PR TITLE
feat(api): typed OpenAPI contract via zod (ADR-0008)

### DIFF
--- a/docs/adr/0008-zod-openapi-contract.md
+++ b/docs/adr/0008-zod-openapi-contract.md
@@ -1,0 +1,70 @@
+# ADR-0008 — zod as the single source for validation & OpenAPI
+
+**Status:** accepted · **Date:** 2026-06-25
+
+## Context
+
+The API already serves Swagger UI (`/docs`) and an OpenAPI document (`/docs/json`)
+via `@fastify/swagger`, but routes carried no schemas — so the spec documented
+nothing useful (no request/response shapes, no auth, no error bodies) and nothing
+validated request input. We need a real, machine-readable contract: it is what
+the Flutter apps build their client against, and it is the reference the backend
+and frontend share.
+
+ADR-0003 already committed us to **zod for runtime validation at the boundaries**
+and "one type system across the wire." We did not want to hand-write JSON Schema
+_and_ zod _and_ TypeScript types for every route — three copies that drift.
+
+## Decision
+
+**Each route declares one zod schema; it drives validation, response
+serialization, TypeScript inference, and the OpenAPI spec.**
+
+- **`fastify-type-provider-zod`** wires zod into Fastify: `validatorCompiler` +
+  `serializerCompiler` are set on the app, and routes are defined through
+  `app.withTypeProvider<ZodTypeProvider>()`. `jsonSchemaTransform` renders each
+  zod schema into the OpenAPI document.
+  - Pinned to the **v4 line** (peer `zod@^3`). v7 requires zod 4; bumping zod to
+    a new major just for docs isn't worth the churn. Revisit when we move to zod 4.
+- **Bearer (JWT) security scheme** is declared once (`components.securitySchemes.
+bearerAuth`); protected routes opt in with `security: [{ bearerAuth: [] }]`
+  (see ADR-0007). Public routes declare nothing.
+- **Tags** group endpoints (`system`, `auth`, …) for a navigable spec.
+- **Shared schemas** live next to their domain and are reused: `errorResponseSchema`
+  (`lib/schemas.ts`) for error bodies, `userResponseSchema` (`modules/users/
+user.schema.ts`) for user output. `GET /me` is the worked example.
+
+### The convention (what every new route does)
+
+```ts
+app.withTypeProvider<ZodTypeProvider>().post(
+  '/things',
+  {
+    schema: {
+      tags: ['things'],
+      summary: 'Create a thing',
+      security: [{ bearerAuth: [] }], // omit for public routes
+      body: z.object({ name: z.string().min(1) }),
+      response: { 201: thingSchema, 400: errorResponseSchema },
+    },
+    preHandler: [app.authenticate],
+  },
+  handler,
+);
+```
+
+## Consequences
+
+- **Input is validated for free** — a `body`/`querystring`/`params` zod schema
+  rejects bad requests (400) before the handler runs. Declare them on every route
+  that takes input.
+- **Responses are serialized against their schema.** A handler that returns data
+  not matching the declared `response` schema fails loudly — keep response schemas
+  honest. `Date` fields use `z.date()` (serialized to ISO date-time strings).
+- **The spec is the contract.** The frontend can generate its client from
+  `/docs/json` (e.g. `curl <staging>/docs/json`), so route schemas must stay
+  accurate — they are not just documentation.
+- Routes without schemas still work but are undocumented and unvalidated; in
+  review we expect schemas on anything taking input or returning a body.
+- Migrating to **zod 4** later means bumping `fastify-type-provider-zod` to v7+;
+  that would supersede the version note here.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       fastify-plugin:
         specifier: ^6.0.0
         version: 6.0.0
+      fastify-type-provider-zod:
+        specifier: ^4.0.2
+        version: 4.0.2(fastify@5.8.5)(zod@3.25.76)
       ioredis:
         specifier: ^5.11.1
         version: 5.11.1
@@ -1266,6 +1269,12 @@ packages:
   fastify-plugin@6.0.0:
     resolution: {integrity: sha512-fZOty7z3O7vOliF6d8bHE3wiEh1KcNnKEQensSgTk9C1DvN6nRLS++XVd86v33Hw/8u9Un8A1zDrQ8ujcQDHEg==}
 
+  fastify-type-provider-zod@4.0.2:
+    resolution: {integrity: sha512-FDRzSL3ZuoZ+4YDevR1YOinmDKkxOdy3QB9dDR845sK+bQvDroPKhHAXLEAOObDxL7SMA0OZN/A4osrNBTdDTQ==}
+    peerDependencies:
+      fastify: ^5.0.0
+      zod: ^3.14.2
+
   fastify@5.8.5:
     resolution: {integrity: sha512-Yqptv59pQzPgQUSIm87hMqHJmdkb1+GPxdE6vW6FRyVE9G86mt7rOghitiU4JHRaTyDUk9pfeKmDeu70lAwM4Q==}
 
@@ -2174,6 +2183,11 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -3195,6 +3209,13 @@ snapshots:
 
   fastify-plugin@6.0.0: {}
 
+  fastify-type-provider-zod@4.0.2(fastify@5.8.5)(zod@3.25.76):
+    dependencies:
+      '@fastify/error': 4.2.0
+      fastify: 5.8.5
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+
   fastify@5.8.5:
     dependencies:
       '@fastify/ajv-compiler': 4.0.5
@@ -4074,5 +4095,9 @@ snapshots:
   yaml@2.9.0: {}
 
   yocto-queue@0.1.0: {}
+
+  zod-to-json-schema@3.25.2(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
 
   zod@3.25.76: {}

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -23,6 +23,7 @@
     "@fastify/swagger-ui": "^6.0.0",
     "fastify": "^5.2.0",
     "fastify-plugin": "^6.0.0",
+    "fastify-type-provider-zod": "^4.0.2",
     "ioredis": "^5.11.1",
     "jose": "^6.2.3",
     "pg": "^8.13.1",

--- a/services/api/src/app.ts
+++ b/services/api/src/app.ts
@@ -1,6 +1,13 @@
 import fastifySwagger from '@fastify/swagger';
 import fastifySwaggerUi from '@fastify/swagger-ui';
 import Fastify, { type FastifyInstance } from 'fastify';
+import {
+  jsonSchemaTransform,
+  serializerCompiler,
+  validatorCompiler,
+  type ZodTypeProvider,
+} from 'fastify-type-provider-zod';
+import { z } from 'zod';
 import { InMemoryKvStore, type KvStore } from './kv/kv.store';
 import { authPlugin } from './modules/auth/auth.plugin';
 import { authRoutes } from './modules/auth/auth.routes';
@@ -33,6 +40,14 @@ export interface AppDeps {
 
 export async function buildApp(deps: AppDeps = {}): Promise<FastifyInstance> {
   const app = Fastify({ logger: deps.logger ?? false });
+
+  // zod is the single source for validation AND the OpenAPI spec (ADR-0008):
+  // route schemas are zod, compiled here and rendered into the docs by
+  // jsonSchemaTransform below. `r` is the zod-typed view used to define routes.
+  app.setValidatorCompiler(validatorCompiler);
+  app.setSerializerCompiler(serializerCompiler);
+  const r = app.withTypeProvider<ZodTypeProvider>();
+
   const isReady = deps.isReady ?? (async () => true);
 
   // OpenAPI docs. Registered before the routes so every route is captured and
@@ -44,7 +59,19 @@ export async function buildApp(deps: AppDeps = {}): Promise<FastifyInstance> {
         description: 'Transactional API — auth, subscriptions, tokens, mobility.',
         version: '0.1.0',
       },
+      tags: [
+        { name: 'system', description: 'Health, readiness, and service metadata' },
+        { name: 'auth', description: 'Authentication and the current user' },
+      ],
+      components: {
+        // Protected routes set `security: [{ bearerAuth: [] }]`; clients send
+        // `Authorization: Bearer <access token>` (see ADR-0007).
+        securitySchemes: {
+          bearerAuth: { type: 'http', scheme: 'bearer', bearerFormat: 'JWT' },
+        },
+      },
     },
+    transform: jsonSchemaTransform,
   });
   await app.register(fastifySwaggerUi, { routePrefix: '/docs' });
 
@@ -57,26 +84,74 @@ export async function buildApp(deps: AppDeps = {}): Promise<FastifyInstance> {
     rateLimit: deps.rateLimit ?? DEFAULT_RATE_LIMIT,
   });
 
-  app.get('/', async () => ({
-    service: 'trotxi-api',
-    version: '0.1.0',
-    docs: '/docs',
-    health: '/healthz',
-  }));
-  app.get('/version', async () => ({
-    name: 'trotxi-api',
-    version: '0.1.0',
-    commit: process.env['GIT_SHA'] ?? 'dev',
-  }));
+  r.get(
+    '/',
+    {
+      schema: {
+        tags: ['system'],
+        summary: 'Service metadata and useful links',
+        response: {
+          200: z.object({
+            service: z.string(),
+            version: z.string(),
+            docs: z.string(),
+            health: z.string(),
+          }),
+        },
+      },
+    },
+    async () => ({ service: 'trotxi-api', version: '0.1.0', docs: '/docs', health: '/healthz' }),
+  );
 
-  app.get('/healthz', async () => ({ status: 'ok' }));
+  r.get(
+    '/version',
+    {
+      schema: {
+        tags: ['system'],
+        summary: 'Build version and commit',
+        response: {
+          200: z.object({ name: z.string(), version: z.string(), commit: z.string() }),
+        },
+      },
+    },
+    async () => ({
+      name: 'trotxi-api',
+      version: '0.1.0',
+      commit: process.env['GIT_SHA'] ?? 'dev',
+    }),
+  );
 
-  app.get('/readyz', async (_request, reply) => {
-    if (await isReady()) {
-      return { status: 'ready' };
-    }
-    return reply.code(503).send({ status: 'not_ready' });
-  });
+  r.get(
+    '/healthz',
+    {
+      schema: {
+        tags: ['system'],
+        summary: 'Liveness probe',
+        response: { 200: z.object({ status: z.literal('ok') }) },
+      },
+    },
+    async () => ({ status: 'ok' as const }),
+  );
+
+  r.get(
+    '/readyz',
+    {
+      schema: {
+        tags: ['system'],
+        summary: 'Readiness probe (pings backing services)',
+        response: {
+          200: z.object({ status: z.literal('ready') }),
+          503: z.object({ status: z.literal('not_ready') }),
+        },
+      },
+    },
+    async (_request, reply) => {
+      if (await isReady()) {
+        return { status: 'ready' as const };
+      }
+      return reply.code(503).send({ status: 'not_ready' as const });
+    },
+  );
 
   return app;
 }

--- a/services/api/src/lib/schemas.ts
+++ b/services/api/src/lib/schemas.ts
@@ -1,0 +1,10 @@
+// Shared response schemas reused across routes (and rendered into the OpenAPI
+// spec via the zod type provider — see ADR-0008).
+
+import { z } from 'zod';
+
+/** Standard error body: a stable machine code plus a human-readable message. */
+export const errorResponseSchema = z.object({
+  error: z.string(),
+  message: z.string(),
+});

--- a/services/api/src/modules/auth/auth.routes.ts
+++ b/services/api/src/modules/auth/auth.routes.ts
@@ -3,7 +3,10 @@
 // in Slice 2. Registered after authPlugin so `app.authenticate` is available.
 
 import type { FastifyInstance } from 'fastify';
+import type { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { errorResponseSchema } from '../../lib/schemas';
 import type { RateLimitConfig } from '../ratelimit/ratelimit.plugin';
+import { userResponseSchema } from '../users/user.schema';
 import type { UserRepository } from '../users/user.repository';
 
 export async function authRoutes(
@@ -11,9 +14,22 @@ export async function authRoutes(
   opts: { users?: UserRepository; rateLimit: RateLimitConfig },
 ): Promise<void> {
   // Authenticate first (sets request.user), then rate-limit per user.
-  app.get(
+  app.withTypeProvider<ZodTypeProvider>().get(
     '/me',
-    { preHandler: [app.authenticate, app.rateLimit({ ...opts.rateLimit, by: 'user' })] },
+    {
+      schema: {
+        tags: ['auth'],
+        summary: 'Get the currently authenticated user',
+        security: [{ bearerAuth: [] }],
+        response: {
+          200: userResponseSchema,
+          401: errorResponseSchema,
+          404: errorResponseSchema,
+          429: errorResponseSchema,
+        },
+      },
+      preHandler: [app.authenticate, app.rateLimit({ ...opts.rateLimit, by: 'user' })],
+    },
     async (request, reply) => {
       // `authenticate` guarantees request.user is set before we reach here.
       const principal = request.user!;

--- a/services/api/src/modules/users/user.schema.ts
+++ b/services/api/src/modules/users/user.schema.ts
@@ -1,0 +1,14 @@
+// Public (response) representation of a user. Drives both OpenAPI docs and
+// response serialization via the zod type provider (ADR-0008).
+
+import { z } from 'zod';
+import { USER_ROLES } from './user.repository';
+
+export const userResponseSchema = z.object({
+  id: z.string().uuid(),
+  displayName: z.string(),
+  phone: z.string().nullable(),
+  avatarUrl: z.string().nullable(),
+  role: z.enum(USER_ROLES),
+  createdAt: z.date(),
+});

--- a/services/api/tests/openapi.test.ts
+++ b/services/api/tests/openapi.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { buildApp } from '../src/app';
+
+async function spec() {
+  const app = await buildApp();
+  const res = await app.inject({ method: 'GET', url: '/docs/json' });
+  expect(res.statusCode).toBe(200);
+  return res.json();
+}
+
+describe('OpenAPI spec', () => {
+  it('declares a Bearer (JWT) security scheme', async () => {
+    const s = await spec();
+    expect(s.components.securitySchemes.bearerAuth).toMatchObject({
+      type: 'http',
+      scheme: 'bearer',
+      bearerFormat: 'JWT',
+    });
+  });
+
+  it('marks GET /me as requiring bearer auth and tags it', async () => {
+    const me = (await spec()).paths['/me'].get;
+    expect(me.security).toContainEqual({ bearerAuth: [] });
+    expect(me.tags).toContain('auth');
+    // Documented outcomes, including the rate-limit response.
+    expect(Object.keys(me.responses)).toEqual(expect.arrayContaining(['200', '401', '404', '429']));
+  });
+
+  it('documents the system routes with a response schema', async () => {
+    const s = await spec();
+    const healthz = s.paths['/healthz'].get;
+    expect(healthz.tags).toContain('system');
+    expect(healthz.responses['200']).toBeTruthy();
+  });
+
+  it('describes the user response shape', async () => {
+    const props = (await spec()).paths['/me'].get.responses['200'].content['application/json']
+      .schema.properties;
+    expect(Object.keys(props)).toEqual(
+      expect.arrayContaining(['id', 'displayName', 'phone', 'avatarUrl', 'role', 'createdAt']),
+    );
+  });
+});


### PR DESCRIPTION
## What
Swagger UI + the OpenAPI doc already existed, but documented nothing useful (no schemas, no auth, no error shapes) and nothing validated input. This makes it a **real, typed contract**: each route declares one **zod** schema that drives validation, response serialization, TS inference, *and* the OpenAPI spec — no duplicated JSON Schema.

- **`fastify-type-provider-zod`** (v4 line — peer `zod@3`; v7 needs zod 4, not worth the bump yet).
- **Bearer (JWT) security scheme** declared once; `GET /me` marked `security: [{ bearerAuth: [] }]`.
- **Tags** (`system`, `auth`); shared **`errorResponseSchema`** + **`userResponseSchema`**.
- Response/error schemas on `/`, `/version`, `/healthz`, `/readyz`, `/me` (incl. the 429 rate-limit response).
- **ADR-0008** records the decision + the per-route convention the team follows.

## Why this matters for the team
- **Frontend** can generate its client straight from **`/docs/json`** (e.g. `curl <staging>/docs/json`). The spec now describes auth, request/response shapes, and error bodies.
- **Backend**: every new route gets input validation for free (declare `body`/`querystring`/`params`), and self-documents. Convention + worked example (`/me`) in ADR-0008.

## Note on serialization
Responses are now serialized against their schema — a handler returning data that doesn't match its `response` schema fails loudly, so schemas must stay honest. `Date` fields use `z.date()` → ISO date-time on the wire.

## Verification
- `pnpm check` green; **50 tests, 100% coverage** (incl. a new `openapi.test.ts` asserting the security scheme, `/me` security, tags, and the user response shape).
- Live `/docs/json` confirmed: `bearerAuth` scheme, `system`/`auth` tags, `/me` secured.

Ref: ADR-0008, ADR-0003.