### PR TITLE
feat(subscriptions): add POST /subscriptions and GET /subscriptions/me endpoints

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -15,10 +15,10 @@ areas land; it is not authoritative once the code moves.
 | KV           | `kv/kv.store.ts` (interface + in-memory), `kv.store.redis.ts` (ADR-0010)                                                                  |
 | Auth         | `auth/jwt.ts`, `auth/auth.plugin.ts` (`authenticate`/`requireRole`), `auth/auth.routes.ts` (`/me`) (ADR-0007)                             |
 | Rate limit   | `ratelimit/ratelimit.plugin.ts` (#23)                                                                                                     |
-| Domain repos | `users/*`, `subscriptions/*` — **repos only, no routes**                                                                                  |
-| Contract     | `lib/schemas.ts`, `user.schema.ts`, OpenAPI via zod type-provider (ADR-0008)                                                              |
+| Domain repos | `users/*` — repo only; `subscriptions/*` — repos + HTTP routes (PR #59)                                                                   |
+| Contract     | `lib/schemas.ts`, `user.schema.ts`, `subscription.schema.ts`, OpenAPI via zod type-provider (ADR-0008)                                    |
 
-**Live HTTP surface:** `/`, `/version`, `/healthz`, `/readyz`, `/me`, `/docs`.
+**Live HTTP surface:** `/`, `/version`, `/healthz`, `/readyz`, `/me`, `/docs`, `/subscriptions`, `/subscriptions/me`.
 
 **Cross-cutting (in place):** repository pattern (ADR-0009), KV fallback
 (ADR-0010), readiness pings DB+KV, rate limiting, typed OpenAPI, ~100% unit
@@ -34,11 +34,32 @@ staging auto / prod gated), CODEOWNERS + code-owner reviews.
 - **`sessions` and `auth_identity` tables exist but are unused** — no refresh
   tokens, rotation, revoke, or logout. The refresh half of ADR-0007 is unbuilt.
 
-### 🟡 Subscriptions
+### 🟢 Subscriptions — HTTP layer complete (closes #58, PR #59)
 
-- Data layer only — **no endpoint** (e.g. `GET /me/subscription`); not usable
-  over HTTP. `plan` is free-text (no enum/CHECK). In-memory repo does not enforce
-  one-active-per-user (the DB does — see ADR-0009).
+**What landed:**
+
+- `subscription.schema.ts` — `plan` is now a typed enum (`'monthly' | 'annual'`),
+  fixing the free-text gap noted previously. `status` is also enumerated
+  (`'active' | 'cancelled' | 'expired'`). Schemas drive both runtime validation
+  and the OpenAPI spec (ADR-0008).
+- `POST /subscriptions` — creates an active subscription for the authenticated user.
+  Returns 409 if one already exists (enforces one-active-per-user at the API layer,
+  complementing the DB `UNIQUE` constraint).
+- `GET /subscriptions/me` — returns the caller's active subscription or 404 if none.
+
+**Design choices:**
+
+- **Both endpoints require auth.** Subscription management is identity-bound —
+  anonymous access is rejected by `app.authenticate` before the handler runs.
+  This is the opposite of the mobility browse endpoints, which are intentionally public.
+- **409 on duplicate, not upsert.** A second `POST /subscriptions` from the same user
+  returns a conflict rather than silently overwriting. The caller must cancel first;
+  this makes state transitions explicit and auditable.
+- **No per-endpoint rate limiting.** The auth guard is the primary traffic barrier
+  here. A malicious caller would need a valid token first, which already limits
+  abuse. The global per-user rate limit on `/me` covers the authenticated surface.
+- **Follows ADR-0009** — `InMemorySubscriptionRepository` for tests/dev; `PgSubscriptionRepository`
+  for real runs; `server.ts` selects by `DATABASE_URL`.
 
 ### ❌ Not started (mapped to issues)
 
@@ -72,5 +93,4 @@ staging auto / prod gated), CODEOWNERS + code-owner reviews.
 
 1. **Auth slice 2** (sign-in + refresh) — the biggest unblock; needs Google OAuth
    setup.
