### PR TITLE
feat(api): Paystack payments — checkout + signed webhook grants tokens (#21b)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       fastify-plugin:
         specifier: ^6.0.0
         version: 6.0.0
+      fastify-raw-body:
+        specifier: ^5.0.0
+        version: 5.0.0
       fastify-type-provider-zod:
         specifier: ^4.0.2
         version: 4.0.2(fastify@5.8.5)(zod@3.25.76)
@@ -1154,6 +1157,10 @@ packages:
     peerDependencies:
       esbuild: '>=0.18'
 
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
@@ -1494,6 +1501,10 @@ packages:
   fastify-plugin@6.0.0:
     resolution: {integrity: sha512-fZOty7z3O7vOliF6d8bHE3wiEh1KcNnKEQensSgTk9C1DvN6nRLS++XVd86v33Hw/8u9Un8A1zDrQ8ujcQDHEg==}
 
+  fastify-raw-body@5.0.0:
+    resolution: {integrity: sha512-2qfoaQ3BQDhZ1gtbkKZd6n0kKxJISJGM6u/skD9ljdWItAscjXrtZ1lnjr7PavmXX9j4EyCPmBDiIsLn07d5vA==}
+    engines: {node: '>= 10'}
+
   fastify-type-provider-zod@4.0.2:
     resolution: {integrity: sha512-FDRzSL3ZuoZ+4YDevR1YOinmDKkxOdy3QB9dDR845sK+bQvDroPKhHAXLEAOObDxL7SMA0OZN/A4osrNBTdDTQ==}
     peerDependencies:
@@ -1678,6 +1689,10 @@ packages:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
     engines: {node: '>=18'}
     hasBin: true
+
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+    engines: {node: '>=0.10.0'}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -2192,6 +2207,10 @@ packages:
   quickjs-wasi@2.2.0:
     resolution: {integrity: sha512-zQxXmQMrEoD3S+jQdYsloq4qAuaxKFHZj6hHqOYGwB2iQZH+q9e/lf5zQPXCKOk0WJuAjzRFbO4KwHIp2D05Iw==}
 
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
+
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
@@ -2260,6 +2279,12 @@ packages:
   safe-stable-stringify@2.5.0:
     resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
     engines: {node: '>=10'}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  secure-json-parse@2.7.0:
+    resolution: {integrity: sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==}
 
   secure-json-parse@4.1.0:
     resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
@@ -2528,6 +2553,10 @@ packages:
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
+
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -3538,6 +3567,8 @@ snapshots:
       esbuild: 0.27.7
       load-tsconfig: 0.2.5
 
+  bytes@3.1.2: {}
+
   cac@6.7.14: {}
 
   call-bind-apply-helpers@1.0.2:
@@ -3929,6 +3960,12 @@ snapshots:
 
   fastify-plugin@6.0.0: {}
 
+  fastify-raw-body@5.0.0:
+    dependencies:
+      fastify-plugin: 5.1.0
+      raw-body: 3.0.2
+      secure-json-parse: 2.7.0
+
   fastify-type-provider-zod@4.0.2(fastify@5.8.5)(zod@3.25.76):
     dependencies:
       '@fastify/error': 4.2.0
@@ -4145,6 +4182,10 @@ snapshots:
   human-signals@5.0.0: {}
 
   husky@9.1.7: {}
+
+  iconv-lite@0.7.2:
+    dependencies:
+      safer-buffer: 2.1.2
 
   ieee754@1.2.1: {}
 
@@ -4625,6 +4666,13 @@ snapshots:
 
   quickjs-wasi@2.2.0: {}
 
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
+
   readdirp@4.1.2: {}
 
   real-require@0.2.0: {}
@@ -4698,6 +4746,10 @@ snapshots:
       ret: 0.5.0
 
   safe-stable-stringify@2.5.0: {}
+
+  safer-buffer@2.1.2: {}
+
+  secure-json-parse@2.7.0: {}
 
   secure-json-parse@4.1.0: {}
 
@@ -4940,6 +4992,8 @@ snapshots:
   undici-types@6.21.0: {}
 
   universalify@2.0.1: {}
+
+  unpipe@1.0.0: {}
 
   uri-js@4.4.1:
     dependencies:

--- a/services/api/.env.example
+++ b/services/api/.env.example
@@ -25,6 +25,10 @@ NODE_ENV=development
 # returns 503 until this is set. Not a secret; no client secret is needed.
 # GOOGLE_CLIENT_ID=xxxxxxxx.apps.googleusercontent.com
 
+# Paystack — the SECRET key (sk_test_… / sk_live_…). A real secret: set in the
+# dashboard, never commit. Unset -> dev fake client (non-prod) / 503 (prod).
+# PAYSTACK_SECRET_KEY=sk_test_xxxxxxxx
+
 # Rate limiting (fixed window) — defaults shown.
 # RATE_LIMIT_MAX=100
 # RATE_LIMIT_WINDOW_SECONDS=60

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -23,6 +23,7 @@
     "@fastify/swagger-ui": "^6.0.0",
     "fastify": "^5.2.0",
     "fastify-plugin": "^6.0.0",
+    "fastify-raw-body": "^5.0.0",
     "fastify-type-provider-zod": "^4.0.2",
     "ioredis": "^5.11.1",
     "jose": "^6.2.3",

--- a/services/api/src/app.ts
+++ b/services/api/src/app.ts
@@ -11,6 +11,8 @@ import { z } from 'zod';
 import { InMemoryKvStore, type KvStore } from './kv/kv.store';
 import { ledgerRoutes } from './modules/ledger/ledger.routes';
 import type { LedgerRepository } from './modules/ledger/ledger.repository';
+import { paymentRoutes } from './modules/payments/payments.routes';
+import type { PaymentsService } from './modules/payments/payments.service';
 import { authPlugin } from './modules/auth/auth.plugin';
 import { authRoutes } from './modules/auth/auth.routes';
 import type { AuthService } from './modules/auth/auth.service';
@@ -43,6 +45,8 @@ export interface AppDeps {
   auth?: AuthConfig;
   /** Sign-in/refresh/logout orchestrator. Routes return 503 when absent. */
   authService?: AuthService;
+  /** Paystack payments orchestrator. Routes return 503 when absent. */
+  paymentsService?: PaymentsService;
   /** Rate-limit thresholds (from env). Defaults applied when unset. */
   rateLimit?: RateLimitConfig;
   logger?: boolean;
@@ -73,6 +77,7 @@ export async function buildApp(deps: AppDeps = {}): Promise<FastifyInstance> {
         { name: 'system', description: 'Health, readiness, and service metadata' },
         { name: 'auth', description: 'Authentication and the current user' },
         { name: 'wallet', description: 'Token wallet / GHS balance' },
+        { name: 'payments', description: 'Subscriptions checkout (Paystack) + webhook' },
       ],
       components: {
         // Protected routes set `security: [{ bearerAuth: [] }]`; clients send
@@ -97,6 +102,10 @@ export async function buildApp(deps: AppDeps = {}): Promise<FastifyInstance> {
   });
   await app.register(ledgerRoutes, {
     ledger: deps.ledger,
+    rateLimit: deps.rateLimit ?? DEFAULT_RATE_LIMIT,
+  });
+  await app.register(paymentRoutes, {
+    paymentsService: deps.paymentsService,
     rateLimit: deps.rateLimit ?? DEFAULT_RATE_LIMIT,
   });
 

--- a/services/api/src/config/env.ts
+++ b/services/api/src/config/env.ts
@@ -19,6 +19,9 @@ const envSchema = z
     // Google "Web" client ID — the audience verified on sign-in. Set to enable
     // real Google sign-in; unset -> dev fake verifier (non-prod) / 503 (prod).
     GOOGLE_CLIENT_ID: z.string().optional(),
+    // Paystack SECRET key (sk_...). Used for the API + webhook signature check.
+    // Set -> real payments; unset -> dev fake client (non-prod) / 503 (prod).
+    PAYSTACK_SECRET_KEY: z.string().optional(),
     // Rate limiting (fixed window). Tunable without a code change.
     RATE_LIMIT_MAX: z.coerce.number().int().positive().default(100),
     RATE_LIMIT_WINDOW_SECONDS: z.coerce.number().int().positive().default(60),

--- a/services/api/src/db/migrations/007_payments.sql
+++ b/services/api/src/db/migrations/007_payments.sql
@@ -1,0 +1,16 @@
+-- 007_payments: Paystack payment records. A state machine (pending → paid|failed)
+-- that is never mutated once paid; `reference` is unique and is both our handle
+-- and Paystack's, so duplicate webhooks dedupe on it (system-design §4.2).
+
+CREATE TABLE IF NOT EXISTS payments (
+  id         uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id    uuid NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+  reference  text NOT NULL UNIQUE,
+  plan       text NOT NULL CHECK (plan IN ('monthly', 'annual')),
+  amount     integer NOT NULL,                 -- GHS (1 token = 1 GHS)
+  currency   text NOT NULL DEFAULT 'GHS',
+  status     text NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'paid', 'failed')),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_payments_user ON payments (user_id);

--- a/services/api/src/modules/payments/payment.repository.pg.ts
+++ b/services/api/src/modules/payments/payment.repository.pg.ts
@@ -1,0 +1,60 @@
+import type { Pool } from 'pg';
+import type { SubscriptionPlan } from '../subscriptions/subscription.repository';
+import type { NewPayment, Payment, PaymentRepository, PaymentStatus } from './payment.repository';
+
+interface PaymentRow {
+  id: string;
+  user_id: string;
+  reference: string;
+  plan: SubscriptionPlan;
+  amount: number;
+  currency: string;
+  status: PaymentStatus;
+  created_at: Date;
+  updated_at: Date;
+}
+
+function toPayment(row: PaymentRow): Payment {
+  return {
+    id: row.id,
+    userId: row.user_id,
+    reference: row.reference,
+    plan: row.plan,
+    amount: row.amount,
+    currency: row.currency,
+    status: row.status,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+export class PgPaymentRepository implements PaymentRepository {
+  constructor(private readonly pool: Pool) {}
+
+  async create(input: NewPayment): Promise<Payment> {
+    const { rows } = await this.pool.query<PaymentRow>(
+      `INSERT INTO payments (user_id, reference, plan, amount, currency)
+       VALUES ($1, $2, $3, $4, $5)
+       RETURNING *`,
+      [input.userId, input.reference, input.plan, input.amount, input.currency],
+    );
+    return toPayment(rows[0]!);
+  }
+
+  async findByReference(reference: string): Promise<Payment | null> {
+    const { rows } = await this.pool.query<PaymentRow>(
+      `SELECT * FROM payments WHERE reference = $1`,
+      [reference],
+    );
+    return rows[0] ? toPayment(rows[0]) : null;
+  }
+
+  async markPaid(reference: string): Promise<void> {
+    // Only pending → paid; a paid row is never mutated again.
+    await this.pool.query(
+      `UPDATE payments SET status = 'paid', updated_at = now()
+       WHERE reference = $1 AND status = 'pending'`,
+      [reference],
+    );
+  }
+}

--- a/services/api/src/modules/payments/payment.repository.ts
+++ b/services/api/src/modules/payments/payment.repository.ts
@@ -1,0 +1,66 @@
+// Payments — a state machine (pending → paid|failed), never mutated once paid.
+// `reference` is unique and dedupes retried webhooks (system-design §4.2).
+
+import type { SubscriptionPlan } from '../subscriptions/subscription.repository';
+
+export type PaymentStatus = 'pending' | 'paid' | 'failed';
+
+export interface Payment {
+  id: string;
+  userId: string;
+  reference: string;
+  plan: SubscriptionPlan;
+  amount: number; // GHS
+  currency: string;
+  status: PaymentStatus;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface NewPayment {
+  userId: string;
+  reference: string;
+  plan: SubscriptionPlan;
+  amount: number;
+  currency: string;
+}
+
+export interface PaymentRepository {
+  create(input: NewPayment): Promise<Payment>;
+  findByReference(reference: string): Promise<Payment | null>;
+  /** Transition pending → paid. No-op if already paid (never mutate a paid row). */
+  markPaid(reference: string): Promise<void>;
+}
+
+export class InMemoryPaymentRepository implements PaymentRepository {
+  private readonly byReference = new Map<string, Payment>();
+
+  async create(input: NewPayment): Promise<Payment> {
+    const now = new Date();
+    const payment: Payment = {
+      id: crypto.randomUUID(),
+      userId: input.userId,
+      reference: input.reference,
+      plan: input.plan,
+      amount: input.amount,
+      currency: input.currency,
+      status: 'pending',
+      createdAt: now,
+      updatedAt: now,
+    };
+    this.byReference.set(payment.reference, payment);
+    return payment;
+  }
+
+  async findByReference(reference: string): Promise<Payment | null> {
+    return this.byReference.get(reference) ?? null;
+  }
+
+  async markPaid(reference: string): Promise<void> {
+    const payment = this.byReference.get(reference);
+    if (payment && payment.status === 'pending') {
+      payment.status = 'paid';
+      payment.updatedAt = new Date();
+    }
+  }
+}

--- a/services/api/src/modules/payments/payments.routes.ts
+++ b/services/api/src/modules/payments/payments.routes.ts
@@ -1,0 +1,114 @@
+// Payment routes. /payments/initialize starts a checkout (auth, per-user limit).
+// /webhooks/paystack is public but signature-verified inside the service; it uses
+// the RAW body (fastify-raw-body) because the HMAC must be over the exact bytes
+// Paystack sent — a re-serialized JSON would not match.
+
+import type { FastifyInstance } from 'fastify';
+import fastifyRawBody from 'fastify-raw-body';
+import type { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { errorResponseSchema } from '../../lib/schemas';
+import type { RateLimitConfig } from '../ratelimit/ratelimit.plugin';
+import {
+  initializePaymentBodySchema,
+  initializePaymentResponseSchema,
+  webhookResponseSchema,
+} from './payments.schema';
+import {
+  InvalidWebhookError,
+  PaymentsNotConfiguredError,
+  type PaymentsService,
+} from './payments.service';
+
+// Webhooks come from Paystack's IPs, not users — a generous per-IP cap is enough.
+const WEBHOOK_RATE_LIMIT = { max: 60, windowSeconds: 60 } as const;
+
+export async function paymentRoutes(
+  app: FastifyInstance,
+  opts: { paymentsService?: PaymentsService; rateLimit: RateLimitConfig },
+): Promise<void> {
+  // rawBody only for routes that opt in via config.rawBody (the webhook).
+  await app.register(fastifyRawBody, { global: false });
+  const r = app.withTypeProvider<ZodTypeProvider>();
+
+  r.post(
+    '/payments/initialize',
+    {
+      schema: {
+        tags: ['payments'],
+        summary: 'Start a Paystack checkout for a subscription plan',
+        security: [{ bearerAuth: [] }],
+        body: initializePaymentBodySchema,
+        response: {
+          200: initializePaymentResponseSchema,
+          401: errorResponseSchema,
+          429: errorResponseSchema,
+          503: errorResponseSchema,
+        },
+      },
+      preHandler: [app.authenticate, app.rateLimit({ ...opts.rateLimit, by: 'user' })],
+    },
+    async (request, reply) => {
+      if (!opts.paymentsService) {
+        return reply
+          .code(503)
+          .send({ error: 'unavailable', message: 'Payments are not configured' });
+      }
+      try {
+        return await opts.paymentsService.initialize(request.user!.id, request.body.plan);
+      } catch (err) {
+        if (err instanceof PaymentsNotConfiguredError) {
+          return reply
+            .code(503)
+            .send({ error: 'unavailable', message: 'Payments are not configured' });
+        }
+        throw err;
+      }
+    },
+  );
+
+  r.post(
+    '/webhooks/paystack',
+    {
+      // rawBody (fastify-raw-body) so we can verify the HMAC over exact bytes.
+      config: { rawBody: true },
+      schema: {
+        tags: ['payments'],
+        summary: 'Paystack payment webhook (signature-verified)',
+        response: {
+          200: webhookResponseSchema,
+          401: errorResponseSchema,
+          503: errorResponseSchema,
+        },
+      },
+      preHandler: [app.rateLimit({ ...WEBHOOK_RATE_LIMIT, by: 'ip' })],
+    },
+    async (request, reply) => {
+      if (!opts.paymentsService) {
+        return reply
+          .code(503)
+          .send({ error: 'unavailable', message: 'Payments are not configured' });
+      }
+      const rawBody = typeof request.rawBody === 'string' ? request.rawBody : '';
+      const signature = request.headers['x-paystack-signature'];
+      try {
+        await opts.paymentsService.handleWebhook(
+          rawBody,
+          typeof signature === 'string' ? signature : undefined,
+        );
+        return { received: true };
+      } catch (err) {
+        if (err instanceof InvalidWebhookError) {
+          return reply
+            .code(401)
+            .send({ error: 'unauthorized', message: 'Invalid webhook signature' });
+        }
+        if (err instanceof PaymentsNotConfiguredError) {
+          return reply
+            .code(503)
+            .send({ error: 'unavailable', message: 'Payments are not configured' });
+        }
+        throw err;
+      }
+    },
+  );
+}

--- a/services/api/src/modules/payments/payments.schema.ts
+++ b/services/api/src/modules/payments/payments.schema.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+import type { SubscriptionPlan } from '../subscriptions/subscription.repository';
+
+// Single source for the plan values; `satisfies` makes TS error if these drift
+// from the SubscriptionPlan union.
+const PLANS = ['monthly', 'annual'] as const satisfies readonly SubscriptionPlan[];
+
+export const initializePaymentBodySchema = z.object({
+  plan: z.enum(PLANS),
+});
+
+export const initializePaymentResponseSchema = z.object({
+  authorizationUrl: z.string(),
+  reference: z.string(),
+});
+
+export const webhookResponseSchema = z.object({
+  received: z.boolean(),
+});

--- a/services/api/src/modules/payments/payments.service.ts
+++ b/services/api/src/modules/payments/payments.service.ts
@@ -1,0 +1,113 @@
+// PaymentsService — initialize a Paystack checkout, and handle the webhook that
+// confirms it. The webhook is the money-in event: on charge.success it GRANTS
+// tokens to the ledger and ACTIVATES the subscription.
+//
+// Not wrapped in one DB transaction by design (system-design §4.2: "idempotent
+// webhooks"): each step is individually idempotent, so a retried/partial webhook
+// converges — the ledger grant is keyed (no double grant), the subscription is
+// guarded by the one-active-per-user index (no double activate), and markPaid
+// only transitions pending → paid. Paystack retries; a nightly reconciliation
+// (future) backstops anything it gives up on.
+
+import type { LedgerRepository } from '../ledger/ledger.repository';
+import type {
+  SubscriptionPlan,
+  SubscriptionRepository,
+} from '../subscriptions/subscription.repository';
+import type { PaymentRepository } from './payment.repository';
+import type { PaystackClient } from './paystack.client';
+
+export class PaymentsNotConfiguredError extends Error {}
+export class InvalidWebhookError extends Error {}
+
+/**
+ * Plan prices in GHS (1 token = 1 GHS, so the price is also the token grant).
+ * Server-authoritative (security.md §7) — PLACEHOLDERS; set the real numbers here.
+ */
+export const PLAN_PRICES_GHS: Record<SubscriptionPlan, number> = {
+  monthly: 250,
+  annual: 2500,
+};
+
+export interface PaymentsServiceDeps {
+  payments: PaymentRepository;
+  ledger: LedgerRepository;
+  subscriptions: SubscriptionRepository;
+  /** Undefined when payments aren't configured (e.g. prod without a Paystack key). */
+  paystack?: PaystackClient;
+  /** Plan → price in GHS (server-authoritative; 1 token = 1 GHS). */
+  planPrices: Record<SubscriptionPlan, number>;
+}
+
+function isUniqueViolation(err: unknown): boolean {
+  return (err as { code?: string }).code === '23505';
+}
+
+interface PaystackWebhookEvent {
+  event?: string;
+  data?: { reference?: string };
+}
+
+export class PaymentsService {
+  constructor(private readonly deps: PaymentsServiceDeps) {}
+
+  /** Create a pending payment and start a Paystack checkout for the plan. */
+  async initialize(
+    userId: string,
+    plan: SubscriptionPlan,
+  ): Promise<{ authorizationUrl: string; reference: string }> {
+    if (!this.deps.paystack) {
+      throw new PaymentsNotConfiguredError('Payments are not configured');
+    }
+    const amount = this.deps.planPrices[plan]; // GHS, server-side
+    const reference = `trotxi_${crypto.randomUUID()}`;
+    await this.deps.payments.create({ userId, reference, plan, amount, currency: 'GHS' });
+    const result = await this.deps.paystack.initializeTransaction({
+      // We don't store email yet; a stable per-user address is fine as Paystack's
+      // customer key (follow-up: capture the real email at sign-in).
+      email: `${userId}@users.trotxi.app`,
+      amountPesewas: amount * 100,
+      reference,
+    });
+    return { authorizationUrl: result.authorizationUrl, reference };
+  }
+
+  /** Verify + process a Paystack webhook. Idempotent; safe to replay. */
+  async handleWebhook(rawBody: string, signature: string | undefined): Promise<void> {
+    if (!this.deps.paystack) {
+      throw new PaymentsNotConfiguredError('Payments are not configured');
+    }
+    if (!this.deps.paystack.verifyWebhookSignature(rawBody, signature)) {
+      throw new InvalidWebhookError('Invalid webhook signature');
+    }
+
+    const event = JSON.parse(rawBody) as PaystackWebhookEvent;
+    if (event.event !== 'charge.success') return; // ignore everything else
+    const reference = event.data?.reference;
+    if (!reference) return;
+
+    const payment = await this.deps.payments.findByReference(reference);
+    if (!payment) return; // unknown reference — not ours
+
+    // Idempotent steps (order doesn't matter for correctness; each is safe to retry):
+    await this.deps.ledger.append({
+      userId: payment.userId,
+      delta: payment.amount,
+      reason: 'subscription_grant',
+      refType: 'payment',
+      refId: payment.id,
+      idempotencyKey: `grant:${reference}`,
+    });
+    await this.activateSubscription(payment.userId, payment.plan);
+    await this.deps.payments.markPaid(reference);
+  }
+
+  private async activateSubscription(userId: string, plan: SubscriptionPlan): Promise<void> {
+    try {
+      await this.deps.subscriptions.create({ userId, plan });
+    } catch (err) {
+      // one-active-per-user index fired — already activated, treat as done.
+      if (!isUniqueViolation(err)) throw err;
+    }
+  }
+}

--- a/services/api/src/modules/payments/paystack.client.live.ts
+++ b/services/api/src/modules/payments/paystack.client.live.ts
@@ -1,0 +1,44 @@
+// Real Paystack HTTP client. Network-bound, so excluded from unit coverage (like
+// the *.pg / *.redis / *.google adapters) — exercised against Paystack's sandbox.
+
+import type { PaystackClient, PaystackInitParams, PaystackInitResult } from './paystack.client';
+import { verifySignature } from './paystack.client';
+
+const PAYSTACK_API = 'https://api.paystack.co';
+
+interface InitializeResponse {
+  status: boolean;
+  data?: { authorization_url: string; reference: string };
+}
+
+export class PaystackHttpClient implements PaystackClient {
+  constructor(private readonly secretKey: string) {}
+
+  async initializeTransaction(params: PaystackInitParams): Promise<PaystackInitResult> {
+    const res = await fetch(`${PAYSTACK_API}/transaction/initialize`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${this.secretKey}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        email: params.email,
+        amount: params.amountPesewas,
+        reference: params.reference,
+        currency: 'GHS',
+      }),
+    });
+    if (!res.ok) {
+      throw new Error(`Paystack initialize failed: ${res.status}`);
+    }
+    const json = (await res.json()) as InitializeResponse;
+    if (!json.status || !json.data) {
+      throw new Error('Paystack initialize returned no data');
+    }
+    return { authorizationUrl: json.data.authorization_url, reference: json.data.reference };
+  }
+
+  verifyWebhookSignature(rawBody: string, signature: string | undefined): boolean {
+    return verifySignature(rawBody, signature, this.secretKey);
+  }
+}

--- a/services/api/src/modules/payments/paystack.client.ts
+++ b/services/api/src/modules/payments/paystack.client.ts
@@ -1,0 +1,60 @@
+// Paystack integration behind an interface so PaymentsService never touches the
+// network directly and tests use the fake. The real HTTP client is in
+// paystack.client.live.ts. Webhook signatures are HMAC-SHA512 of the raw body
+// keyed by the SECRET key (security.md §7 — mandatory, else anyone mints tokens).
+
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+export interface PaystackInitParams {
+  email: string;
+  /** Amount in pesewas (GHS * 100) — Paystack's smallest unit. */
+  amountPesewas: number;
+  reference: string;
+}
+
+export interface PaystackInitResult {
+  authorizationUrl: string;
+  reference: string;
+}
+
+export interface PaystackClient {
+  initializeTransaction(params: PaystackInitParams): Promise<PaystackInitResult>;
+  verifyWebhookSignature(rawBody: string, signature: string | undefined): boolean;
+}
+
+/** HMAC-SHA512(rawBody, secret) as hex — how Paystack signs webhooks. */
+export function paystackSignature(rawBody: string, secret: string): string {
+  return createHmac('sha512', secret).update(rawBody).digest('hex');
+}
+
+/** Constant-time hex compare; false on length mismatch (never throws). */
+export function verifySignature(
+  rawBody: string,
+  signature: string | undefined,
+  secret: string,
+): boolean {
+  if (!signature) return false;
+  const expected = paystackSignature(rawBody, secret);
+  if (expected.length !== signature.length) return false;
+  return timingSafeEqual(Buffer.from(expected), Buffer.from(signature));
+}
+
+/**
+ * Dev/test client: no network. `initializeTransaction` returns a stub URL;
+ * `verifyWebhookSignature` does real HMAC against a known secret so tests can
+ * sign a payload. Never wired in production (see server.ts).
+ */
+export class FakePaystackClient implements PaystackClient {
+  constructor(private readonly secret = 'fake-paystack-secret') {}
+
+  async initializeTransaction(params: PaystackInitParams): Promise<PaystackInitResult> {
+    return {
+      authorizationUrl: `https://checkout.paystack.test/${params.reference}`,
+      reference: params.reference,
+    };
+  }
+
+  verifyWebhookSignature(rawBody: string, signature: string | undefined): boolean {
+    return verifySignature(rawBody, signature, this.secret);
+  }
+}

--- a/services/api/src/server.ts
+++ b/services/api/src/server.ts
@@ -30,6 +30,14 @@ import {
   type LedgerRepository,
 } from './modules/ledger/ledger.repository';
 import { PgLedgerRepository } from './modules/ledger/ledger.repository.pg';
+import {
+  InMemoryPaymentRepository,
+  type PaymentRepository,
+} from './modules/payments/payment.repository';
+import { PgPaymentRepository } from './modules/payments/payment.repository.pg';
+import { FakePaystackClient, type PaystackClient } from './modules/payments/paystack.client';
+import { PaystackHttpClient } from './modules/payments/paystack.client.live';
+import { PaymentsService, PLAN_PRICES_GHS } from './modules/payments/payments.service';
 import { InMemoryUserRepository, type UserRepository } from './modules/users/user.repository';
 import { PgUserRepository } from './modules/users/user.repository.pg';
 
@@ -62,6 +70,7 @@ async function main(): Promise<void> {
   let sessions: SessionRepository;
   let authIdentities: AuthIdentityRepository;
   let ledger: LedgerRepository;
+  let payments: PaymentRepository;
   if (env.DATABASE_URL) {
     pool = createPool(env.DATABASE_URL);
     users = new PgUserRepository(pool);
@@ -69,6 +78,7 @@ async function main(): Promise<void> {
     sessions = new PgSessionRepository(pool);
     authIdentities = new PgAuthIdentityRepository(pool);
     ledger = new PgLedgerRepository(pool);
+    payments = new PgPaymentRepository(pool);
     console.log('Using Postgres repositories');
   } else {
     users = new InMemoryUserRepository();
@@ -76,6 +86,7 @@ async function main(): Promise<void> {
     sessions = new InMemorySessionRepository();
     authIdentities = new InMemoryAuthIdentityRepository();
     ledger = new InMemoryLedgerRepository();
+    payments = new InMemoryPaymentRepository();
     console.log('Using in-memory repositories (no DATABASE_URL set)');
   }
 
@@ -101,6 +112,27 @@ async function main(): Promise<void> {
     refreshTtlDays: env.JWT_REFRESH_TTL_DAYS,
   });
 
+  // Paystack client: real when the secret key is set; a dev fake outside
+  // production; otherwise undefined (payment routes return 503 — keeps staging up).
+  let paystack: PaystackClient | undefined;
+  if (env.PAYSTACK_SECRET_KEY) {
+    paystack = new PaystackHttpClient(env.PAYSTACK_SECRET_KEY);
+    console.log('Using Paystack HTTP client');
+  } else if (env.NODE_ENV !== 'production') {
+    paystack = new FakePaystackClient();
+    console.warn('PAYSTACK_SECRET_KEY not set — using FAKE payments client (non-production only).');
+  } else {
+    console.warn('PAYSTACK_SECRET_KEY not set — payments disabled (POST /payments/* returns 503).');
+  }
+
+  const paymentsService = new PaymentsService({
+    payments,
+    ledger,
+    subscriptions,
+    paystack,
+    planPrices: PLAN_PRICES_GHS,
+  });
+
   // Readiness pings every configured backing service (DB + KV).
   const isReady = async (): Promise<boolean> => {
     if (pool) {
@@ -123,6 +155,7 @@ async function main(): Promise<void> {
     subscriptions,
     ledger,
     authService,
+    paymentsService,
     kv,
     isReady,
     auth,

--- a/services/api/tests/payments.routes.test.ts
+++ b/services/api/tests/payments.routes.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+import { buildApp } from '../src/app';
+import { InMemoryLedgerRepository } from '../src/modules/ledger/ledger.repository';
+import { InMemoryPaymentRepository } from '../src/modules/payments/payment.repository';
+import { FakePaystackClient, paystackSignature } from '../src/modules/payments/paystack.client';
+import { PaymentsService } from '../src/modules/payments/payments.service';
+import { InMemorySubscriptionRepository } from '../src/modules/subscriptions/subscription.repository';
+import { createJwtService, type AuthConfig } from '../src/modules/auth/jwt';
+
+const auth: AuthConfig = {
+  secret: 'test-secret-at-least-32-characters-long-0000',
+  accessTtl: '15m',
+  issuer: 'trotxi',
+  audience: 'trotxi-api',
+};
+const jwt = createJwtService(auth);
+const FAKE_SECRET = 'fake-paystack-secret';
+const bearer = (t: string) => ({ authorization: `Bearer ${t}` });
+
+function appWithPayments() {
+  const ledger = new InMemoryLedgerRepository();
+  const paymentsService = new PaymentsService({
+    payments: new InMemoryPaymentRepository(),
+    ledger,
+    subscriptions: new InMemorySubscriptionRepository(),
+    paystack: new FakePaystackClient(FAKE_SECRET),
+    planPrices: { monthly: 250, annual: 2500 },
+  });
+  return { ledger, build: buildApp({ auth, ledger, paymentsService }) };
+}
+
+describe('POST /payments/initialize', () => {
+  it('rejects an unauthenticated request', async () => {
+    const { build } = appWithPayments();
+    const app = await build;
+    const res = await app.inject({
+      method: 'POST',
+      url: '/payments/initialize',
+      payload: { plan: 'monthly' },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('returns a checkout URL for an authenticated user', async () => {
+    const { build } = appWithPayments();
+    const app = await build;
+    const token = await jwt.signAccessToken({ userId: 'rider-1', role: 'commuter' });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/payments/initialize',
+      headers: bearer(token),
+      payload: { plan: 'monthly' },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().authorizationUrl).toBeTruthy();
+    expect(res.json().reference).toBeTruthy();
+  });
+
+  it('returns 503 when payments are not configured', async () => {
+    const app = await buildApp({ auth });
+    const token = await jwt.signAccessToken({ userId: 'rider-1', role: 'commuter' });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/payments/initialize',
+      headers: bearer(token),
+      payload: { plan: 'monthly' },
+    });
+    expect(res.statusCode).toBe(503);
+  });
+});
+
+describe('POST /webhooks/paystack', () => {
+  it('grants tokens on a validly-signed charge.success (end-to-end)', async () => {
+    const { build } = appWithPayments();
+    const app = await build;
+    const token = await jwt.signAccessToken({ userId: 'rider-1', role: 'commuter' });
+
+    const init = await app.inject({
+      method: 'POST',
+      url: '/payments/initialize',
+      headers: bearer(token),
+      payload: { plan: 'monthly' },
+    });
+    const { reference } = init.json();
+
+    const body = JSON.stringify({ event: 'charge.success', data: { reference } });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/webhooks/paystack',
+      headers: {
+        'content-type': 'application/json',
+        'x-paystack-signature': paystackSignature(body, FAKE_SECRET),
+      },
+      payload: body,
+    });
+    expect(res.statusCode).toBe(200);
+
+    const balance = await app.inject({ method: 'GET', url: '/me/balance', headers: bearer(token) });
+    expect(balance.json()).toEqual({ balanceGhs: 250 });
+  });
+
+  it('rejects a bad signature with 401', async () => {
+    const { build } = appWithPayments();
+    const app = await build;
+    const body = JSON.stringify({ event: 'charge.success', data: { reference: 'x' } });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/webhooks/paystack',
+      headers: { 'content-type': 'application/json', 'x-paystack-signature': 'bad' },
+      payload: body,
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('returns 503 when payments are not configured', async () => {
+    const app = await buildApp({ auth });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/webhooks/paystack',
+      headers: { 'content-type': 'application/json', 'x-paystack-signature': 'x' },
+      payload: '{}',
+    });
+    expect(res.statusCode).toBe(503);
+  });
+});

--- a/services/api/tests/payments.service.test.ts
+++ b/services/api/tests/payments.service.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest';
+import { InMemoryLedgerRepository } from '../src/modules/ledger/ledger.repository';
+import { InMemoryPaymentRepository } from '../src/modules/payments/payment.repository';
+import { FakePaystackClient, paystackSignature } from '../src/modules/payments/paystack.client';
+import {
+  InvalidWebhookError,
+  PaymentsNotConfiguredError,
+  PaymentsService,
+} from '../src/modules/payments/payments.service';
+import {
+  InMemorySubscriptionRepository,
+  type SubscriptionRepository,
+} from '../src/modules/subscriptions/subscription.repository';
+
+const FAKE_SECRET = 'fake-paystack-secret';
+const planPrices = { monthly: 250, annual: 2500 };
+
+function make(subscriptions: SubscriptionRepository = new InMemorySubscriptionRepository()) {
+  const payments = new InMemoryPaymentRepository();
+  const ledger = new InMemoryLedgerRepository();
+  const service = new PaymentsService({
+    payments,
+    ledger,
+    subscriptions,
+    paystack: new FakePaystackClient(FAKE_SECRET),
+    planPrices,
+  });
+  return { payments, ledger, subscriptions, service };
+}
+
+function chargeSuccess(reference: string): { body: string; signature: string } {
+  const body = JSON.stringify({ event: 'charge.success', data: { reference } });
+  return { body, signature: paystackSignature(body, FAKE_SECRET) };
+}
+
+describe('PaymentsService.initialize', () => {
+  it('creates a pending payment and returns a checkout URL', async () => {
+    const { service, payments } = make();
+    const { reference, authorizationUrl } = await service.initialize('u1', 'monthly');
+    expect(authorizationUrl).toBeTruthy();
+    const payment = await payments.findByReference(reference);
+    expect(payment).toMatchObject({
+      userId: 'u1',
+      plan: 'monthly',
+      amount: 250,
+      status: 'pending',
+    });
+  });
+
+  it('throws when payments are not configured', async () => {
+    const service = new PaymentsService({
+      payments: new InMemoryPaymentRepository(),
+      ledger: new InMemoryLedgerRepository(),
+      subscriptions: new InMemorySubscriptionRepository(),
+      planPrices,
+    });
+    await expect(service.initialize('u1', 'monthly')).rejects.toBeInstanceOf(
+      PaymentsNotConfiguredError,
+    );
+  });
+});
+
+describe('PaymentsService.handleWebhook', () => {
+  it('rejects an invalid signature', async () => {
+    const { service } = make();
+    await expect(service.handleWebhook('{}', 'bad-sig')).rejects.toBeInstanceOf(
+      InvalidWebhookError,
+    );
+  });
+
+  it('on charge.success: grants tokens, activates the subscription, marks paid', async () => {
+    const { service, ledger, subscriptions, payments } = make();
+    const { reference } = await service.initialize('u1', 'monthly');
+    const { body, signature } = chargeSuccess(reference);
+
+    await service.handleWebhook(body, signature);
+
+    expect(await ledger.balanceOf('u1')).toBe(250);
+    expect(await subscriptions.findActiveByUser('u1')).not.toBeNull();
+    expect((await payments.findByReference(reference))?.status).toBe('paid');
+  });
+
+  it('is idempotent — replaying the webhook does not double-grant', async () => {
+    const { service, ledger } = make();
+    const { reference } = await service.initialize('u1', 'monthly');
+    const { body, signature } = chargeSuccess(reference);
+
+    await service.handleWebhook(body, signature);
+    await service.handleWebhook(body, signature); // replay
+
+    expect(await ledger.balanceOf('u1')).toBe(250); // not 500
+  });
+
+  it('ignores non charge.success events and unknown references', async () => {
+    const { service, ledger } = make();
+    const { reference } = await service.initialize('u1', 'monthly');
+
+    const failed = JSON.stringify({ event: 'charge.failed', data: { reference } });
+    await service.handleWebhook(failed, paystackSignature(failed, FAKE_SECRET));
+
+    const unknown = JSON.stringify({ event: 'charge.success', data: { reference: 'nope' } });
+    await service.handleWebhook(unknown, paystackSignature(unknown, FAKE_SECRET));
+
+    expect(await ledger.balanceOf('u1')).toBe(0);
+  });
+
+  it('treats a unique-violation on activation as already-active (idempotent)', async () => {
+    const subscriptions: SubscriptionRepository = {
+      findActiveByUser: async () => null,
+      create: async () => {
+        throw Object.assign(new Error('dup'), { code: '23505' });
+      },
+    };
+    const { service, ledger } = make(subscriptions);
+    const { reference } = await service.initialize('u1', 'monthly');
+    const { body, signature } = chargeSuccess(reference);
+
+    await expect(service.handleWebhook(body, signature)).resolves.toBeUndefined();
+    expect(await ledger.balanceOf('u1')).toBe(250);
+  });
+
+  it('propagates non-unique errors from activation', async () => {
+    const subscriptions: SubscriptionRepository = {
+      findActiveByUser: async () => null,
+      create: async () => {
+        throw new Error('db down');
+      },
+    };
+    const { service } = make(subscriptions);
+    const { reference } = await service.initialize('u1', 'monthly');
+    const { body, signature } = chargeSuccess(reference);
+
+    await expect(service.handleWebhook(body, signature)).rejects.toThrow('db down');
+  });
+});

--- a/services/api/tests/paystack.client.test.ts
+++ b/services/api/tests/paystack.client.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import {
+  FakePaystackClient,
+  paystackSignature,
+  verifySignature,
+} from '../src/modules/payments/paystack.client';
+
+describe('paystack signatures', () => {
+  it('paystackSignature is a deterministic HMAC-SHA512 hex digest', () => {
+    const a = paystackSignature('{"x":1}', 'secret');
+    expect(a).toBe(paystackSignature('{"x":1}', 'secret'));
+    expect(a).toMatch(/^[0-9a-f]{128}$/);
+    expect(a).not.toBe(paystackSignature('{"x":1}', 'other-secret'));
+  });
+
+  it('verifySignature accepts a valid signature and rejects bad/missing/wrong-key', () => {
+    const body = '{"event":"charge.success"}';
+    const sig = paystackSignature(body, 's');
+    expect(verifySignature(body, sig, 's')).toBe(true);
+    expect(verifySignature(body, 'deadbeef', 's')).toBe(false);
+    expect(verifySignature(body, undefined, 's')).toBe(false);
+    expect(verifySignature(body, sig, 'wrong-key')).toBe(false);
+  });
+});
+
+describe('FakePaystackClient', () => {
+  it('initializeTransaction returns a stub URL carrying the reference', async () => {
+    const client = new FakePaystackClient();
+    const result = await client.initializeTransaction({
+      email: 'a@b.com',
+      amountPesewas: 25000,
+      reference: 'ref-1',
+    });
+    expect(result.reference).toBe('ref-1');
+    expect(result.authorizationUrl).toContain('ref-1');
+  });
+
+  it('verifyWebhookSignature validates against its configured secret', () => {
+    const client = new FakePaystackClient('sek');
+    const body = '{"a":1}';
+    expect(client.verifyWebhookSignature(body, paystackSignature(body, 'sek'))).toBe(true);
+    expect(client.verifyWebhookSignature(body, 'nope')).toBe(false);
+  });
+});

--- a/services/api/vitest.config.ts
+++ b/services/api/vitest.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
         'src/**/*.pg.ts',
         'src/**/*.redis.ts',
         'src/**/*.google.ts',
+        'src/**/*.live.ts',
       ],
       thresholds: {
         lines: 80,


### PR DESCRIPTION
## What
Completes **#21** — the money-in flow. Builds on the ledger (#64): a paid subscription **grants GHS tokens** to the wallet and **activates the subscription**.

- **`007_payments`** — payment state machine (`pending → paid|failed`), `reference` unique, never mutated once paid (system-design §4.2).
- **Paystack behind an interface** — `FakePaystackClient` (dev/test) + real HTTP client (excluded from unit coverage, like `*.pg`). **Webhook signature = HMAC-SHA512 over the RAW body** keyed by the secret (security.md §7 — *mandatory*, else anyone mints tokens), via `fastify-raw-body`.
- **`PaymentsService`** — `initialize` (pending payment + Paystack checkout URL); webhook on `charge.success` does, **idempotently**: grant tokens (keyed `grant:<ref>`) → activate subscription (guarded by the one-active index) → mark paid. Replay-safe per the design's "idempotent webhooks" (no single mega-transaction; nightly reconciliation is the future backstop).
- **`POST /payments/initialize`** (auth) + **`POST /webhooks/paystack`** (public, signed). Plan prices are **server-authoritative** (placeholders in `payments.service.ts` — set real GHS values there).

## Config
- `PAYSTACK_SECRET_KEY` (a real secret): set → live; unset → dev fake (non-prod) / **503** (prod). No keys needed to build/test.
- This is the **`sk_...` secret key** only; the `pk_...` public key is the mobile app's.

## Verification
- `pnpm check` green; **101 tests, ~98% coverage** (service/routes/signature; pg + live client excluded).
- **Live HTTP smoke:** sign in → `/payments/initialize` → **signed webhook → 200** (granted) → bad signature → **401** → `/me/balance` → **`{ balanceGhs: 250 }`**.

## To go live (later, your end)
1. Roll the test key you pasted (it's in the chat), set the new `sk_test_…` in the Render dashboard.
2. Register the webhook URL in Paystack → `https://…/webhooks/paystack`.
3. Set the real plan prices.

Closes #21