### PR TITLE
feat(auth): sign-in + refresh + logout via AuthService (slice 2)

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -35,6 +35,11 @@ services:
       # Render dashboard; never commit it. Generate: openssl rand -base64 48
       - key: JWT_SECRET
         sync: false
+      # Google "Web" OAuth client ID — the audience verified on sign-in. Set the
+      # value in the Render dashboard (kept out of the repo). Unset -> POST
+      # /auth/google returns 503.
+      - key: GOOGLE_CLIENT_ID
+        sync: false
 
   # ---- Production (uncomment when going live) ----
   # Needs a paid Postgres plan so data doesn't expire. After applying, set the
@@ -61,6 +66,8 @@ services:
   #         property: connectionString
   #     - key: JWT_SECRET
   #       sync: false   # required; set in dashboard (ADR-0007)
+  #     - key: GOOGLE_CLIENT_ID
+  #       sync: false   # set in dashboard
   #
   # …and add under `databases:`
   # - name: trotxi-db-production

--- a/services/api/.env.example
+++ b/services/api/.env.example
@@ -18,6 +18,12 @@ NODE_ENV=development
 # JWT_ACCESS_TTL=15m
 # JWT_ISSUER=trotxi
 # JWT_AUDIENCE=trotxi-api
+# JWT_REFRESH_TTL_DAYS=30
+
+# Google sign-in — the "Web" OAuth client ID (the audience verified on sign-in).
+# Unset -> a dev fake verifier is used (non-prod); in prod, POST /auth/google
+# returns 503 until this is set. Not a secret; no client secret is needed.
+# GOOGLE_CLIENT_ID=xxxxxxxx.apps.googleusercontent.com
 
 # Rate limiting (fixed window) — defaults shown.
 # RATE_LIMIT_MAX=100

--- a/services/api/src/app.ts
+++ b/services/api/src/app.ts
@@ -11,6 +11,7 @@ import { z } from 'zod';
 import { InMemoryKvStore, type KvStore } from './kv/kv.store';
 import { authPlugin } from './modules/auth/auth.plugin';
 import { authRoutes } from './modules/auth/auth.routes';
