### PR TITLE
test(e2e): DB-backed harness — exercise the Postgres path end-to-end

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,8 +86,25 @@ jobs:
     name: E2E (Playwright)
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    # When the API gains a datastore, add a postgis/postgis service container
-    # here (see docs/architecture.md) and the e2e globalSetup will migrate+seed.
+    # Real Postgres so the suite exercises the Pg adapters end-to-end; the e2e
+    # globalSetup migrates + seeds it. Specs self-skip the DB-backed cases when
+    # DATABASE_URL is unset (local zero-infra runs).
+    services:
+      postgres:
+        image: postgis/postgis:16-3.4
+        env:
+          POSTGRES_USER: trotxi
+          POSTGRES_PASSWORD: trotxi
+          POSTGRES_DB: trotxi
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U trotxi"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+    env:
+      DATABASE_URL: postgres://trotxi:trotxi@localhost:5432/trotxi
     steps:
       - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v6

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -1,0 +1,17 @@
+// Shared constants for the DB-backed e2e run. Imported by playwright.config.ts
+// (to configure the server under test), global-setup.ts (to seed), and the specs
+// (to mint matching tokens). Single source so the secret/user never drift apart.
+
+/** Test-only signing secret; also passed to the API under test as JWT_SECRET. */
+export const E2E_JWT_SECRET = 'e2e-only-secret-at-least-32-characters-0000';
+
+/** Must match the API's JWT issuer/audience defaults (config/env.ts). */
+export const JWT_ISSUER = 'trotxi';
+export const JWT_AUDIENCE = 'trotxi-api';
+
+/** A user seeded into the e2e database (fixed id so specs can mint its token). */
+export const SEED_USER = {
+  id: '00000000-0000-0000-0000-0000000000e2',
+  displayName: 'E2E User',
+  role: 'commuter' as const,
+};

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,0 +1,33 @@
+// Runs once before the e2e suite. When DATABASE_URL is set (CI, or local after
+// `pnpm infra:up`), it migrates a real Postgres and seeds a known user so the
+// DB-backed specs can exercise the Postgres path. With no DATABASE_URL it's a
+// no-op and those specs skip — local runs stay zero-infra.
+
+import { execSync } from 'node:child_process';
+import { Client } from 'pg';
+import { SEED_USER } from './fixtures';
+
+export default async function globalSetup(): Promise<void> {
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) {
+    console.log('[e2e] No DATABASE_URL — running in-memory; DB-backed specs will skip.');
+    return;
+  }
+
+  console.log('[e2e] Migrating e2e database…');
+  execSync('pnpm --filter @trotxi/api run migrate', { stdio: 'inherit' });
+
+  console.log('[e2e] Seeding fixture user…');
+  const client = new Client({ connectionString });
+  await client.connect();
+  try {
+    await client.query(
+      `INSERT INTO users (id, display_name, role)
+       VALUES ($1, $2, $3)
+       ON CONFLICT (id) DO NOTHING`,
+      [SEED_USER.id, SEED_USER.displayName, SEED_USER.role],
+    );
+  } finally {
+    await client.end();
+  }
+}

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -9,6 +9,9 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.49.1",
-    "@types/node": "^22.10.2"
+    "@types/node": "^22.10.2",
+    "@types/pg": "^8.20.0",
+    "jose": "^6.2.3",
+    "pg": "^8.22.0"
   }
 }

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,7 +1,12 @@
 import { defineConfig } from '@playwright/test';
+import { E2E_JWT_SECRET } from './fixtures';
 
 const PORT = Number(process.env.E2E_PORT ?? 3100);
 const BASE_URL = `http://127.0.0.1:${PORT}`;
