### PR TITLE
feat(api): append-only token ledger + GET /me/balance (#21a)

### DIFF
--- a/docs/adr/0011-token-ledger.md
+++ b/docs/adr/0011-token-ledger.md
@@ -1,0 +1,44 @@
+# ADR-0011 — Append-only token ledger (the GHS wallet)
+
+**Status:** accepted · **Date:** 2026-06-27
+
+## Context
+
+Trotxi is a prepaid product: a subscription payment grants **GHS-denominated
+tokens** (1 token = 1 GHS) that a rider spends on trotro fares. This is money, so
+correctness and auditability are non-negotiable. A mutable `token_balance`
+column is the classic way to lose money — concurrent boardings race, a crash
+mid-update corrupts it, and there is no audit trail. Full rationale lives in the
+strategy repo (`system-design §4.1`, `security §7`); this ADR records the
+decision in the repo where the code lives (#21).
+
+## Decision
+
+Model the wallet as an **append-only `token_ledger`**, not a balance column:
+
+- Every grant (+) and spend (−) is **one immutable row**; **balance = `SUM(delta)`**
+  (derived; may be cached later but is never the source of truth).
+- **Exactly-once writes** via a unique `idempotency_key` — a retried grant/debit
+  is a no-op, never a double-write.
+- **Fail-safe money** (lands with the consumers, not this PR):
+  - **Debits** (boarding, #20) run a `balance ≥ 0` guard **inside one
+    serializable transaction**.
+  - **Payments** (#21b) are a state machine (`pending → paid|failed`), **never
+    mutated once `paid`**, fed by **signature-verified, idempotent webhooks**;
+    nightly reconciliation against the aggregator.
+- Full money history is reconstructable per user (audit + Act 843).
+
+**Scope:** this PR (#21a) ships the **ledger + derived balance** (`GET
+/me/balance`). **Grants** come from payments (#21b); **debits** from boarding
+(#20). The earlier "hold-half / charge-at-scan split" is **dropped** — we charge
+once, at commit (system-design §4.3).
+
+## Consequences
+
+- Reads compute `SUM(delta)`; introduce a cached balance only as an optimization,
+  never as the truth.
+- The `idempotency_key` unique constraint is the backbone of no-double-spend /
+  no-double-grant — every money mutation must supply a meaningful key.
+- The in-memory repo mirrors the shape for tests/dev but the **database enforces**
+  the uniqueness + checks (ADR-0009); money paths are validated against real
+  Postgres (e2e), not the in-memory stand-in.

--- a/services/api/src/app.ts
+++ b/services/api/src/app.ts
@@ -9,6 +9,8 @@ import {
 } from 'fastify-type-provider-zod';
 import { z } from 'zod';
 import { InMemoryKvStore, type KvStore } from './kv/kv.store';
+import { ledgerRoutes } from './modules/ledger/ledger.routes';
+import type { LedgerRepository } from './modules/ledger/ledger.repository';
 import { authPlugin } from './modules/auth/auth.plugin';
 import { authRoutes } from './modules/auth/auth.routes';
 import type { AuthService } from './modules/auth/auth.service';
@@ -33,6 +35,8 @@ export interface AppDeps {
   users?: UserRepository;
   /** Selected by DATABASE_URL (in-memory vs Postgres). Consumed by routes/services. */
   subscriptions?: SubscriptionRepository;
+  /** Token wallet ledger (in-memory vs Postgres). Derived balance + grants/debits. */
+  ledger?: LedgerRepository;
   /** Selected by REDIS_URL (in-memory vs Redis). For rate limits, idempotency, cache. */
   kv?: KvStore;
   /** JWT/auth settings. Defaults to a dev-only config when unset (tests, local). */
@@ -68,6 +72,7 @@ export async function buildApp(deps: AppDeps = {}): Promise<FastifyInstance> {
       tags: [
         { name: 'system', description: 'Health, readiness, and service metadata' },
         { name: 'auth', description: 'Authentication and the current user' },
+        { name: 'wallet', description: 'Token wallet / GHS balance' },
       ],
       components: {
         // Protected routes set `security: [{ bearerAuth: [] }]`; clients send
@@ -88,6 +93,10 @@ export async function buildApp(deps: AppDeps = {}): Promise<FastifyInstance> {
   await app.register(authRoutes, {
     users: deps.users,
     authService: deps.authService,
+    rateLimit: deps.rateLimit ?? DEFAULT_RATE_LIMIT,
+  });
+  await app.register(ledgerRoutes, {
+    ledger: deps.ledger,
     rateLimit: deps.rateLimit ?? DEFAULT_RATE_LIMIT,
   });
 

--- a/services/api/src/db/migrations/006_token_ledger.sql
+++ b/services/api/src/db/migrations/006_token_ledger.sql
@@ -1,0 +1,15 @@
+-- 006_token_ledger: the rider's GHS wallet as an append-only ledger.
+-- Balance is SUM(delta), never a mutable column (system-design §4.1). Tokens are
+-- pegged 1:1 to GHS. Every grant (+) and spend (-) is one immutable row.
+
+CREATE TABLE IF NOT EXISTS token_ledger (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id         uuid NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+  delta           integer NOT NULL,        -- GHS-denominated: +250 grant, -3 fare
+  reason          text NOT NULL CHECK (reason IN ('subscription_grant', 'boarding', 'refund')),
+  ref_type        text NOT NULL CHECK (ref_type IN ('payment', 'boarding')),
+  ref_id          uuid,
+  idempotency_key text NOT NULL UNIQUE,     -- exactly-once writes (retries are no-ops)
+  created_at      timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_token_ledger_user ON token_ledger (user_id);

--- a/services/api/src/modules/ledger/ledger.repository.pg.ts
+++ b/services/api/src/modules/ledger/ledger.repository.pg.ts
@@ -1,0 +1,69 @@
+import type { Pool } from 'pg';
+import type {
+  LedgerEntry,
+  LedgerReason,
+  LedgerRefType,
+  LedgerRepository,
+  NewLedgerEntry,
+} from './ledger.repository';
+
+interface LedgerRow {
+  id: string;
+  user_id: string;
+  delta: number;
+  reason: LedgerReason;
+  ref_type: LedgerRefType;
+  ref_id: string | null;
+  idempotency_key: string;
+  created_at: Date;
+}
+
+function toEntry(row: LedgerRow): LedgerEntry {
+  return {
+    id: row.id,
+    userId: row.user_id,
+    delta: row.delta,
+    reason: row.reason,
+    refType: row.ref_type,
+    refId: row.ref_id,
+    idempotencyKey: row.idempotency_key,
+    createdAt: row.created_at,
+  };
+}
+
+export class PgLedgerRepository implements LedgerRepository {
+  constructor(private readonly pool: Pool) {}
+
+  async append(input: NewLedgerEntry): Promise<LedgerEntry> {
+    // Exactly-once: the unique idempotency_key makes a retried write a no-op.
+    const { rows } = await this.pool.query<LedgerRow>(
+      `INSERT INTO token_ledger (user_id, delta, reason, ref_type, ref_id, idempotency_key)
+       VALUES ($1, $2, $3, $4, $5, $6)
+       ON CONFLICT (idempotency_key) DO NOTHING
+       RETURNING *`,
+      [
+        input.userId,
+        input.delta,
+        input.reason,
+        input.refType,
+        input.refId ?? null,
+        input.idempotencyKey,
+      ],
+    );
+    if (rows[0]) return toEntry(rows[0]);
+
+    const existing = await this.pool.query<LedgerRow>(
+      `SELECT * FROM token_ledger WHERE idempotency_key = $1`,
+      [input.idempotencyKey],
+    );
+    return toEntry(existing.rows[0]!);
+  }
+
+  async balanceOf(userId: string): Promise<number> {
+    const { rows } = await this.pool.query<{ balance: number }>(
+      `SELECT COALESCE(SUM(delta), 0)::int AS balance FROM token_ledger WHERE user_id = $1`,
+      [userId],
+    );
+    return rows[0]!.balance;
+  }
+}

--- a/services/api/src/modules/ledger/ledger.repository.ts
+++ b/services/api/src/modules/ledger/ledger.repository.ts
@@ -1,0 +1,64 @@
+// Token ledger — the rider's GHS wallet (system-design §4.1, ADR-0011).
+// Append-only: every entry is immutable; the balance is the SUM of deltas, never
+// a stored column. Writes are exactly-once via idempotency_key, so a retried
+// grant or debit is a no-op rather than a double-spend.
+
+export type LedgerReason = 'subscription_grant' | 'boarding' | 'refund';
+export type LedgerRefType = 'payment' | 'boarding';
+
+export interface LedgerEntry {
+  id: string;
+  userId: string;
+  /** GHS-denominated: positive for grants, negative for spends. */
+  delta: number;
+  reason: LedgerReason;
+  refType: LedgerRefType;
+  refId: string | null;
+  idempotencyKey: string;
+  createdAt: Date;
+}
+
+export interface NewLedgerEntry {
+  userId: string;
+  delta: number;
+  reason: LedgerReason;
+  refType: LedgerRefType;
+  refId?: string | null;
+  idempotencyKey: string;
+}
+
+export interface LedgerRepository {
+  /** Append an entry; if the idempotency key already exists, return the existing
+   *  row unchanged (idempotent — no second write). */
+  append(entry: NewLedgerEntry): Promise<LedgerEntry>;
+  /** Derived balance for a user = SUM(delta). 0 when there are no entries. */
+  balanceOf(userId: string): Promise<number>;
+}
+
+export class InMemoryLedgerRepository implements LedgerRepository {
+  private readonly entries: LedgerEntry[] = [];
+  private readonly byKey = new Map<string, LedgerEntry>();
+
+  async append(input: NewLedgerEntry): Promise<LedgerEntry> {
+    const existing = this.byKey.get(input.idempotencyKey);
+    if (existing) return existing;
+
+    const entry: LedgerEntry = {
+      id: crypto.randomUUID(),
+      userId: input.userId,
+      delta: input.delta,
+      reason: input.reason,
+      refType: input.refType,
+      refId: input.refId ?? null,
+      idempotencyKey: input.idempotencyKey,
+      createdAt: new Date(),
+    };
+    this.entries.push(entry);
+    this.byKey.set(entry.idempotencyKey, entry);
+    return entry;
+  }
+
+  async balanceOf(userId: string): Promise<number> {
+    return this.entries.filter((e) => e.userId === userId).reduce((sum, e) => sum + e.delta, 0);
+  }
+}

--- a/services/api/src/modules/ledger/ledger.routes.ts
+++ b/services/api/src/modules/ledger/ledger.routes.ts
@@ -1,0 +1,35 @@
+// Wallet routes. GET /me/balance exposes the rider's derived GHS balance (the
+// home screen, app #35). Read-only here; grants come from payments (#21b),
+// debits from boarding (#20).
+
+import type { FastifyInstance } from 'fastify';
+import type { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { errorResponseSchema } from '../../lib/schemas';
+import type { RateLimitConfig } from '../ratelimit/ratelimit.plugin';
+import type { LedgerRepository } from './ledger.repository';
+import { balanceResponseSchema } from './ledger.schema';
+
+export async function ledgerRoutes(
+  app: FastifyInstance,
+  opts: { ledger?: LedgerRepository; rateLimit: RateLimitConfig },
+): Promise<void> {
+  app.withTypeProvider<ZodTypeProvider>().get(
+    '/me/balance',
+    {
+      schema: {
+        tags: ['wallet'],
+        summary: 'Get the authenticated rider GHS token balance',
+        security: [{ bearerAuth: [] }],
+        response: {
+          200: balanceResponseSchema,
+          401: errorResponseSchema,
+        },
+      },
+      preHandler: [app.authenticate, app.rateLimit({ ...opts.rateLimit, by: 'user' })],
+    },
+    async (request) => {
+      const balanceGhs = opts.ledger ? await opts.ledger.balanceOf(request.user!.id) : 0;
+      return { balanceGhs };
+    },
+  );
+}

--- a/services/api/src/modules/ledger/ledger.schema.ts
+++ b/services/api/src/modules/ledger/ledger.schema.ts
@@ -1,0 +1,6 @@
+import { z } from 'zod';
+
+export const balanceResponseSchema = z.object({
+  /** Remaining GHS value of the rider's tokens (1 token = 1 GHS). */
+  balanceGhs: z.number().int(),
+});

--- a/services/api/src/server.ts
+++ b/services/api/src/server.ts
@@ -25,6 +25,11 @@ import {
   type SubscriptionRepository,
 } from './modules/subscriptions/subscription.repository';
 import { PgSubscriptionRepository } from './modules/subscriptions/subscription.repository.pg';
+import {
+  InMemoryLedgerRepository,
+  type LedgerRepository,
+} from './modules/ledger/ledger.repository';
+import { PgLedgerRepository } from './modules/ledger/ledger.repository.pg';
 import { InMemoryUserRepository, type UserRepository } from './modules/users/user.repository';
 import { PgUserRepository } from './modules/users/user.repository.pg';
 
@@ -56,18 +61,21 @@ async function main(): Promise<void> {
   let subscriptions: SubscriptionRepository;
   let sessions: SessionRepository;
   let authIdentities: AuthIdentityRepository;
+  let ledger: LedgerRepository;
   if (env.DATABASE_URL) {
     pool = createPool(env.DATABASE_URL);
     users = new PgUserRepository(pool);
     subscriptions = new PgSubscriptionRepository(pool);
     sessions = new PgSessionRepository(pool);
     authIdentities = new PgAuthIdentityRepository(pool);
+    ledger = new PgLedgerRepository(pool);
     console.log('Using Postgres repositories');
   } else {
     users = new InMemoryUserRepository();
     subscriptions = new InMemorySubscriptionRepository();
     sessions = new InMemorySessionRepository();
     authIdentities = new InMemoryAuthIdentityRepository();
+    ledger = new InMemoryLedgerRepository();
     console.log('Using in-memory repositories (no DATABASE_URL set)');
   }
 
@@ -113,6 +121,7 @@ async function main(): Promise<void> {
   const app = await buildApp({
     users,
     subscriptions,
+    ledger,
     authService,
     kv,
     isReady,

--- a/services/api/tests/ledger.repository.test.ts
+++ b/services/api/tests/ledger.repository.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { InMemoryLedgerRepository } from '../src/modules/ledger/ledger.repository';
+
+describe('InMemoryLedgerRepository', () => {
+  it('appends an entry', async () => {
+    const ledger = new InMemoryLedgerRepository();
+    const entry = await ledger.append({
+      userId: 'u1',
+      delta: 250,
+      reason: 'subscription_grant',
+      refType: 'payment',
+      refId: 'pay-1',
+      idempotencyKey: 'grant:pay-1',
+    });
+    expect(entry.id).toBeTruthy();
+    expect(entry.delta).toBe(250);
+    expect(entry.reason).toBe('subscription_grant');
+    expect(entry.createdAt).toBeInstanceOf(Date);
+  });
+
+  it('is idempotent — a repeated key returns the existing entry and does not double-count', async () => {
+    const ledger = new InMemoryLedgerRepository();
+    const first = await ledger.append({
+      userId: 'u1',
+      delta: 250,
+      reason: 'subscription_grant',
+      refType: 'payment',
+      idempotencyKey: 'grant:pay-1',
+    });
+    const again = await ledger.append({
+      userId: 'u1',
+      delta: 250,
+      reason: 'subscription_grant',
+      refType: 'payment',
+      idempotencyKey: 'grant:pay-1',
+    });
+    expect(again.id).toBe(first.id);
+    expect(await ledger.balanceOf('u1')).toBe(250); // not 500
+  });
+
+  it('derives balance as the sum of deltas (grants and debits)', async () => {
+    const ledger = new InMemoryLedgerRepository();
+    await ledger.append({
+      userId: 'u1',
+      delta: 250,
+      reason: 'subscription_grant',
+      refType: 'payment',
+      idempotencyKey: 'k1',
+    });
+    await ledger.append({
+      userId: 'u1',
+      delta: -3,
+      reason: 'boarding',
+      refType: 'boarding',
+      idempotencyKey: 'k2',
+    });
+    expect(await ledger.balanceOf('u1')).toBe(247);
+  });
+
+  it('returns 0 for a user with no entries', async () => {
+    const ledger = new InMemoryLedgerRepository();
+    expect(await ledger.balanceOf('nobody')).toBe(0);
+  });
+});

--- a/services/api/tests/ledger.routes.test.ts
+++ b/services/api/tests/ledger.routes.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { buildApp } from '../src/app';
+import { InMemoryLedgerRepository } from '../src/modules/ledger/ledger.repository';
+import { createJwtService, type AuthConfig } from '../src/modules/auth/jwt';
+
+const auth: AuthConfig = {
+  secret: 'test-secret-at-least-32-characters-long-0000',
+  accessTtl: '15m',
+  issuer: 'trotxi',
+  audience: 'trotxi-api',
+};
+const jwt = createJwtService(auth);
+const bearer = (token: string) => ({ authorization: `Bearer ${token}` });
+
+describe('GET /me/balance', () => {
+  it('rejects an unauthenticated request', async () => {
+    const app = await buildApp({ auth, ledger: new InMemoryLedgerRepository() });
+    const res = await app.inject({ method: 'GET', url: '/me/balance' });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('returns the authenticated rider derived balance', async () => {
+    const ledger = new InMemoryLedgerRepository();
+    await ledger.append({
+      userId: 'rider-1',
+      delta: 250,
+      reason: 'subscription_grant',
+      refType: 'payment',
+      idempotencyKey: 'k1',
+    });
+    await ledger.append({
+      userId: 'rider-1',
+      delta: -10,
+      reason: 'boarding',
+      refType: 'boarding',
+      idempotencyKey: 'k2',
+    });
+    const app = await buildApp({ auth, ledger });
+    const token = await jwt.signAccessToken({ userId: 'rider-1', role: 'commuter' });
+
+    const res = await app.inject({ method: 'GET', url: '/me/balance', headers: bearer(token) });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ balanceGhs: 240 });
+  });
+
+  it('returns 0 when no ledger is wired', async () => {
+    const app = await buildApp({ auth });
+    const token = await jwt.signAccessToken({ userId: 'rider-x', role: 'commuter' });
+    const res = await app.inject({ method: 'GET', url: '/me/balance', headers: bearer(token) });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ balanceGhs: 0 });
+  });
+});


### PR DESCRIPTION
## What
The rider's **GHS wallet as an append-only ledger** — the correctness core of the money system (system-design §4.1, **ADR-0011**). First of two PRs for #21 (this is the **grant/balance** half; Paystack payments are #21b).

- **`006_token_ledger`** — `delta` (GHS, ±), `reason`/`ref_type` CHECKs, **`idempotency_key` unique**.
- **`ledger.repository`** (in-memory + pg): **idempotent `append`** (retried key = no-op, via `ON CONFLICT DO NOTHING`) + **`balanceOf` = `SUM(delta)`**.
- **`GET /me/balance`** (auth + per-user rate limit) — gives the FE home screen (#35) its contract.
- **ADR-0011** records the model: append-only, balance = sum, 1 token = 1 GHS, exactly-once writes, money-fails-safe.

## Scope (deliberate)
- **Grants** (subscription paid → +tokens) come from **#21b** (Paystack). **Debits** (boarding fare) from **#20**. This PR is just the ledger + read.
- The old "hold-half / charge-at-scan" idea is **dropped** per the design — charge once, at commit.
- Transactions: a pure grant is one idempotent insert (no cross-repo tx needed here). The *serializable* tx (mark-paid + grant + activate, and the debit balance-guard) lands with its consumers (#21b / #20).

## Verification
- `pnpm check` green; **83 tests, ~99% coverage** (ledger repo + route 100%).
- Live smoke: `/me/balance` → 401 without a token, `{ "balanceGhs": 0 }` after sign-in.

## Migration numbering
Used **`006`** (left `005` for #57's mobility rename) to dodge a collision.

Part of #21