+import type { AuthService } from './modules/auth/auth.service';
 import { DEV_AUTH_CONFIG, type AuthConfig } from './modules/auth/jwt';
 import {
   DEFAULT_RATE_LIMIT,
@@ -36,6 +37,8 @@ export interface AppDeps {
   kv?: KvStore;
   /** JWT/auth settings. Defaults to a dev-only config when unset (tests, local). */
   auth?: AuthConfig;
+  /** Sign-in/refresh/logout orchestrator. Routes return 503 when absent. */
+  authService?: AuthService;
   /** Rate-limit thresholds (from env). Defaults applied when unset. */
   rateLimit?: RateLimitConfig;
   logger?: boolean;
@@ -84,6 +87,7 @@ export async function buildApp(deps: AppDeps = {}): Promise<FastifyInstance> {
   await app.register(rateLimitPlugin, { kv });
   await app.register(authRoutes, {
     users: deps.users,
+    authService: deps.authService,
     rateLimit: deps.rateLimit ?? DEFAULT_RATE_LIMIT,
   });
 

--- a/services/api/src/config/env.ts
+++ b/services/api/src/config/env.ts
@@ -15,6 +15,10 @@ const envSchema = z
     JWT_ACCESS_TTL: z.string().default('15m'),
     JWT_ISSUER: z.string().default('trotxi'),
     JWT_AUDIENCE: z.string().default('trotxi-api'),
+    JWT_REFRESH_TTL_DAYS: z.coerce.number().int().positive().default(30),
+    // Google "Web" client ID — the audience verified on sign-in. Set to enable
+    // real Google sign-in; unset -> dev fake verifier (non-prod) / 503 (prod).
+    GOOGLE_CLIENT_ID: z.string().optional(),
     // Rate limiting (fixed window). Tunable without a code change.
     RATE_LIMIT_MAX: z.coerce.number().int().positive().default(100),
     RATE_LIMIT_WINDOW_SECONDS: z.coerce.number().int().positive().default(60),

--- a/services/api/src/modules/auth/auth-identity.repository.pg.ts
+++ b/services/api/src/modules/auth/auth-identity.repository.pg.ts
@@ -1,0 +1,47 @@
+import type { Pool } from 'pg';
+import type {
+  AuthIdentity,
+  AuthIdentityRepository,
+  NewAuthIdentity,
+} from './auth-identity.repository';
+import type { AuthProvider } from './id-token-verifier';
+
+interface AuthIdentityRow {
+  id: string;
+  user_id: string;
+  provider: AuthProvider;
+  provider_id: string;
+  created_at: Date;
+}
+
+function toAuthIdentity(row: AuthIdentityRow): AuthIdentity {
+  return {
+    id: row.id,
+    userId: row.user_id,
+    provider: row.provider,
+    providerId: row.provider_id,
+    createdAt: row.created_at,
+  };
+}
+
+export class PgAuthIdentityRepository implements AuthIdentityRepository {
+  constructor(private readonly pool: Pool) {}
+
+  async findByProvider(provider: AuthProvider, providerId: string): Promise<AuthIdentity | null> {
+    const { rows } = await this.pool.query<AuthIdentityRow>(
+      `SELECT * FROM auth_identity WHERE provider = $1 AND provider_id = $2`,
+      [provider, providerId],
+    );
+    return rows[0] ? toAuthIdentity(rows[0]) : null;
+  }
+
+  async create(input: NewAuthIdentity): Promise<AuthIdentity> {
+    const { rows } = await this.pool.query<AuthIdentityRow>(
+      `INSERT INTO auth_identity (user_id, provider, provider_id)
+       VALUES ($1, $2, $3)
+       RETURNING *`,
+      [input.userId, input.provider, input.providerId],
+    );
+    return toAuthIdentity(rows[0]!);
+  }
+}

--- a/services/api/src/modules/auth/auth-identity.repository.ts
+++ b/services/api/src/modules/auth/auth-identity.repository.ts
@@ -1,0 +1,48 @@
+// Links a provider identity (google/apple + subject id) to a Trotxi user. The
+// (provider, provider_id) pair is unique, so a returning user maps to the same
+// account. Backs the social-first sign-in in ADR-0007.
+
+import type { AuthProvider } from './id-token-verifier';
+
+export interface AuthIdentity {
+  id: string;
+  userId: string;
+  provider: AuthProvider;
+  providerId: string;
+  createdAt: Date;
+}
+
+export interface NewAuthIdentity {
+  userId: string;
+  provider: AuthProvider;
+  providerId: string;
+}
+
+export interface AuthIdentityRepository {
+  findByProvider(provider: AuthProvider, providerId: string): Promise<AuthIdentity | null>;
+  create(input: NewAuthIdentity): Promise<AuthIdentity>;
+}
+
+export class InMemoryAuthIdentityRepository implements AuthIdentityRepository {
+  private readonly identities = new Map<string, AuthIdentity>();
+
+  private key(provider: AuthProvider, providerId: string): string {
+    return `${provider}:${providerId}`;
+  }
+
+  async findByProvider(provider: AuthProvider, providerId: string): Promise<AuthIdentity | null> {
+    return this.identities.get(this.key(provider, providerId)) ?? null;
+  }
+
+  async create(input: NewAuthIdentity): Promise<AuthIdentity> {
+    const identity: AuthIdentity = {
+      id: crypto.randomUUID(),
+      userId: input.userId,
+      provider: input.provider,
+      providerId: input.providerId,
+      createdAt: new Date(),
+    };
+    this.identities.set(this.key(input.provider, input.providerId), identity);
+    return identity;
+  }
+}

--- a/services/api/src/modules/auth/auth.routes.ts
+++ b/services/api/src/modules/auth/auth.routes.ts
@@ -1,6 +1,6 @@
-// Auth routes. `GET /me` is the first protected endpoint — it proves the guard
-// end-to-end (token -> request.user -> repository lookup). Sign-in/refresh land
-// in Slice 2. Registered after authPlugin so `app.authenticate` is available.
+// Auth routes — thin HTTP layer over AuthService (ADR-0009 layering). `GET /me`
+// reads the principal; `/auth/*` handle social sign-in, refresh, and logout.
+// Sign-in/refresh are rate-limited per IP (they take untrusted input pre-auth).
 
 import type { FastifyInstance } from 'fastify';
 import type { ZodTypeProvider } from 'fastify-type-provider-zod';
@@ -8,13 +8,29 @@ import { errorResponseSchema } from '../../lib/schemas';
 import type { RateLimitConfig } from '../ratelimit/ratelimit.plugin';
 import { userResponseSchema } from '../users/user.schema';
 import type { UserRepository } from '../users/user.repository';
+import {
+  authResultSchema,
+  googleSignInBodySchema,
+  logoutBodySchema,
+  refreshBodySchema,
+  tokensSchema,
+} from './auth.schema';
+import {
+  type AuthService,
+  InvalidRefreshTokenError,
+  SignInNotConfiguredError,
+} from './auth.service';
+
+// Strict per-IP limit for the credential endpoints (brute-force / abuse guard).
+const AUTH_RATE_LIMIT = { max: 10, windowSeconds: 60 } as const;
 
 export async function authRoutes(
   app: FastifyInstance,
-  opts: { users?: UserRepository; rateLimit: RateLimitConfig },
+  opts: { users?: UserRepository; authService?: AuthService; rateLimit: RateLimitConfig },
 ): Promise<void> {
-  // Authenticate first (sets request.user), then rate-limit per user.
-  app.withTypeProvider<ZodTypeProvider>().get(
+  const r = app.withTypeProvider<ZodTypeProvider>();
+
+  r.get(
     '/me',
     {
       schema: {
@@ -31,13 +47,95 @@ export async function authRoutes(
       preHandler: [app.authenticate, app.rateLimit({ ...opts.rateLimit, by: 'user' })],
     },
     async (request, reply) => {
-      // `authenticate` guarantees request.user is set before we reach here.
       const principal = request.user!;
       const user = opts.users ? await opts.users.findById(principal.id) : null;
       if (!user) {
         return reply.code(404).send({ error: 'not_found', message: 'User not found' });
       }
       return user;
+    },
+  );
+
+  r.post(
+    '/auth/google',
+    {
+      schema: {
+        tags: ['auth'],
+        summary: 'Sign in with a Google ID token (creates the account on first use)',
+        body: googleSignInBodySchema,
+        response: {
+          200: authResultSchema,
+          401: errorResponseSchema,
+          429: errorResponseSchema,
+          503: errorResponseSchema,
+        },
+      },
+      preHandler: [app.rateLimit({ ...AUTH_RATE_LIMIT, by: 'ip' })],
+    },
+    async (request, reply) => {
+      if (!opts.authService) {
+        return reply.code(503).send({ error: 'unavailable', message: 'Sign-in is not configured' });
+      }
+      try {
+        return await opts.authService.signIn(request.body.idToken);
+      } catch (err) {
+        if (err instanceof SignInNotConfiguredError) {
+          return reply
+            .code(503)
+            .send({ error: 'unavailable', message: 'Sign-in is not configured' });
+        }
+        return reply.code(401).send({ error: 'unauthorized', message: 'Invalid ID token' });
+      }
+    },
+  );
+
+  r.post(
+    '/auth/refresh',
+    {
+      schema: {
+        tags: ['auth'],
+        summary: 'Exchange a refresh token for a new token pair (rotates the session)',
+        body: refreshBodySchema,
+        response: {
+          200: tokensSchema,
+          401: errorResponseSchema,
+          429: errorResponseSchema,
+          503: errorResponseSchema,
+        },
+      },
+      preHandler: [app.rateLimit({ ...AUTH_RATE_LIMIT, by: 'ip' })],
+    },
+    async (request, reply) => {
+      if (!opts.authService) {
+        return reply.code(503).send({ error: 'unavailable', message: 'Sign-in is not configured' });
+      }
+      try {
+        return await opts.authService.refresh(request.body.refreshToken);
+      } catch (err) {
+        if (err instanceof InvalidRefreshTokenError) {
+          return reply
+            .code(401)
+            .send({ error: 'unauthorized', message: 'Invalid or expired refresh token' });
+        }
+        throw err;
+      }
+    },
+  );
+
+  r.post(
+    '/auth/logout',
+    {
+      schema: {
+        tags: ['auth'],
+        summary: 'Revoke a refresh token (idempotent)',
+        body: logoutBodySchema,
+      },
+    },
+    async (request, reply) => {
+      if (opts.authService) {
+        await opts.authService.logout(request.body.refreshToken);
+      }
+      return reply.code(204).send();
     },
   );
 }

--- a/services/api/src/modules/auth/auth.schema.ts
+++ b/services/api/src/modules/auth/auth.schema.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod';
+import { userResponseSchema } from '../users/user.schema';
+
+export const googleSignInBodySchema = z.object({
+  idToken: z.string().min(1),
+});
+
+export const refreshBodySchema = z.object({
+  refreshToken: z.string().min(1),
+});
+
+export const logoutBodySchema = refreshBodySchema;
+
+export const tokensSchema = z.object({
+  accessToken: z.string(),
+  refreshToken: z.string(),
+});
+
+export const authResultSchema = tokensSchema.extend({
+  user: userResponseSchema,
+});

--- a/services/api/src/modules/auth/auth.service.ts
+++ b/services/api/src/modules/auth/auth.service.ts
@@ -1,0 +1,122 @@
+// AuthService — the first service-layer service (ADR-0009 layering: routes ->
+// services -> repositories). It owns the sign-in/refresh/logout *business logic*
+// and orchestrates the repos + JWT + verifier; the routes stay thin.
+//
+// Not wrapped in a DB transaction yet: on a concurrent *first* sign-in for a new
+// identity the loser may leave an orphan user row (harmless — never linked), and
+// refresh rotation revokes-then-creates (a crash mid-way just forces re-login).
+// Transactional sign-in + refresh-reuse detection are slice-3 hardening.
+
+import type { JwtService } from './jwt';
+import type { AuthIdentityRepository } from './auth-identity.repository';
+import type { IdTokenVerifier, VerifiedIdentity } from './id-token-verifier';
+import type { SessionRepository } from './session.repository';
+import { generateRefreshToken, hashToken } from './tokens';
+import type { User, UserRepository } from '../users/user.repository';
+
+export class SignInNotConfiguredError extends Error {}
+export class InvalidRefreshTokenError extends Error {}
+
+export interface AuthTokens {
+  accessToken: string;
+  refreshToken: string;
+}
+
+export interface AuthResult extends AuthTokens {
+  user: User;
+}
+
+export interface AuthServiceDeps {
+  users: UserRepository;
+  authIdentities: AuthIdentityRepository;
+  sessions: SessionRepository;
+  jwt: JwtService;
+  /** Undefined when sign-in isn't configured (e.g. prod without GOOGLE_CLIENT_ID). */
+  verifier?: IdTokenVerifier;
+  refreshTtlDays: number;
+}
+
+function isUniqueViolation(err: unknown): boolean {
+  return (err as { code?: string }).code === '23505';
+}
+
+export class AuthService {
+  constructor(private readonly deps: AuthServiceDeps) {}
+
+  /** Verify a provider ID token, find-or-create the user, and issue tokens. */
+  async signIn(idToken: string): Promise<AuthResult> {
+    if (!this.deps.verifier) {
+      throw new SignInNotConfiguredError('Sign-in is not configured');
+    }
+    const identity = await this.deps.verifier.verify(idToken); // throws if invalid
+    const user = await this.findOrCreateUser(identity);
+    const tokens = await this.issueTokens(user);
+    return { user, ...tokens };
+  }
+
+  /** Rotate a valid refresh token: revoke the old session, issue a new pair. */
+  async refresh(refreshToken: string): Promise<AuthTokens> {
+    const session = await this.deps.sessions.findByHash(hashToken(refreshToken));
+    if (!session || session.revokedAt !== null || session.expiresAt <= new Date()) {
+      throw new InvalidRefreshTokenError('Invalid or expired refresh token');
+    }
+    const user = await this.deps.users.findById(session.userId);
+    if (!user) {
+      throw new InvalidRefreshTokenError('Invalid or expired refresh token');
+    }
+    await this.deps.sessions.revoke(session.id);
+    return this.issueTokens(user, session.id);
+  }
+
+  /** Revoke the session for a refresh token. Idempotent — unknown tokens no-op. */
+  async logout(refreshToken: string): Promise<void> {
+    const session = await this.deps.sessions.findByHash(hashToken(refreshToken));
+    if (session && session.revokedAt === null) {
+      await this.deps.sessions.revoke(session.id);
+    }
+  }
+
+  private async issueTokens(user: User, rotatedFrom?: string): Promise<AuthTokens> {
+    const refresh = generateRefreshToken(this.deps.refreshTtlDays);
+    await this.deps.sessions.create({
+      userId: user.id,
+      refreshTokenHash: refresh.hash,
+      expiresAt: refresh.expiresAt,
+      rotatedFrom,
+    });
+    const accessToken = await this.deps.jwt.signAccessToken({ userId: user.id, role: user.role });
+    return { accessToken, refreshToken: refresh.token };
+  }
+
+  private async findOrCreateUser(identity: VerifiedIdentity): Promise<User> {
+    const existing = await this.deps.authIdentities.findByProvider(
+      identity.provider,
+      identity.providerId,
+    );
+    if (existing) {
+      const user = await this.deps.users.findById(existing.userId);
+      if (user) return user;
+    }
+
+    const user = await this.deps.users.create({ displayName: identity.displayName ?? 'New User' });
+    try {
+      await this.deps.authIdentities.create({
+        userId: user.id,
+        provider: identity.provider,
+        providerId: identity.providerId,
+      });
+    } catch (err) {
+      // Lost a concurrent first sign-in race — the identity now exists; reuse it.
+      if (isUniqueViolation(err)) {
+        const winner = await this.deps.authIdentities.findByProvider(
+          identity.provider,
+          identity.providerId,
+        );
+        const user2 = winner && (await this.deps.users.findById(winner.userId));
+        if (user2) return user2;
+      }
+      throw err;
+    }
+    return user;
+  }
+}

--- a/services/api/src/modules/auth/id-token-verifier.google.ts
+++ b/services/api/src/modules/auth/id-token-verifier.google.ts
@@ -1,0 +1,39 @@
+// Real Google ID-token verification: checks the signature against Google's JWKS
+// and that the token was minted for OUR client (audience) by Google (issuer).
+// Network-bound (fetches Google's keys), so excluded from unit coverage like the
+// *.pg.ts adapters — exercised via real sign-in / manual testing.
+
+import { createRemoteJWKSet, jwtVerify } from 'jose';
+import { z } from 'zod';
+import type { IdTokenVerifier, VerifiedIdentity } from './id-token-verifier';
+
+const GOOGLE_JWKS = createRemoteJWKSet(new URL('https://www.googleapis.com/oauth2/v3/certs'));
+const GOOGLE_ISSUERS = ['https://accounts.google.com', 'accounts.google.com'];
+
+const googleClaimsSchema = z.object({
+  sub: z.string().min(1),
+  email: z.string().optional(),
+  email_verified: z.boolean().optional(),
+  name: z.string().optional(),
+});
+
+export class GoogleIdTokenVerifier implements IdTokenVerifier {
+  constructor(private readonly clientId: string) {}
+
+  async verify(idToken: string): Promise<VerifiedIdentity> {
+    const { payload } = await jwtVerify(idToken, GOOGLE_JWKS, {
+      issuer: GOOGLE_ISSUERS,
+      audience: this.clientId,
+    });
+    const claims = googleClaimsSchema.parse(payload);
+    if (claims.email_verified === false) {
+      throw new Error('Google email not verified');
+    }
+    return {
+      provider: 'google',
+      providerId: claims.sub,
+      email: claims.email ?? null,
+      displayName: claims.name ?? null,
+    };
+  }
+}

--- a/services/api/src/modules/auth/id-token-verifier.ts
+++ b/services/api/src/modules/auth/id-token-verifier.ts
@@ -1,0 +1,51 @@
+// Social sign-in verification. The AuthService depends on this interface, not on
+// any provider — so Google (and later Apple) are pluggable, and tests use the
+// fake. The real Google implementation (JWKS over the network) lives in
+// id-token-verifier.google.ts. See ADR-0007.
+
+import { z } from 'zod';
+
+export type AuthProvider = 'google' | 'apple';
+
+/** The trustworthy identity extracted from a verified provider ID token. */
+export interface VerifiedIdentity {
+  provider: AuthProvider;
+  /** The provider's stable subject id (auth_identity.provider_id). */
+  providerId: string;
+  email: string | null;
+  displayName: string | null;
+}
+
+export interface IdTokenVerifier {
+  /** Resolve the identity, or reject if the token is invalid/untrusted. */
+  verify(idToken: string): Promise<VerifiedIdentity>;
+}
+
+const fakeClaimsSchema = z.object({
+  sub: z.string().min(1),
+  email: z.string().optional(),
+  name: z.string().optional(),
+});
+
+/**
+ * Dev/test verifier: the "token" is a JSON blob of claims. Lets the API and the
+ * mobile app exercise the full sign-in flow with no Google setup. NEVER used in
+ * production — the server only wires this outside production (see server.ts).
+ */
+export class FakeIdTokenVerifier implements IdTokenVerifier {
+  async verify(idToken: string): Promise<VerifiedIdentity> {
+    let raw: unknown;
+    try {
+      raw = JSON.parse(idToken);
+    } catch {
+      throw new Error('fake id token must be JSON');
+    }
+    const claims = fakeClaimsSchema.parse(raw);
+    return {
+      provider: 'google',
+      providerId: claims.sub,
+      email: claims.email ?? null,
+      displayName: claims.name ?? null,
+    };
+  }
+}

--- a/services/api/src/modules/auth/session.repository.pg.ts
+++ b/services/api/src/modules/auth/session.repository.pg.ts
@@ -1,0 +1,53 @@
+import type { Pool } from 'pg';
+import type { NewSession, Session, SessionRepository } from './session.repository';
+
+interface SessionRow {
+  id: string;
+  user_id: string;
+  refresh_token_hash: string;
+  expires_at: Date;
+  revoked_at: Date | null;
+  rotated_from: string | null;
+  created_at: Date;
+}
+
+function toSession(row: SessionRow): Session {
+  return {
+    id: row.id,
+    userId: row.user_id,
+    refreshTokenHash: row.refresh_token_hash,
+    expiresAt: row.expires_at,
+    revokedAt: row.revoked_at,
+    rotatedFrom: row.rotated_from,
+    createdAt: row.created_at,
+  };
+}
+
+export class PgSessionRepository implements SessionRepository {
+  constructor(private readonly pool: Pool) {}
+
+  async create(input: NewSession): Promise<Session> {
+    const { rows } = await this.pool.query<SessionRow>(
+      `INSERT INTO sessions (user_id, refresh_token_hash, expires_at, rotated_from)
+       VALUES ($1, $2, $3, $4)
+       RETURNING *`,
+      [input.userId, input.refreshTokenHash, input.expiresAt, input.rotatedFrom ?? null],
+    );
+    return toSession(rows[0]!);
+  }
+
+  async findByHash(refreshTokenHash: string): Promise<Session | null> {
+    const { rows } = await this.pool.query<SessionRow>(
+      `SELECT * FROM sessions WHERE refresh_token_hash = $1`,
+      [refreshTokenHash],
+    );
+    return rows[0] ? toSession(rows[0]) : null;
+  }
+
+  async revoke(id: string): Promise<void> {
+    await this.pool.query(
+      `UPDATE sessions SET revoked_at = now() WHERE id = $1 AND revoked_at IS NULL`,
+      [id],
+    );
+  }
+}

--- a/services/api/src/modules/auth/session.repository.ts
+++ b/services/api/src/modules/auth/session.repository.ts
@@ -1,0 +1,59 @@
+// Refresh-token sessions. One row per issued refresh token (stored hashed),
+// rotated on use and revocable on logout. Backs the refresh half of ADR-0007.
+
+export interface Session {
+  id: string;
+  userId: string;
+  refreshTokenHash: string;
+  expiresAt: Date;
+  revokedAt: Date | null;
+  rotatedFrom: string | null;
+  createdAt: Date;
+}
+
+export interface NewSession {
+  userId: string;
+  refreshTokenHash: string;
+  expiresAt: Date;
+  rotatedFrom?: string | null;
+}
+
+export interface SessionRepository {
+  create(input: NewSession): Promise<Session>;
+  findByHash(refreshTokenHash: string): Promise<Session | null>;
+  revoke(id: string): Promise<void>;
+}
+
+export class InMemorySessionRepository implements SessionRepository {
+  private readonly sessions = new Map<string, Session>();
+
+  async create(input: NewSession): Promise<Session> {
+    const session: Session = {
+      id: crypto.randomUUID(),
+      userId: input.userId,
+      refreshTokenHash: input.refreshTokenHash,
+      expiresAt: input.expiresAt,
+      revokedAt: null,
+      rotatedFrom: input.rotatedFrom ?? null,
+      createdAt: new Date(),
+    };
+    this.sessions.set(session.id, session);
+    return session;
+  }
+
+  async findByHash(refreshTokenHash: string): Promise<Session | null> {
+    for (const session of this.sessions.values()) {
+      if (session.refreshTokenHash === refreshTokenHash) {
+        return session;
+      }
+    }
+    return null;
+  }
+
+  async revoke(id: string): Promise<void> {
+    const session = this.sessions.get(id);
+    if (session && !session.revokedAt) {
+      session.revokedAt = new Date();
+    }
+  }
+}

--- a/services/api/src/modules/auth/tokens.ts
+++ b/services/api/src/modules/auth/tokens.ts
@@ -1,0 +1,26 @@
+// Refresh-token helpers. The raw token is returned to the client exactly once;
+// only its SHA-256 hash is stored (sessions.refresh_token_hash), so a database
+// leak never exposes usable tokens. See ADR-0007.
+
+import { createHash, randomBytes } from 'node:crypto';
+
+export function hashToken(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}
+
+export interface GeneratedRefreshToken {
+  /** Raw token — returned to the client, never persisted. */
+  token: string;
+  /** SHA-256 of the token — what we store and look up by. */
+  hash: string;
+  expiresAt: Date;
+}
+
+export function generateRefreshToken(ttlDays: number): GeneratedRefreshToken {
+  const token = randomBytes(32).toString('base64url');
+  return {
+    token,
+    hash: hashToken(token),
+    expiresAt: new Date(Date.now() + ttlDays * 24 * 60 * 60 * 1000),
+  };
+}

--- a/services/api/src/server.ts
+++ b/services/api/src/server.ts
@@ -5,7 +5,20 @@ import { loadEnv } from './config/env';
 import { createPool } from './db/pool';
 import { InMemoryKvStore, type KvStore } from './kv/kv.store';
 import { RedisKvStore } from './kv/kv.store.redis';
-import { DEV_AUTH_CONFIG, type AuthConfig } from './modules/auth/jwt';
+import {
+  InMemoryAuthIdentityRepository,
+  type AuthIdentityRepository,
+} from './modules/auth/auth-identity.repository';
+import { PgAuthIdentityRepository } from './modules/auth/auth-identity.repository.pg';
+import { AuthService } from './modules/auth/auth.service';
+import { FakeIdTokenVerifier, type IdTokenVerifier } from './modules/auth/id-token-verifier';
+import { GoogleIdTokenVerifier } from './modules/auth/id-token-verifier.google';
+import { createJwtService, DEV_AUTH_CONFIG, type AuthConfig } from './modules/auth/jwt';
+import {
+  InMemorySessionRepository,
+  type SessionRepository,
+} from './modules/auth/session.repository';
+import { PgSessionRepository } from './modules/auth/session.repository.pg';
 import type { RateLimitConfig } from './modules/ratelimit/ratelimit.plugin';
 import {
   InMemorySubscriptionRepository,
@@ -41,16 +54,44 @@ async function main(): Promise<void> {
   let pool: Pool | undefined;
   let users: UserRepository;
   let subscriptions: SubscriptionRepository;
+  let sessions: SessionRepository;
+  let authIdentities: AuthIdentityRepository;
   if (env.DATABASE_URL) {
     pool = createPool(env.DATABASE_URL);
     users = new PgUserRepository(pool);
     subscriptions = new PgSubscriptionRepository(pool);
+    sessions = new PgSessionRepository(pool);
+    authIdentities = new PgAuthIdentityRepository(pool);
     console.log('Using Postgres repositories');
   } else {
     users = new InMemoryUserRepository();
     subscriptions = new InMemorySubscriptionRepository();
+    sessions = new InMemorySessionRepository();
+    authIdentities = new InMemoryAuthIdentityRepository();
     console.log('Using in-memory repositories (no DATABASE_URL set)');
   }
+
+  // Sign-in verifier: real Google when configured; a dev fake outside production;
+  // otherwise undefined (POST /auth/google returns 503 — keeps staging booting).
+  let verifier: IdTokenVerifier | undefined;
+  if (env.GOOGLE_CLIENT_ID) {
+    verifier = new GoogleIdTokenVerifier(env.GOOGLE_CLIENT_ID);
+    console.log('Using Google ID-token verifier');
+  } else if (env.NODE_ENV !== 'production') {
+    verifier = new FakeIdTokenVerifier();
+    console.warn('GOOGLE_CLIENT_ID not set — using FAKE sign-in verifier (non-production only).');
+  } else {
+    console.warn('GOOGLE_CLIENT_ID not set — sign-in disabled (POST /auth/google returns 503).');
+  }
+
+  const authService = new AuthService({
+    users,
+    authIdentities,
+    sessions,
+    jwt: createJwtService(auth),
+    verifier,
+    refreshTtlDays: env.JWT_REFRESH_TTL_DAYS,
+  });
 
   // Readiness pings every configured backing service (DB + KV).
   const isReady = async (): Promise<boolean> => {
@@ -69,7 +110,16 @@ async function main(): Promise<void> {
     windowSeconds: env.RATE_LIMIT_WINDOW_SECONDS,
   };
 
-  const app = await buildApp({ users, subscriptions, kv, isReady, auth, rateLimit, logger: true });
+  const app = await buildApp({
+    users,
+    subscriptions,
+    authService,
+    kv,
+    isReady,
+    auth,
+    rateLimit,
+    logger: true,
+  });
 
   const shutdown = async (signal: string): Promise<void> => {
     app.log.info(`Received ${signal}, shutting down`);

--- a/services/api/tests/auth.service.test.ts
+++ b/services/api/tests/auth.service.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from 'vitest';
+import {
+  InMemoryAuthIdentityRepository,
+  type AuthIdentityRepository,
+} from '../src/modules/auth/auth-identity.repository';
+import {
+  AuthService,
+  InvalidRefreshTokenError,
+  SignInNotConfiguredError,
+} from '../src/modules/auth/auth.service';
+import { FakeIdTokenVerifier } from '../src/modules/auth/id-token-verifier';
+import { createJwtService, type AuthConfig } from '../src/modules/auth/jwt';
+import { InMemorySessionRepository } from '../src/modules/auth/session.repository';
+import { hashToken } from '../src/modules/auth/tokens';
+import { InMemoryUserRepository } from '../src/modules/users/user.repository';
+
+const authConfig: AuthConfig = {
+  secret: 'test-secret-at-least-32-characters-long-0000',
+  accessTtl: '15m',
+  issuer: 'trotxi',
+  audience: 'trotxi-api',
+};
+const jwt = createJwtService(authConfig);
+const googleToken = (sub: string, name = 'Ama') =>
+  JSON.stringify({ sub, name, email: `${sub}@example.com` });
+
+function makeService() {
+  const users = new InMemoryUserRepository();
+  const authIdentities = new InMemoryAuthIdentityRepository();
+  const sessions = new InMemorySessionRepository();
+  const service = new AuthService({
+    users,
+    authIdentities,
+    sessions,
+    jwt,
+    verifier: new FakeIdTokenVerifier(),
+    refreshTtlDays: 30,
+  });
+  return { users, authIdentities, sessions, service };
+}
+
+describe('AuthService.signIn', () => {
+  it('creates user + identity + session and issues verifiable tokens', async () => {
+    const { service, users, sessions } = makeService();
+    const result = await service.signIn(googleToken('g-1'));
+
+    expect(result.user.displayName).toBe('Ama');
+    expect(await users.findById(result.user.id)).not.toBeNull();
+    expect(await jwt.verifyAccessToken(result.accessToken)).toEqual({
+      userId: result.user.id,
+      role: 'commuter',
+    });
+    expect(await sessions.findByHash(hashToken(result.refreshToken))).not.toBeNull();
+  });
+
+  it('falls back to a default display name when the provider returns no name', async () => {
+    const { service } = makeService();
+    const result = await service.signIn(JSON.stringify({ sub: 'g-min' }));
+    expect(result.user.displayName).toBe('New User');
+  });
+
+  it('reuses the same user on repeat sign-in with the same identity', async () => {
+    const { service } = makeService();
+    const a = await service.signIn(googleToken('g-1'));
+    const b = await service.signIn(googleToken('g-1'));
+    expect(b.user.id).toBe(a.user.id);
+  });
+
+  it('throws when no verifier is configured', async () => {
+    const service = new AuthService({
+      users: new InMemoryUserRepository(),
+      authIdentities: new InMemoryAuthIdentityRepository(),
+      sessions: new InMemorySessionRepository(),
+      jwt,
+      refreshTtlDays: 30,
+    });
+    await expect(service.signIn(googleToken('g-1'))).rejects.toBeInstanceOf(
+      SignInNotConfiguredError,
+    );
+  });
+
+  it('rejects an invalid id token', async () => {
+    const { service } = makeService();
+    await expect(service.signIn('not-json')).rejects.toThrow();
+  });
+
+  it('recovers from a concurrent first-sign-in race (unique violation)', async () => {
+    const users = new InMemoryUserRepository();
+    const winner = await users.create({ displayName: 'Winner' });
+    let raced = false;
+    const authIdentities: AuthIdentityRepository = {
+      findByProvider: async (provider, providerId) =>
+        raced ? { id: 'x', userId: winner.id, provider, providerId, createdAt: new Date() } : null,
+      create: async () => {
+        raced = true; // the "winner" created it between our check and our insert
+        throw Object.assign(new Error('duplicate'), { code: '23505' });
+      },
+    };
+    const service = new AuthService({
+      users,
+      authIdentities,
+      sessions: new InMemorySessionRepository(),
+      jwt,
+      verifier: new FakeIdTokenVerifier(),
+      refreshTtlDays: 30,
+    });
+
+    const result = await service.signIn(googleToken('g-1'));
+    expect(result.user.id).toBe(winner.id);
+  });
+
+  it('propagates non-unique errors from identity creation', async () => {
+    const authIdentities: AuthIdentityRepository = {
+      findByProvider: async () => null,
+      create: async () => {
+        throw new Error('db down');
+      },
+    };
+    const service = new AuthService({
+      users: new InMemoryUserRepository(),
+      authIdentities,
+      sessions: new InMemorySessionRepository(),
+      jwt,
+      verifier: new FakeIdTokenVerifier(),
+      refreshTtlDays: 30,
+    });
+    await expect(service.signIn(googleToken('g-1'))).rejects.toThrow('db down');
+  });
+});
+
+describe('AuthService.refresh', () => {
+  it('rotates: issues new tokens and invalidates the old refresh token', async () => {
+    const { service } = makeService();
+    const { refreshToken } = await service.signIn(googleToken('g-1'));
+
+    const rotated = await service.refresh(refreshToken);
+    expect(rotated.accessToken).toBeTruthy();
+    expect(rotated.refreshToken).not.toBe(refreshToken);
+
+    await expect(service.refresh(refreshToken)).rejects.toBeInstanceOf(InvalidRefreshTokenError);
+    expect((await service.refresh(rotated.refreshToken)).accessToken).toBeTruthy();
+  });
+
+  it('rejects an unknown refresh token', async () => {
+    const { service } = makeService();
+    await expect(service.refresh('nope')).rejects.toBeInstanceOf(InvalidRefreshTokenError);
+  });
+
+  it('rejects an expired session', async () => {
+    const { service, users, sessions } = makeService();
+    const user = await users.create({ displayName: 'Old' });
+    const raw = 'expired-token';
+    await sessions.create({
+      userId: user.id,
+      refreshTokenHash: hashToken(raw),
+      expiresAt: new Date(Date.now() - 1000),
+    });
+    await expect(service.refresh(raw)).rejects.toBeInstanceOf(InvalidRefreshTokenError);
+  });
+});
+
+describe('AuthService.logout', () => {
+  it('revokes the session so the refresh token stops working', async () => {
+    const { service } = makeService();
+    const { refreshToken } = await service.signIn(googleToken('g-1'));
+    await service.logout(refreshToken);
+    await expect(service.refresh(refreshToken)).rejects.toBeInstanceOf(InvalidRefreshTokenError);
+  });
+
+  it('is a no-op for an unknown token', async () => {
+    const { service } = makeService();
+    await expect(service.logout('whatever')).resolves.toBeUndefined();
+  });
+});

--- a/services/api/tests/auth.signin.test.ts
+++ b/services/api/tests/auth.signin.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from 'vitest';
+import { buildApp } from '../src/app';
+import { InMemoryAuthIdentityRepository } from '../src/modules/auth/auth-identity.repository';
+import { AuthService } from '../src/modules/auth/auth.service';
+import { FakeIdTokenVerifier } from '../src/modules/auth/id-token-verifier';
+import { createJwtService, type AuthConfig } from '../src/modules/auth/jwt';
+import { InMemorySessionRepository } from '../src/modules/auth/session.repository';
+import { InMemoryUserRepository } from '../src/modules/users/user.repository';
+
+const auth: AuthConfig = {
+  secret: 'test-secret-at-least-32-characters-long-0000',
+  accessTtl: '15m',
+  issuer: 'trotxi',
+  audience: 'trotxi-api',
+};
+const googleToken = (sub: string) => JSON.stringify({ sub, name: 'Ama', email: `${sub}@x.com` });
+
+async function appWithAuth() {
+  const users = new InMemoryUserRepository();
+  const authService = new AuthService({
+    users,
+    authIdentities: new InMemoryAuthIdentityRepository(),
+    sessions: new InMemorySessionRepository(),
+    jwt: createJwtService(auth),
+    verifier: new FakeIdTokenVerifier(),
+    refreshTtlDays: 30,
+  });
+  return buildApp({ auth, users, authService });
+}
+
+describe('POST /auth/google', () => {
+  it('signs in, returns user + tokens, and the access token works on /me', async () => {
+    const app = await appWithAuth();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/auth/google',
+      payload: { idToken: googleToken('g-1') },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.user).toMatchObject({ displayName: 'Ama', role: 'commuter' });
+    expect(body.accessToken).toBeTruthy();
+    expect(body.refreshToken).toBeTruthy();
+
+    const me = await app.inject({
+      method: 'GET',
+      url: '/me',
+      headers: { authorization: `Bearer ${body.accessToken}` },
+    });
+    expect(me.statusCode).toBe(200);
+    expect(me.json()).toMatchObject({ id: body.user.id });
+  });
+
+  it('rejects an invalid id token with 401', async () => {
+    const app = await appWithAuth();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/auth/google',
+      payload: { idToken: 'not-json' },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('returns 503 when no auth service is wired', async () => {
+    const app = await buildApp({ auth });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/auth/google',
+      payload: { idToken: googleToken('g-1') },
+    });
+    expect(res.statusCode).toBe(503);
+  });
+
+  it('returns 503 when the service has no verifier configured', async () => {
+    const authService = new AuthService({
+      users: new InMemoryUserRepository(),
+      authIdentities: new InMemoryAuthIdentityRepository(),
+      sessions: new InMemorySessionRepository(),
+      jwt: createJwtService(auth),
+      refreshTtlDays: 30,
+    });
+    const app = await buildApp({ auth, authService });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/auth/google',
+      payload: { idToken: googleToken('g-1') },
+    });
+    expect(res.statusCode).toBe(503);
+  });
+});
+
+describe('POST /auth/refresh and /auth/logout', () => {
+  it('rotates tokens and rejects reuse of the old refresh token', async () => {
+    const app = await appWithAuth();
+    const signin = (
+      await app.inject({
+        method: 'POST',
+        url: '/auth/google',
+        payload: { idToken: googleToken('g-1') },
+      })
+    ).json();
+
+    const refreshed = await app.inject({
+      method: 'POST',
+      url: '/auth/refresh',
+      payload: { refreshToken: signin.refreshToken },
+    });
+    expect(refreshed.statusCode).toBe(200);
+    expect(refreshed.json().refreshToken).not.toBe(signin.refreshToken);
+
+    const reuse = await app.inject({
+      method: 'POST',
+      url: '/auth/refresh',
+      payload: { refreshToken: signin.refreshToken },
+    });
+    expect(reuse.statusCode).toBe(401);
+  });
+
+  it('logout revokes the token (204) and refresh then fails', async () => {
+    const app = await appWithAuth();
+    const signin = (
+      await app.inject({
+        method: 'POST',
+        url: '/auth/google',
+        payload: { idToken: googleToken('g-1') },
+      })
+    ).json();
+
+    const out = await app.inject({
+      method: 'POST',
+      url: '/auth/logout',
+      payload: { refreshToken: signin.refreshToken },
+    });
+    expect(out.statusCode).toBe(204);
+
+    const after = await app.inject({
+      method: 'POST',
+      url: '/auth/refresh',
+      payload: { refreshToken: signin.refreshToken },
+    });
+    expect(after.statusCode).toBe(401);
+  });
+
+  it('refresh returns 503 and logout returns 204 when no auth service is wired', async () => {
+    const app = await buildApp({ auth });
+    const refresh = await app.inject({
+      method: 'POST',
+      url: '/auth/refresh',
+      payload: { refreshToken: 'x' },
+    });
+    expect(refresh.statusCode).toBe(503);
+    const logout = await app.inject({
+      method: 'POST',
+      url: '/auth/logout',
+      payload: { refreshToken: 'x' },
+    });
+    expect(logout.statusCode).toBe(204);
+  });
+});

--- a/services/api/tests/env.test.ts
+++ b/services/api/tests/env.test.ts
@@ -5,6 +5,7 @@ const DEFAULTS = {
   JWT_ACCESS_TTL: '15m',
   JWT_ISSUER: 'trotxi',
   JWT_AUDIENCE: 'trotxi-api',
+  JWT_REFRESH_TTL_DAYS: 30,
   RATE_LIMIT_MAX: 100,
   RATE_LIMIT_WINDOW_SECONDS: 60,
 };

--- a/services/api/tests/tokens.test.ts
+++ b/services/api/tests/tokens.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { generateRefreshToken, hashToken } from '../src/modules/auth/tokens';
+
+describe('tokens', () => {
+  it('hashToken is a deterministic sha256 hex digest', () => {
+    expect(hashToken('abc')).toBe(hashToken('abc'));
+    expect(hashToken('abc')).toMatch(/^[0-9a-f]{64}$/);
+    expect(hashToken('abc')).not.toBe(hashToken('abd'));
+  });
+
+  it('generateRefreshToken returns a token whose hash matches, with a future expiry', () => {
+    const r = generateRefreshToken(30);
+    expect(r.token).toBeTruthy();
+    expect(r.hash).toBe(hashToken(r.token));
+    expect(r.expiresAt.getTime()).toBeGreaterThan(Date.now());
+  });
+
+  it('generates a unique token each call', () => {
+    expect(generateRefreshToken(1).token).not.toBe(generateRefreshToken(1).token);
+  });
+});

--- a/services/api/vitest.config.ts
+++ b/services/api/vitest.config.ts
@@ -10,7 +10,13 @@ export default defineConfig({
       // The entrypoint, *.pg.ts repositories, and db scripts run only against
       // real infrastructure — the e2e suite covers those. The unit gate applies
       // to the logic layer (services + in-memory repos).
-      exclude: ['src/server.ts', 'src/db/**', 'src/**/*.pg.ts', 'src/**/*.redis.ts'],
+      exclude: [
+        'src/server.ts',
+        'src/db/**',
+        'src/**/*.pg.ts',
+        'src/**/*.redis.ts',
+        'src/**/*.google.ts',
+      ],
       thresholds: {
         lines: 80,
         functions: 80,


### PR DESCRIPTION
## What
Completes the auth spine ([#16](https://github.com/TROTXI/mobility-core/issues/16)) — the **refresh/session half of ADR-0007** — and stands up the **first service-layer service** (ADR-0009): `routes → AuthService → repositories`. Closes the "auth is half-built" gap in STATUS.md.

### The service
**`AuthService`** owns the logic; routes are thin:
- `signIn(idToken)` → verify ID token → **find-or-create** user + `auth_identity` → create `session` (hashed refresh token) → issue access + refresh.
- `refresh(token)` → validate → **rotate** (revoke old, issue new).
- `logout(token)` → revoke (idempotent).

### Pluggable verifier (this is why we're not blocked on Google)
`IdTokenVerifier` interface with:
- **`GoogleIdTokenVerifier`** — jose JWKS, verifies signature + issuer + audience (`GOOGLE_CLIENT_ID`). Excluded from unit coverage (network), like `*.pg.ts`.
- **`FakeIdTokenVerifier`** — dev/test only.

Wired by env in `server.ts`: **Google** when `GOOGLE_CLIENT_ID` is set → **fake** outside production → otherwise `POST /auth/google` returns **503** (so staging keeps booting — no `JWT_SECRET`-style surprise).

### Endpoints (zod/OpenAPI, per-IP rate-limited)
`POST /auth/google`, `POST /auth/refresh`, `POST /auth/logout`. Refresh tokens are random, **stored only as a SHA-256 hash** (`sessions.refresh_token_hash`), rotated on use, revocable on logout.

### Also
- `SessionRepository` (finally uses the `sessions` table) + `AuthIdentityRepository` (`auth_identity`), in-memory + Postgres.
- env: `GOOGLE_CLIENT_ID`, `JWT_REFRESH_TTL_DAYS` (default 30).

## Deliberate scope / tradeoffs
- **No cross-repo DB transaction yet:** a concurrent *first* sign-in race can leave an orphan user row (harmless — never linked; we catch the unique violation and reuse the winner). Refresh rotation is revoke-then-create (a crash mid-way just forces re-login). **Transactional sign-in + refresh-reuse detection are slice-3 hardening.**
- **Apple** deferred (paid Apple Developer account) — the verifier interface makes it a drop-in later.

## Verification
- `pnpm check` green; **76 tests, ~99% coverage** (service + routes + tokens).
- **Live HTTP smoke:** sign-in → `/me` → refresh → reuse-old-rejected(401) → logout(204) → refresh-after-logout(401). ✅

## Action to flip on real Google (your end)
Set **`GOOGLE_CLIENT_ID`** (the Google "Web" client ID) in env + Render. Until then dev uses the fake verifier and staging returns 503 on `/auth/google` — both safe. No client *secret* needed (we only verify the ID token).

Closes #16