### PR TITLE
feat(subscriptions): define SubscriptionPlan and SubscriptionStatus t…

### DIFF
--- a/services/api/src/db/migrations/004_subscription_plan_check.sql
+++ b/services/api/src/db/migrations/004_subscription_plan_check.sql
@@ -1,0 +1,5 @@
+-- 004_subscription_plan_check: enforce allowed plan values.
+
+ALTER TABLE subscriptions
+  ADD CONSTRAINT chk_subscriptions_plan
+  CHECK (plan IN ('monthly', 'annual'));

--- a/services/api/src/modules/subscriptions/subscription.repository.pg.ts
+++ b/services/api/src/modules/subscriptions/subscription.repository.pg.ts
@@ -5,11 +5,13 @@ import type {
   SubscriptionRepository,
 } from './subscription.repository';
 
+import type { SubscriptionPlan, SubscriptionStatus } from './subscription.repository';
+
 interface SubscriptionRow {
   id: string;
   user_id: string;
-  plan: string;
-  status: string;
+  plan: SubscriptionPlan;
+  status: SubscriptionStatus;
   created_at: Date;
 }
 

--- a/services/api/src/modules/subscriptions/subscription.repository.ts
+++ b/services/api/src/modules/subscriptions/subscription.repository.ts
@@ -1,14 +1,17 @@
+export type SubscriptionPlan = 'monthly' | 'annual';
+export type SubscriptionStatus = 'active' | 'cancelled' | 'expired';
+
 export interface Subscription {
   id: string;
   userId: string;
-  plan: string;
-  status: string;
+  plan: SubscriptionPlan;
+  status: SubscriptionStatus;
   createdAt: Date;
 }
 
 export interface NewSubscription {
   userId: string;
-  plan: string;
+  plan: SubscriptionPlan;
 }
 
 export interface SubscriptionRepository {

--- a/services/api/tests/subscription.repository.test.ts
+++ b/services/api/tests/subscription.repository.test.ts
@@ -4,21 +4,21 @@ import { InMemorySubscriptionRepository } from '../src/modules/subscriptions/sub
 describe('InMemorySubscriptionRepository', () => {
   it('creates a subscription with active status and returns it', async () => {
     const repo = new InMemorySubscriptionRepository();
-    const created = await repo.create({ userId: 'user-1', plan: 'monthly' });
+    const created = await repo.create({ userId: 'user-1', plan: 'monthly' as const });
 
     expect(created.id).toBeTruthy();
     expect(created.userId).toBe('user-1');
-    expect(created.plan).toBe('monthly');
+    expect(created.plan).toBe('monthly' as const);
     expect(created.status).toBe('active');
     expect(created.createdAt).toBeInstanceOf(Date);
   });
 
   it('finds the active subscription for a user', async () => {
     const repo = new InMemorySubscriptionRepository();
-    await repo.create({ userId: 'user-1', plan: 'monthly' });
+    await repo.create({ userId: 'user-1', plan: 'monthly' as const });
 
     const found = await repo.findActiveByUser('user-1');
-    expect(found?.plan).toBe('monthly');
+    expect(found?.plan).toBe('monthly' as const);
   });
 
   it('returns null when the user has no active subscription', async () => {
@@ -28,7 +28,7 @@ describe('InMemorySubscriptionRepository', () => {
 
   it('returns null for a different user', async () => {
     const repo = new InMemorySubscriptionRepository();
-    await repo.create({ userId: 'user-1', plan: 'monthly' });
+    await repo.create({ userId: 'user-1', plan: 'monthly' as const });
 
     expect(await repo.findActiveByUser('user-2')).toBeNull();
   });


### PR DESCRIPTION


## Summary

<!-- One or two sentences: what does this PR change and why? Link the work item. -->

# Closes: #53 

- Add SubscriptionPlan ('monthly' | 'annual') and SubscriptionStatus ('active' | 'cancelled' | 'expired') types to replace free string fields
- Update Subscription and NewSubscription interfaces to use the new types
- Update PgSubscriptionRepository row mapper to use typed fields
- Add 004_subscription_plan_check.sql migration to enforce allowed plan values at the DB level with a CHECK constraint

## Test plan

<!-- Commands or steps a reviewer can run. e.g. `make check`, `make e2e`, a screen to open. -->

## Checklist

- [ ] pnpm migrate applies cleanly and is idempotent
- [ ]  pnpm check passes (format + typecheck + lint + unit tests)
- [ ]  TypeScript rejects invalid plan values at compile time