-2. `GET /me/subscription` — make subscriptions a real, secured, documented API.
-3. Observability (#28) — `/metrics` + structured fields, before traffic grows.
+2. Observability (#28) — `/metrics` + structured fields, before traffic grows.

--- a/services/api/src/app.ts
+++ b/services/api/src/app.ts
@@ -18,6 +18,7 @@ import {
   type RateLimitConfig,
 } from './modules/ratelimit/ratelimit.plugin';
 import type { SubscriptionRepository } from './modules/subscriptions/subscription.repository';
+import { subscriptionRoutes } from './modules/subscriptions/subscription.routes';
 import type { UserRepository } from './modules/users/user.repository';
 
 /**
@@ -65,6 +66,7 @@ export async function buildApp(deps: AppDeps = {}): Promise<FastifyInstance> {
       tags: [
         { name: 'system', description: 'Health, readiness, and service metadata' },
         { name: 'auth', description: 'Authentication and the current user' },
+        { name: 'subscriptions', description: 'Subscription management' },
       ],
       components: {
         // Protected routes set `security: [{ bearerAuth: [] }]`; clients send
@@ -86,6 +88,7 @@ export async function buildApp(deps: AppDeps = {}): Promise<FastifyInstance> {
     users: deps.users,
     rateLimit: deps.rateLimit ?? DEFAULT_RATE_LIMIT,
   });
+  await app.register(subscriptionRoutes, { subscriptions: deps.subscriptions });
 
   r.get(
     '/',

--- a/services/api/src/modules/subscriptions/subscription.repository.ts
+++ b/services/api/src/modules/subscriptions/subscription.repository.ts
@@ -1,3 +1,8 @@
+// Subscription repository. One active subscription per user is the intended
+// invariant — enforced by the DB UNIQUE constraint and checked in the route
+// handler before create(). findActiveByUser returns only 'active' rows so
+// cancelled/expired subscriptions are invisible to the caller.
+
 export type SubscriptionPlan = 'monthly' | 'annual';
 export type SubscriptionStatus = 'active' | 'cancelled' | 'expired';
 

--- a/services/api/src/modules/subscriptions/subscription.routes.ts
+++ b/services/api/src/modules/subscriptions/subscription.routes.ts
@@ -1,0 +1,88 @@
+import type { FastifyInstance } from 'fastify';
+import type { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { errorResponseSchema } from '../../lib/schemas';
+import type { SubscriptionRepository } from './subscription.repository';
+import { createSubscriptionBodySchema, subscriptionResponseSchema } from './subscription.schema';
+
+export async function subscriptionRoutes(
+  app: FastifyInstance,
+  opts: { subscriptions?: SubscriptionRepository },
+): Promise<void> {
+  const r = app.withTypeProvider<ZodTypeProvider>();
+
+  r.post(
+    '/subscriptions',
+    {
+      schema: {
+        tags: ['subscriptions'],
+        summary: 'Create a subscription for the authenticated user',
+        security: [{ bearerAuth: [] }],
+        body: createSubscriptionBodySchema,
+        response: {
+          201: subscriptionResponseSchema,
+          401: errorResponseSchema,
+          409: errorResponseSchema,
+        },
+      },
+      preHandler: [app.authenticate],
+    },
+    async (request, reply) => {
+      const principal = request.user!;
+
+      const existing = opts.subscriptions
+        ? await opts.subscriptions.findActiveByUser(principal.id)
+        : null;
+
+      if (existing) {
+        return reply.code(409).send({
+          error: 'conflict',
+          message: 'User already has an active subscription',
+        });
+      }
+
+      const subscription = opts.subscriptions
+        ? await opts.subscriptions.create({ userId: principal.id, plan: request.body.plan })
+        : null;
+
+      if (!subscription) {
+        return reply
+          .code(409)
+          .send({ error: 'unavailable', message: 'Subscription service unavailable' });
+      }
+
+      return reply.code(201).send(subscription);
+    },
+  );
+
+  r.get(
+    '/subscriptions/me',
+    {
+      schema: {
+        tags: ['subscriptions'],
+        summary: 'Get the active subscription for the authenticated user',
+        security: [{ bearerAuth: [] }],
+        response: {
+          200: subscriptionResponseSchema,
+          401: errorResponseSchema,
+          404: errorResponseSchema,
+        },
+      },
+      preHandler: [app.authenticate],
+    },
+    async (request, reply) => {
+      const principal = request.user!;
+
+      const subscription = opts.subscriptions
+        ? await opts.subscriptions.findActiveByUser(principal.id)
+        : null;
+
+      if (!subscription) {
+        return reply
+          .code(404)
+          .send({ error: 'not_found', message: 'No active subscription found' });
+      }
+
+      return subscription;
+    },
+  );
+}

--- a/services/api/src/modules/subscriptions/subscription.routes.ts
+++ b/services/api/src/modules/subscriptions/subscription.routes.ts
@@ -1,3 +1,9 @@
+// Subscription route handlers. Both endpoints require a valid bearer token —
+// anonymous access is rejected by app.authenticate before reaching the handler.
+// POST /subscriptions enforces one-active-per-user at the API layer (409 on
+// duplicate) in addition to the DB-level constraint, so callers get a clear
+// error rather than a constraint violation from Postgres.
+
 import type { FastifyInstance } from 'fastify';
 import type { ZodTypeProvider } from 'fastify-type-provider-zod';
 import { errorResponseSchema } from '../../lib/schemas';

--- a/services/api/src/modules/subscriptions/subscription.schema.ts
+++ b/services/api/src/modules/subscriptions/subscription.schema.ts
@@ -1,3 +1,8 @@
+// Zod schemas for the subscriptions domain. Enums are exported as const arrays
+// so they can be reused in the repository types and future CHECK constraints
+// without duplicating the literal values. Drives both runtime validation and
+// the OpenAPI spec via the zod type provider (ADR-0008).
+
 import { z } from 'zod';
 
 export const SUBSCRIPTION_PLANS = ['monthly', 'annual'] as const;

--- a/services/api/src/modules/subscriptions/subscription.schema.ts
+++ b/services/api/src/modules/subscriptions/subscription.schema.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+
+export const SUBSCRIPTION_PLANS = ['monthly', 'annual'] as const;
+export const SUBSCRIPTION_STATUSES = ['active', 'cancelled', 'expired'] as const;
+
+export const subscriptionResponseSchema = z.object({
+  id: z.string().uuid(),
+  userId: z.string().uuid(),
+  plan: z.enum(SUBSCRIPTION_PLANS),
+  status: z.enum(SUBSCRIPTION_STATUSES),
+  createdAt: z.date(),
+});
+
+export const createSubscriptionBodySchema = z.object({
+  plan: z.enum(SUBSCRIPTION_PLANS),
+});


### PR DESCRIPTION


## What

<!-- One or two sentences: what does this PR change and why? Link the work item. -->
Owner: @Foyade (BE) · Wave: 1 · Depends on: PR #42 (subscriptions data layer, merged)

HTTP layer for the subscriptions domain. Both endpoints require a valid bearer token — anonymous access is rejected at the auth guard before reaching the handler.

What was added

subscription.schema.ts -- Zod schemas for the request body (plan) and response shape. Drives both OpenAPI docs and runtime validation via the zod type provider (ADR-0008).

subscription.routes.ts -- POST /subscriptions creates an active subscription for the authenticated user, rejecting with 409 if one already exists. GET /subscriptions/me returns the current active subscription or 404 if none found.

app.ts -- subscriptionRoutes registered after authPlugin so app.authenticate is available. subscriptions tag added to the OpenAPI spec.

Closes: #58 

## How to verify

<!-- Commands or steps a reviewer can run. e.g. `make check`, `make e2e`, a screen to open. -->

## Checklist

- [ ] pnpm check passes
- [ ]  POST /subscriptions without a token returns 401 Missing bearer token
- [ ]  POST /subscriptions with a valid token and { "plan": "monthly" } returns 201 with the subscription
- [ ]  POST /subscriptions a second time with the same user returns 409 conflict
- [ ]  GET /subscriptions/me with a valid token returns the active subscription
- [ ]  GET /subscriptions/me with no subscription returns 404
- [ ]  Both endpoints visible in Swagger UI at /docs under the subscriptions tag
