### PR TITLE
docs: status/gap analysis + ADR-0009/0010 + ADR-0003 Node 24 note

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,0 +1,76 @@
+# Platform status & gap analysis
+
+**Snapshot:** 2026-06-26 · a point-in-time map of `mobility-core`. Update as
+areas land; it is not authoritative once the code moves.
+
+## Architecture (what exists)
+
+`services/api` — Fastify 5 + TypeScript (Node 24), single process, layered
+`server.ts → buildApp (app.ts) → plugins/routes → repositories`.
+
+| Layer        | Modules                                                                                                                                   |
+| ------------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| Config       | `config/env.ts` (zod-validated env), `config/dotenv.ts`                                                                                   |
+| Data         | `db/migrate.ts` (runner), `db/pool.ts`; migrations `001_init` (users, auth_identity, sessions), `002`/`003` (subscriptions + constraints) |
+| KV           | `kv/kv.store.ts` (interface + in-memory), `kv.store.redis.ts` (ADR-0010)                                                                  |
+| Auth         | `auth/jwt.ts`, `auth/auth.plugin.ts` (`authenticate`/`requireRole`), `auth/auth.routes.ts` (`/me`) (ADR-0007)                             |
+| Rate limit   | `ratelimit/ratelimit.plugin.ts` (#23)                                                                                                     |
+| Domain repos | `users/*`, `subscriptions/*` — **repos only, no routes**                                                                                  |
+| Contract     | `lib/schemas.ts`, `user.schema.ts`, OpenAPI via zod type-provider (ADR-0008)                                                              |
+
+**Live HTTP surface:** `/`, `/version`, `/healthz`, `/readyz`, `/me`, `/docs`.
+
+**Cross-cutting (in place):** repository pattern (ADR-0009), KV fallback
+(ADR-0010), readiness pings DB+KV, rate limiting, typed OpenAPI, ~100% unit
+coverage, CI + security gates (gitleaks/CodeQL/audit), CD (migrate→deploy,
+staging auto / prod gated), CODEOWNERS + code-owner reviews.
+
+## Gaps
+
+### 🔴 Auth is half-built (highest impact)
+
+- **No sign-in** — no `/auth/google` / `/auth/apple`, no ID-token verification
+  (slice 2). Blocks the mobile login flow (#34).
+- **`sessions` and `auth_identity` tables exist but are unused** — no refresh
+  tokens, rotation, revoke, or logout. The refresh half of ADR-0007 is unbuilt.
+
+### 🟡 Subscriptions
+
+- Data layer only — **no endpoint** (e.g. `GET /me/subscription`); not usable
+  over HTTP. `plan` is free-text (no enum/CHECK). In-memory repo does not enforce
+  one-active-per-user (the DB does — see ADR-0009).
+
+### ❌ Not started (mapped to issues)
+
+| Area                                    | Issue         | Notes                                   |
+| --------------------------------------- | ------------- | --------------------------------------- |
+| Mobility (routes/stops/trips, PostGIS)  | #17/#18/#25   | PostGIS enabled, no spatial tables      |
+| Token ledger & payments (Paystack)      | #21           | no tables/logic (CTO)                   |
+| QR boarding / passes / scan_events      | #20           | none (CTO)                              |
+| Avatar upload → R2                      | #24           | none                                    |
+| Observability (RED metrics, `/metrics`) | #28           | only default pino logs                  |
+| Feature flags + force-update            | #27           | none                                    |
+| Account deletion                        | #30           | none                                    |
+| Flutter apps                            | #32+          | `apps/` is a README — no scaffold       |
+| Telemetry (MQTT→Go)                     | ADR-0002/0006 | EMQX in compose, no pipeline (deferred) |
+
+### 🟡 Architecture notes
+
+- **No service layer** yet — routes call repositories directly. Fine at this size;
+  introduce `routes → services → repositories` before real business logic lands.
+- e2e is minimal — no DB-backed flows (ci.yml has a TODO for a postgis service
+  container + seed).
+
+## ADR status
+
+- **0003** (TS+Fastify) — amended for Node 24 (was 22).
+- **0007** (JWT) — accurate; rate limiting it cited as "slice 3" has since landed (#23).
+- **0009** (repository pattern), **0010** (KV/Redis) — added to record patterns
+  that were previously only in code comments.
+
+## Suggested next
+
+1. **Auth slice 2** (sign-in + refresh) — the biggest unblock; needs Google OAuth
+   setup.
+2. `GET /me/subscription` — make subscriptions a real, secured, documented API.
+3. Observability (#28) — `/metrics` + structured fields, before traffic grows.

--- a/docs/adr/0003-typescript-fastify-api.md
+++ b/docs/adr/0003-typescript-fastify-api.md
@@ -31,3 +31,10 @@ Technical grounds:
 - Strict mode + ESLint are non-negotiable gates in CI.
 - CPU-bound features do not get added to this service; they go to the Go side
   (ADR-0002) or a worker.
+
+## Update — 2026-06-26
+
+The runtime is now **Node.js 24** (current Active LTS), not 22 as written above —
+reflected in `package.json` `engines`, `.nvmrc`, the Dockerfile, and CI. The
+TypeScript + Fastify + zod decision is unchanged; only the Node version moved.
+(Amendment note rather than a superseding ADR, since the decision itself stands.)

--- a/docs/adr/0009-repository-pattern.md
+++ b/docs/adr/0009-repository-pattern.md
@@ -1,0 +1,40 @@
+# ADR-0009 — Repository pattern with environment-selected datastore
+
+**Status:** accepted · **Date:** 2026-06-26
+
+## Context
+
+We want two things that usually conflict: **zero-infra local dev and tests** (no
+database needed to run or unit-test the API) **and** real Postgres in CI and
+production — without branching the domain logic on which one is active. This was
+established in the database foundation (#15) and every domain module now copies
+it (`users`, `subscriptions`).
+
+## Decision
+
+Each domain exposes a **repository interface** with two implementations:
+
+- **InMemory** (`*.repository.ts`) — `Map`-backed, the reference implementation.
+  Used by unit tests and zero-infra local dev.
+- **Postgres** (`*.repository.pg.ts`) — the real adapter.
+
+`server.ts` selects the implementation **at startup by `DATABASE_URL`** (set →
+Postgres, unset → in-memory). Conventions:
+
+- A `toX(row)` helper maps snake_case rows → camelCase domain objects.
+- **Parameterized queries only** (`$1, $2`) — never string-concatenate values
+  (the SQL-injection guard).
+- `*.pg.ts` adapters are **excluded from unit coverage** (`vitest.config.ts`) —
+  they run only against real infrastructure (CI migrations job / e2e).
+- Routes and services depend on the **interface**, never on a concrete adapter.
+
+## Consequences
+
+- Domain/route logic is datastore-agnostic; tests run with no DB; CI/e2e exercise
+  the Postgres path.
+- **In-memory repos may not enforce every DB constraint** (e.g. partial unique
+  indexes). The database is the source of truth; the in-memory adapter is a
+  convenience for tests/dev, not a second enforcement point.
+- As business rules grow, logic belongs in a **service layer above the
+  repositories** (routes → services → repositories), not in the adapters.
+- The KV/cache layer mirrors this same shape — see ADR-0010.

--- a/docs/adr/0010-kv-redis.md
+++ b/docs/adr/0010-kv-redis.md
@@ -1,0 +1,39 @@
+# ADR-0010 — Key-value store (Redis) with in-memory fallback
+
+**Status:** accepted · **Date:** 2026-06-26
+
+## Context
+
+We need a fast key-value layer for **rate-limit counters**, **idempotency keys**,
+and short-lived **caching** (#22). We want the same "zero-infra locally, real in
+production" ergonomics as the datastore (ADR-0009), and we don't want callers
+binding directly to a Redis client.
+
+## Decision
+
+A **`KvStore` interface** (`get` / `set` with TTL / `del` / `increment` / `ping`
+/ `close`) with two implementations, selected by **`REDIS_URL`** — mirroring the
+repository pattern (ADR-0009):
+
+- **`InMemoryKvStore`** — default (no `REDIS_URL`); zero infra for dev/tests/CI.
+- **`RedisKvStore`** — `ioredis` (the rate-limiter ecosystem standard); used when
+  `REDIS_URL` is set. Excluded from unit coverage like `*.pg.ts`.
+
+Scope and guarantees:
+
+- **Ephemeral data only** — counters, idempotency keys, cache. **Sessions and
+  refresh tokens live in Postgres** (ADR-0007), _not_ Redis. So a wiped Redis
+  loses nothing critical, and the **free, no-persistence Redis tier is safe** for
+  the pilot (Render Key Value / Upstash).
+- `increment(key, ttl)` is **fixed-window** (TTL set once, on first write) — the
+  building block for rate limiting (#23).
+- `/readyz` pings the KV when one is configured; it's closed on shutdown.
+
+## Consequences
+
+- Rate limiting (#23) and future idempotency keys build on this seam; **no Redis
+  account is needed** for dev/tests/CI.
+- Consumers treat the KV as best-effort — the rate limiter **fails open** if the
+  store is unavailable, so a Redis outage degrades rather than downs the API.
+- The pub/sub seam for the telemetry path (ADR-0002) can extend this client
+  later rather than introducing a separate dependency.


### PR DESCRIPTION
## What
Indexes the current codebase, records the gaps, and fixes the ADR drift surfaced in that review.

- **`docs/STATUS.md`** — architecture map, gap analysis (auth half-built, subscriptions has no endpoint, what's not started by issue), and ADR status. A dated snapshot for the team.
- **ADR-0009 — Repository pattern** (in-memory ↔ Postgres by `DATABASE_URL`). Foundational pattern every BE module copies; previously only in code comments.
- **ADR-0010 — KV/Redis with in-memory fallback** (#22 shipped without an ADR; our rule requires one for architectural choices).
- **ADR-0003 — amendment note**: runtime is Node 24, not 22. Original decision untouched (note, not a rewrite — ADRs are immutable per ADR-0001).

## Headline gaps (detail in STATUS.md)
- 🔴 **Auth half-built** — guard + `/me` only; no sign-in, and `sessions`/`auth_identity` tables are unused (slice 2 unbuilt). Blocks mobile login (#34).
- 🟡 **Subscriptions** — data layer only, no HTTP endpoint.
- ❌ Mobility, payments/ledger, QR, R2, observability, feature flags, account deletion, Flutter apps — not started (mapped to issues).

Docs-only; no code change.