+
+// Set (CI, or local `pnpm infra:up`) -> the API under test uses Postgres and the
+// DB-backed specs run. Unset -> in-memory, those specs skip.
+const DATABASE_URL = process.env.DATABASE_URL;
 
 export default defineConfig({
   testDir: './tests',
@@ -9,12 +14,11 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
   reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : 'list',
+  // Migrates + seeds the e2e database when DATABASE_URL is set (no-op otherwise).
+  globalSetup: './global-setup.ts',
   use: {
     baseURL: BASE_URL,
   },
-  // When the API gains a datastore: add a globalSetup that provisions a
-  // dedicated e2e database (drop/recreate + migrate + seed) and inject its
-  // DATABASE_URL below, so runs are hermetic and never touch dev data.
   webServer: {
     command: 'pnpm exec tsx src/server.ts',
     cwd: '../services/api',
@@ -25,6 +29,10 @@ export default defineConfig({
       PORT: String(PORT),
       HOST: '127.0.0.1',
       NODE_ENV: 'test',
+      // Deterministic secret so specs can mint tokens the server accepts.
+      JWT_SECRET: E2E_JWT_SECRET,
+      // Pass through when present so the server uses Postgres (see global-setup).
+      ...(DATABASE_URL ? { DATABASE_URL } : {}),
     },
   },
 });

--- a/e2e/tests/me.spec.ts
+++ b/e2e/tests/me.spec.ts
@@ -1,0 +1,45 @@
+import { expect, test } from '@playwright/test';
+import { SignJWT } from 'jose';
+import { E2E_JWT_SECRET, JWT_AUDIENCE, JWT_ISSUER, SEED_USER } from '../fixtures';
+
+const hasDb = !!process.env.DATABASE_URL;
+
+async function accessToken(sub: string, role: string): Promise<string> {
+  return new SignJWT({ role })
+    .setProtectedHeader({ alg: 'HS256' })
+    .setSubject(sub)
+    .setIssuedAt()
+    .setIssuer(JWT_ISSUER)
+    .setAudience(JWT_AUDIENCE)
+    .setExpirationTime('5m')
+    .sign(new TextEncoder().encode(E2E_JWT_SECRET));
+}
+
+test.describe('GET /me', () => {
+  test('rejects an unauthenticated request', async ({ request }) => {
+    const res = await request.get('/me');
+    expect(res.status()).toBe(401);
+  });
+
+  test.describe('against Postgres', () => {
+    // Exercises the real DB path end-to-end: token -> guard -> Pg repo -> row.
+    test.skip(!hasDb, 'requires DATABASE_URL (real Postgres)');
+
+    test('returns the seeded user for a valid token', async ({ request }) => {
+      const token = await accessToken(SEED_USER.id, SEED_USER.role);
+      const res = await request.get('/me', { headers: { authorization: `Bearer ${token}` } });
+      expect(res.status()).toBe(200);
+      expect(await res.json()).toMatchObject({
+        id: SEED_USER.id,
+        displayName: SEED_USER.displayName,
+        role: SEED_USER.role,
+      });
+    });
+
+    test('returns 404 for a valid token whose user does not exist', async ({ request }) => {
+      const token = await accessToken('00000000-0000-0000-0000-0000000000ff', 'commuter');
+      const res = await request.get('/me', { headers: { authorization: `Bearer ${token}` } });
+      expect(res.status()).toBe(404);
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,15 @@ importers:
       '@types/node':
         specifier: ^22.10.2
         version: 22.19.21
+      '@types/pg':
+        specifier: ^8.20.0
+        version: 8.20.0
+      jose:
+        specifier: ^6.2.3
+        version: 6.2.3
+      pg:
+        specifier: ^8.22.0
+        version: 8.22.0
 
   services/api:
     dependencies:


### PR DESCRIPTION
## What
Closes the **"e2e is in-memory only"** gap from STATUS.md. Our Pg adapters (`*.pg.ts`) are excluded from unit coverage, so until now **no test ran real SQL**. This adds a DB-backed e2e path.

- **`global-setup.ts`** — when `DATABASE_URL` is set, migrates a real Postgres and seeds a fixture user; no-op otherwise.
- **`playwright.config`** — runs the API under test against that Postgres and passes a deterministic `JWT_SECRET` so specs can mint accepted tokens.
- **`me.spec.ts`** — `401` (unauth), **`200` (seeded user, real DB row)**, `404` (valid token, missing user).
- **`ci.yml`** — the E2E job now runs a `postgis/postgis` service container.

**Zero-infra preserved:** with no `DATABASE_URL` the DB-backed specs **self-skip**, so local runs (and anyone without Docker) are unchanged — verified locally (5 passed, 2 skipped).

## Why it matters
This is the harness **slice 2 will reuse** for the sign-in → session → refresh flow, and it finally verifies the production data path (queries, column mapping, constraints, serialization) — not just the in-memory stand-in.

## Verification
- Local (in-memory): 5 passed, 2 skipped.
- CI: the postgis service exercises the `200`/`404` DB-backed cases for real.

Ref: STATUS.md (e2e gap), ADR-0009.