### PR TITLE
fix(payments): separate subscription (membership fee) from token top-ups

### DIFF
--- a/docs/adr/0011-token-ledger.md
+++ b/docs/adr/0011-token-ledger.md
@@ -42,3 +42,17 @@ once, at commit (system-design §4.3).
 - The in-memory repo mirrors the shape for tests/dev but the **database enforces**
   the uniqueness + checks (ADR-0009); money paths are validated against real
   Postgres (e2e), not the in-memory stand-in.
+
+## Update — 2026-06-28
+
+Correction to the model: **a subscription is a platform membership fee, not a
+token grant** (the original `subscription_grant` reason, copied from
+system-design §4.1, conflated the two). There are two separate money flows:
+
+- **subscription** payment → activates platform membership; grants **no** tokens.
+- **topup** payment → grants ride tokens (GHS) to the wallet.
+
+Boarding requires **both** an active subscription and sufficient balance
+(system-design §4.3) — two gates, not one. The ledger grant reason is now
+`topup` (migration `008`); `subscription_grant` is removed. The strategy
+`system-design §4.1/§4.2` should be updated to match.

--- a/services/api/src/db/migrations/008_payment_purpose.sql
+++ b/services/api/src/db/migrations/008_payment_purpose.sql
@@ -1,0 +1,17 @@
+-- 008_payment_purpose: separate two distinct money flows.
+--   subscription = a membership fee to be on the platform (does NOT grant tokens)
+--   topup        = loading GHS into the wallet to pay ride fares
+-- So a payment now carries a `purpose`, `plan` only applies to subscriptions, and
+-- the ledger's grant reason is `topup` (the old `subscription_grant` was wrong).
+
+ALTER TABLE payments
+  ADD COLUMN IF NOT EXISTS purpose text NOT NULL DEFAULT 'subscription'
+  CHECK (purpose IN ('subscription', 'topup'));
+
+-- plan is meaningful only for subscription payments; top-ups have none.
+ALTER TABLE payments ALTER COLUMN plan DROP NOT NULL;
+
+-- Subscriptions no longer grant tokens; top-ups do.
+ALTER TABLE token_ledger DROP CONSTRAINT IF EXISTS token_ledger_reason_check;
+ALTER TABLE token_ledger
+  ADD CONSTRAINT token_ledger_reason_check CHECK (reason IN ('topup', 'boarding', 'refund'));

--- a/services/api/src/modules/ledger/ledger.repository.ts
+++ b/services/api/src/modules/ledger/ledger.repository.ts
@@ -3,7 +3,7 @@
 // a stored column. Writes are exactly-once via idempotency_key, so a retried
 // grant or debit is a no-op rather than a double-spend.
 
-export type LedgerReason = 'subscription_grant' | 'boarding' | 'refund';
+export type LedgerReason = 'topup' | 'boarding' | 'refund';
 export type LedgerRefType = 'payment' | 'boarding';
 
 export interface LedgerEntry {

--- a/services/api/src/modules/payments/payment.repository.pg.ts
+++ b/services/api/src/modules/payments/payment.repository.pg.ts
@@ -1,12 +1,19 @@
 import type { Pool } from 'pg';
 import type { SubscriptionPlan } from '../subscriptions/subscription.repository';
-import type { NewPayment, Payment, PaymentRepository, PaymentStatus } from './payment.repository';
+import type {
+  NewPayment,
+  Payment,
+  PaymentPurpose,
+  PaymentRepository,
+  PaymentStatus,
+} from './payment.repository';
 
 interface PaymentRow {
   id: string;
   user_id: string;
   reference: string;
-  plan: SubscriptionPlan;
+  purpose: PaymentPurpose;
+  plan: SubscriptionPlan | null;
   amount: number;
   currency: string;
   status: PaymentStatus;
@@ -19,6 +26,7 @@ function toPayment(row: PaymentRow): Payment {
     id: row.id,
     userId: row.user_id,
     reference: row.reference,
+    purpose: row.purpose,
     plan: row.plan,
     amount: row.amount,
     currency: row.currency,
@@ -33,10 +41,10 @@ export class PgPaymentRepository implements PaymentRepository {
 
   async create(input: NewPayment): Promise<Payment> {
     const { rows } = await this.pool.query<PaymentRow>(
-      `INSERT INTO payments (user_id, reference, plan, amount, currency)
-       VALUES ($1, $2, $3, $4, $5)
+      `INSERT INTO payments (user_id, reference, purpose, plan, amount, currency)
+       VALUES ($1, $2, $3, $4, $5, $6)
        RETURNING *`,
-      [input.userId, input.reference, input.plan, input.amount, input.currency],
+      [input.userId, input.reference, input.purpose, input.plan, input.amount, input.currency],
     );
     return toPayment(rows[0]!);
   }

--- a/services/api/src/modules/payments/payment.repository.ts
+++ b/services/api/src/modules/payments/payment.repository.ts
@@ -1,15 +1,19 @@
 // Payments — a state machine (pending → paid|failed), never mutated once paid.
-// `reference` is unique and dedupes retried webhooks (system-design §4.2).
+// `reference` is unique and dedupes retried webhooks (system-design §4.2). A
+// payment has a `purpose`: a subscription membership fee, or a wallet top-up.
 
 import type { SubscriptionPlan } from '../subscriptions/subscription.repository';
 
 export type PaymentStatus = 'pending' | 'paid' | 'failed';
+export type PaymentPurpose = 'subscription' | 'topup';
 
 export interface Payment {
   id: string;
   userId: string;
   reference: string;
-  plan: SubscriptionPlan;
+  purpose: PaymentPurpose;
+  /** Set for subscription payments; null for top-ups. */
+  plan: SubscriptionPlan | null;
   amount: number; // GHS
   currency: string;
   status: PaymentStatus;
@@ -20,7 +24,8 @@ export interface Payment {
 export interface NewPayment {
   userId: string;
   reference: string;
-  plan: SubscriptionPlan;
+  purpose: PaymentPurpose;
+  plan: SubscriptionPlan | null;
   amount: number;
   currency: string;
 }
@@ -41,6 +46,7 @@ export class InMemoryPaymentRepository implements PaymentRepository {
       id: crypto.randomUUID(),
       userId: input.userId,
       reference: input.reference,
+      purpose: input.purpose,
       plan: input.plan,
       amount: input.amount,
       currency: input.currency,

--- a/services/api/src/modules/payments/payments.routes.ts
+++ b/services/api/src/modules/payments/payments.routes.ts
@@ -1,4 +1,5 @@
-// Payment routes. /payments/initialize starts a checkout (auth, per-user limit).
+// Payment routes. /payments/subscribe (membership fee) and /payments/topup (load
+// ride tokens) start a Paystack checkout — both auth + per-user rate limit.
 // /webhooks/paystack is public but signature-verified inside the service; it uses
 // the RAW body (fastify-raw-body) because the HMAC must be over the exact bytes
 // Paystack sent — a re-serialized JSON would not match.
@@ -9,8 +10,9 @@ import type { ZodTypeProvider } from 'fastify-type-provider-zod';
 import { errorResponseSchema } from '../../lib/schemas';
 import type { RateLimitConfig } from '../ratelimit/ratelimit.plugin';
 import {
-  initializePaymentBodySchema,
-  initializePaymentResponseSchema,
+  checkoutResponseSchema,
+  subscribeBodySchema,
+  topupBodySchema,
   webhookResponseSchema,
 } from './payments.schema';
 import {
@@ -29,17 +31,18 @@ export async function paymentRoutes(
   // rawBody only for routes that opt in via config.rawBody (the webhook).
   await app.register(fastifyRawBody, { global: false });
   const r = app.withTypeProvider<ZodTypeProvider>();
+  const UNAVAILABLE = { error: 'unavailable', message: 'Payments are not configured' };
 
   r.post(
-    '/payments/initialize',
+    '/payments/subscribe',
     {
       schema: {
         tags: ['payments'],
-        summary: 'Start a Paystack checkout for a subscription plan',
+        summary: 'Start a Paystack checkout for the platform membership fee',
         security: [{ bearerAuth: [] }],
-        body: initializePaymentBodySchema,
+        body: subscribeBodySchema,
         response: {
-          200: initializePaymentResponseSchema,
+          200: checkoutResponseSchema,
           401: errorResponseSchema,
           429: errorResponseSchema,
           503: errorResponseSchema,
@@ -48,19 +51,42 @@ export async function paymentRoutes(
       preHandler: [app.authenticate, app.rateLimit({ ...opts.rateLimit, by: 'user' })],
     },
     async (request, reply) => {
-      if (!opts.paymentsService) {
-        return reply
-          .code(503)
-          .send({ error: 'unavailable', message: 'Payments are not configured' });
-      }
+      if (!opts.paymentsService) return reply.code(503).send(UNAVAILABLE);
       try {
-        return await opts.paymentsService.initialize(request.user!.id, request.body.plan);
+        return await opts.paymentsService.initializeSubscription(
+          request.user!.id,
+          request.body.plan,
+        );
       } catch (err) {
-        if (err instanceof PaymentsNotConfiguredError) {
-          return reply
-            .code(503)
-            .send({ error: 'unavailable', message: 'Payments are not configured' });
-        }
+        if (err instanceof PaymentsNotConfiguredError) return reply.code(503).send(UNAVAILABLE);
+        throw err;
+      }
+    },
+  );
+
+  r.post(
+    '/payments/topup',
+    {
+      schema: {
+        tags: ['payments'],
+        summary: 'Start a Paystack checkout to load ride tokens (GHS) into the wallet',
+        security: [{ bearerAuth: [] }],
+        body: topupBodySchema,
+        response: {
+          200: checkoutResponseSchema,
+          401: errorResponseSchema,
+          429: errorResponseSchema,
+          503: errorResponseSchema,
+        },
+      },
+      preHandler: [app.authenticate, app.rateLimit({ ...opts.rateLimit, by: 'user' })],
+    },
+    async (request, reply) => {
+      if (!opts.paymentsService) return reply.code(503).send(UNAVAILABLE);
+      try {
+        return await opts.paymentsService.initializeTopup(request.user!.id, request.body.amountGhs);
+      } catch (err) {
+        if (err instanceof PaymentsNotConfiguredError) return reply.code(503).send(UNAVAILABLE);
         throw err;
       }
     },
@@ -69,7 +95,6 @@ export async function paymentRoutes(
   r.post(
     '/webhooks/paystack',
     {
-      // rawBody (fastify-raw-body) so we can verify the HMAC over exact bytes.
       config: { rawBody: true },
       schema: {
         tags: ['payments'],
@@ -83,11 +108,7 @@ export async function paymentRoutes(
       preHandler: [app.rateLimit({ ...WEBHOOK_RATE_LIMIT, by: 'ip' })],
     },
     async (request, reply) => {
-      if (!opts.paymentsService) {
-        return reply
-          .code(503)
-          .send({ error: 'unavailable', message: 'Payments are not configured' });
-      }
+      if (!opts.paymentsService) return reply.code(503).send(UNAVAILABLE);
       const rawBody = typeof request.rawBody === 'string' ? request.rawBody : '';
       const signature = request.headers['x-paystack-signature'];
       try {
@@ -102,11 +123,7 @@ export async function paymentRoutes(
             .code(401)
             .send({ error: 'unauthorized', message: 'Invalid webhook signature' });
         }
-        if (err instanceof PaymentsNotConfiguredError) {
-          return reply
-            .code(503)
-            .send({ error: 'unavailable', message: 'Payments are not configured' });
-        }
+        if (err instanceof PaymentsNotConfiguredError) return reply.code(503).send(UNAVAILABLE);
         throw err;
       }
     },

--- a/services/api/src/modules/payments/payments.schema.ts
+++ b/services/api/src/modules/payments/payments.schema.ts
@@ -5,11 +5,16 @@ import type { SubscriptionPlan } from '../subscriptions/subscription.repository'
 // from the SubscriptionPlan union.
 const PLANS = ['monthly', 'annual'] as const satisfies readonly SubscriptionPlan[];
 
-export const initializePaymentBodySchema = z.object({
+export const subscribeBodySchema = z.object({
   plan: z.enum(PLANS),
 });
 
-export const initializePaymentResponseSchema = z.object({
+export const topupBodySchema = z.object({
+  /** GHS to load into the wallet (1 token = 1 GHS). */
+  amountGhs: z.number().int().min(1),
+});
+
+export const checkoutResponseSchema = z.object({
   authorizationUrl: z.string(),
   reference: z.string(),
 });

--- a/services/api/src/modules/payments/payments.service.ts
+++ b/services/api/src/modules/payments/payments.service.ts
@@ -1,32 +1,34 @@
-// PaymentsService — initialize a Paystack checkout, and handle the webhook that
-// confirms it. The webhook is the money-in event: on charge.success it GRANTS
-// tokens to the ledger and ACTIVATES the subscription.
+// PaymentsService — two distinct money flows, both via Paystack:
+//   subscription = a membership fee to be on the platform → ACTIVATES the
+//                  subscription on success (grants NO tokens).
+//   topup        = loading GHS into the wallet → GRANTS tokens on success.
+// The webhook (charge.success) branches on the payment's purpose.
 //
 // Not wrapped in one DB transaction by design (system-design §4.2: "idempotent
-// webhooks"): each step is individually idempotent, so a retried/partial webhook
-// converges — the ledger grant is keyed (no double grant), the subscription is
-// guarded by the one-active-per-user index (no double activate), and markPaid
-// only transitions pending → paid. Paystack retries; a nightly reconciliation
-// (future) backstops anything it gives up on.
+// webhooks") — each step is individually idempotent (ledger grant keyed; the
+// one-active-per-user index guards activation; markPaid only does pending→paid),
+// so a retried/partial webhook converges. Paystack retries; reconciliation
+// (future) backstops the rest.
 
 import type { LedgerRepository } from '../ledger/ledger.repository';
 import type {
   SubscriptionPlan,
   SubscriptionRepository,
 } from '../subscriptions/subscription.repository';
-import type { PaymentRepository } from './payment.repository';
+import type { NewPayment, PaymentRepository } from './payment.repository';
 import type { PaystackClient } from './paystack.client';
 
 export class PaymentsNotConfiguredError extends Error {}
 export class InvalidWebhookError extends Error {}
 
 /**
- * Plan prices in GHS (1 token = 1 GHS, so the price is also the token grant).
- * Server-authoritative (security.md §7) — PLACEHOLDERS; set the real numbers here.
+ * Membership fee in GHS to be on the platform — this is NOT ride money (top-ups
+ * fund rides). Server-authoritative (security.md §7). PLACEHOLDERS — set real
+ * values here.
  */
-export const PLAN_PRICES_GHS: Record<SubscriptionPlan, number> = {
-  monthly: 250,
-  annual: 2500,
+export const SUBSCRIPTION_FEES_GHS: Record<SubscriptionPlan, number> = {
+  monthly: 20,
+  annual: 200,
 };
 
 export interface PaymentsServiceDeps {
@@ -35,8 +37,8 @@ export interface PaymentsServiceDeps {
   subscriptions: SubscriptionRepository;
   /** Undefined when payments aren't configured (e.g. prod without a Paystack key). */
   paystack?: PaystackClient;
-  /** Plan → price in GHS (server-authoritative; 1 token = 1 GHS). */
-  planPrices: Record<SubscriptionPlan, number>;
+  /** Plan → membership fee in GHS (server-authoritative). */
+  subscriptionFees: Record<SubscriptionPlan, number>;
 }
 
 function isUniqueViolation(err: unknown): boolean {
@@ -48,25 +50,47 @@ interface PaystackWebhookEvent {
   data?: { reference?: string };
 }
 
+export interface CheckoutResult {
+  authorizationUrl: string;
+  reference: string;
+}
+
 export class PaymentsService {
   constructor(private readonly deps: PaymentsServiceDeps) {}
 
-  /** Create a pending payment and start a Paystack checkout for the plan. */
-  async initialize(
-    userId: string,
-    plan: SubscriptionPlan,
-  ): Promise<{ authorizationUrl: string; reference: string }> {
+  /** Start a checkout for the platform membership fee (activates on success). */
+  async initializeSubscription(userId: string, plan: SubscriptionPlan): Promise<CheckoutResult> {
+    return this.startCheckout({
+      userId,
+      purpose: 'subscription',
+      plan,
+      amount: this.deps.subscriptionFees[plan],
+      currency: 'GHS',
+    });
+  }
+
+  /** Start a checkout to load `amountGhs` of ride tokens into the wallet. */
+  async initializeTopup(userId: string, amountGhs: number): Promise<CheckoutResult> {
+    return this.startCheckout({
+      userId,
+      purpose: 'topup',
+      plan: null,
+      amount: amountGhs,
+      currency: 'GHS',
+    });
+  }
+
+  private async startCheckout(input: Omit<NewPayment, 'reference'>): Promise<CheckoutResult> {
     if (!this.deps.paystack) {
       throw new PaymentsNotConfiguredError('Payments are not configured');
     }
-    const amount = this.deps.planPrices[plan]; // GHS, server-side
     const reference = `trotxi_${crypto.randomUUID()}`;
-    await this.deps.payments.create({ userId, reference, plan, amount, currency: 'GHS' });
+    await this.deps.payments.create({ ...input, reference });
     const result = await this.deps.paystack.initializeTransaction({
       // We don't store email yet; a stable per-user address is fine as Paystack's
       // customer key (follow-up: capture the real email at sign-in).
-      email: `${userId}@users.trotxi.app`,
-      amountPesewas: amount * 100,
+      email: `${input.userId}@users.trotxi.app`,
+      amountPesewas: input.amount * 100,
       reference,
     });
     return { authorizationUrl: result.authorizationUrl, reference };
@@ -89,16 +113,21 @@ export class PaymentsService {
     const payment = await this.deps.payments.findByReference(reference);
     if (!payment) return; // unknown reference — not ours
 
-    // Idempotent steps (order doesn't matter for correctness; each is safe to retry):
-    await this.deps.ledger.append({
-      userId: payment.userId,
-      delta: payment.amount,
-      reason: 'subscription_grant',
-      refType: 'payment',
-      refId: payment.id,
-      idempotencyKey: `grant:${reference}`,
-    });
-    await this.activateSubscription(payment.userId, payment.plan);
+    if (payment.purpose === 'topup') {
+      // Load ride money into the wallet (keyed → no double grant).
+      await this.deps.ledger.append({
+        userId: payment.userId,
+        delta: payment.amount,
+        reason: 'topup',
+        refType: 'payment',
+        refId: payment.id,
+        idempotencyKey: `topup:${reference}`,
+      });
+    } else if (payment.plan) {
+      // Membership fee paid — activate the subscription (no tokens).
+      await this.activateSubscription(payment.userId, payment.plan);
+    }
+
     await this.deps.payments.markPaid(reference);
   }
 

--- a/services/api/src/server.ts
+++ b/services/api/src/server.ts
@@ -37,7 +37,7 @@ import {
 import { PgPaymentRepository } from './modules/payments/payment.repository.pg';
 import { FakePaystackClient, type PaystackClient } from './modules/payments/paystack.client';
 import { PaystackHttpClient } from './modules/payments/paystack.client.live';
-import { PaymentsService, PLAN_PRICES_GHS } from './modules/payments/payments.service';
+import { PaymentsService, SUBSCRIPTION_FEES_GHS } from './modules/payments/payments.service';
 import { InMemoryUserRepository, type UserRepository } from './modules/users/user.repository';
 import { PgUserRepository } from './modules/users/user.repository.pg';
 
@@ -130,7 +130,7 @@ async function main(): Promise<void> {
     ledger,
     subscriptions,
     paystack,
-    planPrices: PLAN_PRICES_GHS,
+    subscriptionFees: SUBSCRIPTION_FEES_GHS,
   });
 
   // Readiness pings every configured backing service (DB + KV).

--- a/services/api/tests/ledger.repository.test.ts
+++ b/services/api/tests/ledger.repository.test.ts
@@ -7,14 +7,14 @@ describe('InMemoryLedgerRepository', () => {
     const entry = await ledger.append({
       userId: 'u1',
       delta: 250,
-      reason: 'subscription_grant',
+      reason: 'topup',
       refType: 'payment',
       refId: 'pay-1',
       idempotencyKey: 'grant:pay-1',
     });
     expect(entry.id).toBeTruthy();
     expect(entry.delta).toBe(250);
-    expect(entry.reason).toBe('subscription_grant');
+    expect(entry.reason).toBe('topup');
     expect(entry.createdAt).toBeInstanceOf(Date);
   });
 
@@ -23,14 +23,14 @@ describe('InMemoryLedgerRepository', () => {
     const first = await ledger.append({
       userId: 'u1',
       delta: 250,
-      reason: 'subscription_grant',
+      reason: 'topup',
       refType: 'payment',
       idempotencyKey: 'grant:pay-1',
     });
     const again = await ledger.append({
       userId: 'u1',
       delta: 250,
-      reason: 'subscription_grant',
+      reason: 'topup',
       refType: 'payment',
       idempotencyKey: 'grant:pay-1',
     });
@@ -43,7 +43,7 @@ describe('InMemoryLedgerRepository', () => {
     await ledger.append({
       userId: 'u1',
       delta: 250,
-      reason: 'subscription_grant',
+      reason: 'topup',
       refType: 'payment',
       idempotencyKey: 'k1',
     });

--- a/services/api/tests/ledger.routes.test.ts
+++ b/services/api/tests/ledger.routes.test.ts
@@ -24,7 +24,7 @@ describe('GET /me/balance', () => {
     await ledger.append({
       userId: 'rider-1',
       delta: 250,
-      reason: 'subscription_grant',
+      reason: 'topup',
       refType: 'payment',
       idempotencyKey: 'k1',
     });

--- a/services/api/tests/payments.routes.test.ts
+++ b/services/api/tests/payments.routes.test.ts
@@ -19,95 +19,130 @@ const bearer = (t: string) => ({ authorization: `Bearer ${t}` });
 
 function appWithPayments() {
   const ledger = new InMemoryLedgerRepository();
+  const subscriptions = new InMemorySubscriptionRepository();
   const paymentsService = new PaymentsService({
     payments: new InMemoryPaymentRepository(),
     ledger,
-    subscriptions: new InMemorySubscriptionRepository(),
+    subscriptions,
     paystack: new FakePaystackClient(FAKE_SECRET),
-    planPrices: { monthly: 250, annual: 2500 },
+    subscriptionFees: { monthly: 20, annual: 200 },
   });
-  return { ledger, build: buildApp({ auth, ledger, paymentsService }) };
+  return { ledger, subscriptions, build: buildApp({ auth, ledger, paymentsService }) };
 }
 
-describe('POST /payments/initialize', () => {
-  it('rejects an unauthenticated request', async () => {
-    const { build } = appWithPayments();
-    const app = await build;
-    const res = await app.inject({
-      method: 'POST',
-      url: '/payments/initialize',
-      payload: { plan: 'monthly' },
-    });
-    expect(res.statusCode).toBe(401);
+async function webhookFor(app: Awaited<ReturnType<typeof buildApp>>, reference: string) {
+  const body = JSON.stringify({ event: 'charge.success', data: { reference } });
+  return app.inject({
+    method: 'POST',
+    url: '/webhooks/paystack',
+    headers: {
+      'content-type': 'application/json',
+      'x-paystack-signature': paystackSignature(body, FAKE_SECRET),
+    },
+    payload: body,
+  });
+}
+
+describe('POST /payments/subscribe + /payments/topup', () => {
+  it('rejects unauthenticated requests', async () => {
+    const app = await appWithPayments().build;
+    expect(
+      (
+        await app.inject({
+          method: 'POST',
+          url: '/payments/subscribe',
+          payload: { plan: 'monthly' },
+        })
+      ).statusCode,
+    ).toBe(401);
+    expect(
+      (await app.inject({ method: 'POST', url: '/payments/topup', payload: { amountGhs: 50 } }))
+        .statusCode,
+    ).toBe(401);
   });
 
   it('returns a checkout URL for an authenticated user', async () => {
-    const { build } = appWithPayments();
-    const app = await build;
+    const app = await appWithPayments().build;
     const token = await jwt.signAccessToken({ userId: 'rider-1', role: 'commuter' });
-    const res = await app.inject({
+    const sub = await app.inject({
       method: 'POST',
-      url: '/payments/initialize',
+      url: '/payments/subscribe',
       headers: bearer(token),
       payload: { plan: 'monthly' },
     });
-    expect(res.statusCode).toBe(200);
-    expect(res.json().authorizationUrl).toBeTruthy();
-    expect(res.json().reference).toBeTruthy();
+    expect(sub.statusCode).toBe(200);
+    expect(sub.json().authorizationUrl).toBeTruthy();
+    const top = await app.inject({
+      method: 'POST',
+      url: '/payments/topup',
+      headers: bearer(token),
+      payload: { amountGhs: 50 },
+    });
+    expect(top.statusCode).toBe(200);
   });
 
   it('returns 503 when payments are not configured', async () => {
     const app = await buildApp({ auth });
     const token = await jwt.signAccessToken({ userId: 'rider-1', role: 'commuter' });
-    const res = await app.inject({
-      method: 'POST',
-      url: '/payments/initialize',
-      headers: bearer(token),
-      payload: { plan: 'monthly' },
-    });
-    expect(res.statusCode).toBe(503);
+    expect(
+      (
+        await app.inject({
+          method: 'POST',
+          url: '/payments/topup',
+          headers: bearer(token),
+          payload: { amountGhs: 50 },
+        })
+      ).statusCode,
+    ).toBe(503);
   });
 });
 
 describe('POST /webhooks/paystack', () => {
-  it('grants tokens on a validly-signed charge.success (end-to-end)', async () => {
+  it('topup: a signed charge.success grants tokens (balance via /me/balance)', async () => {
     const { build } = appWithPayments();
     const app = await build;
     const token = await jwt.signAccessToken({ userId: 'rider-1', role: 'commuter' });
+    const { reference } = (
+      await app.inject({
+        method: 'POST',
+        url: '/payments/topup',
+        headers: bearer(token),
+        payload: { amountGhs: 50 },
+      })
+    ).json();
 
-    const init = await app.inject({
-      method: 'POST',
-      url: '/payments/initialize',
-      headers: bearer(token),
-      payload: { plan: 'monthly' },
-    });
-    const { reference } = init.json();
-
-    const body = JSON.stringify({ event: 'charge.success', data: { reference } });
-    const res = await app.inject({
-      method: 'POST',
-      url: '/webhooks/paystack',
-      headers: {
-        'content-type': 'application/json',
-        'x-paystack-signature': paystackSignature(body, FAKE_SECRET),
-      },
-      payload: body,
-    });
-    expect(res.statusCode).toBe(200);
+    expect((await webhookFor(app, reference)).statusCode).toBe(200);
 
     const balance = await app.inject({ method: 'GET', url: '/me/balance', headers: bearer(token) });
-    expect(balance.json()).toEqual({ balanceGhs: 250 });
+    expect(balance.json()).toEqual({ balanceGhs: 50 });
+  });
+
+  it('subscription: a signed charge.success activates membership without granting tokens', async () => {
+    const { build, ledger, subscriptions } = appWithPayments();
+    const app = await build;
+    const token = await jwt.signAccessToken({ userId: 'rider-2', role: 'commuter' });
+    const { reference } = (
+      await app.inject({
+        method: 'POST',
+        url: '/payments/subscribe',
+        headers: bearer(token),
+        payload: { plan: 'monthly' },
+      })
+    ).json();
+
+    expect((await webhookFor(app, reference)).statusCode).toBe(200);
+
+    expect(await subscriptions.findActiveByUser('rider-2')).not.toBeNull();
+    expect(await ledger.balanceOf('rider-2')).toBe(0);
   });
 
   it('rejects a bad signature with 401', async () => {
-    const { build } = appWithPayments();
-    const app = await build;
-    const body = JSON.stringify({ event: 'charge.success', data: { reference: 'x' } });
+    const app = await appWithPayments().build;
     const res = await app.inject({
       method: 'POST',
       url: '/webhooks/paystack',
       headers: { 'content-type': 'application/json', 'x-paystack-signature': 'bad' },
-      payload: body,
+      payload: '{"event":"charge.success","data":{"reference":"x"}}',
     });
     expect(res.statusCode).toBe(401);
   });

--- a/services/api/tests/payments.service.test.ts
+++ b/services/api/tests/payments.service.test.ts
@@ -13,7 +13,7 @@ import {
 } from '../src/modules/subscriptions/subscription.repository';
 
 const FAKE_SECRET = 'fake-paystack-secret';
-const planPrices = { monthly: 250, annual: 2500 };
+const subscriptionFees = { monthly: 20, annual: 200 };
 
 function make(subscriptions: SubscriptionRepository = new InMemorySubscriptionRepository()) {
   const payments = new InMemoryPaymentRepository();
@@ -23,7 +23,7 @@ function make(subscriptions: SubscriptionRepository = new InMemorySubscriptionRe
     ledger,
     subscriptions,
     paystack: new FakePaystackClient(FAKE_SECRET),
-    planPrices,
+    subscriptionFees,
   });
   return { payments, ledger, subscriptions, service };
 }
@@ -33,16 +33,26 @@ function chargeSuccess(reference: string): { body: string; signature: string } {
   return { body, signature: paystackSignature(body, FAKE_SECRET) };
 }
 
-describe('PaymentsService.initialize', () => {
-  it('creates a pending payment and returns a checkout URL', async () => {
+describe('PaymentsService.initialize*', () => {
+  it('subscription: pending payment with the membership fee + a checkout URL', async () => {
     const { service, payments } = make();
-    const { reference, authorizationUrl } = await service.initialize('u1', 'monthly');
+    const { reference, authorizationUrl } = await service.initializeSubscription('u1', 'monthly');
     expect(authorizationUrl).toBeTruthy();
-    const payment = await payments.findByReference(reference);
-    expect(payment).toMatchObject({
-      userId: 'u1',
+    expect(await payments.findByReference(reference)).toMatchObject({
+      purpose: 'subscription',
       plan: 'monthly',
-      amount: 250,
+      amount: 20,
+      status: 'pending',
+    });
+  });
+
+  it('topup: pending payment with no plan and the chosen amount', async () => {
+    const { service, payments } = make();
+    const { reference } = await service.initializeTopup('u1', 50);
+    expect(await payments.findByReference(reference)).toMatchObject({
+      purpose: 'topup',
+      plan: null,
+      amount: 50,
       status: 'pending',
     });
   });
@@ -52,9 +62,9 @@ describe('PaymentsService.initialize', () => {
       payments: new InMemoryPaymentRepository(),
       ledger: new InMemoryLedgerRepository(),
       subscriptions: new InMemorySubscriptionRepository(),
-      planPrices,
+      subscriptionFees,
     });
-    await expect(service.initialize('u1', 'monthly')).rejects.toBeInstanceOf(
+    await expect(service.initializeTopup('u1', 50)).rejects.toBeInstanceOf(
       PaymentsNotConfiguredError,
     );
   });
@@ -63,60 +73,67 @@ describe('PaymentsService.initialize', () => {
 describe('PaymentsService.handleWebhook', () => {
   it('rejects an invalid signature', async () => {
     const { service } = make();
-    await expect(service.handleWebhook('{}', 'bad-sig')).rejects.toBeInstanceOf(
-      InvalidWebhookError,
-    );
+    await expect(service.handleWebhook('{}', 'bad')).rejects.toBeInstanceOf(InvalidWebhookError);
   });
 
-  it('on charge.success: grants tokens, activates the subscription, marks paid', async () => {
+  it('subscription paid: activates the subscription and grants NO tokens', async () => {
     const { service, ledger, subscriptions, payments } = make();
-    const { reference } = await service.initialize('u1', 'monthly');
+    const { reference } = await service.initializeSubscription('u1', 'monthly');
     const { body, signature } = chargeSuccess(reference);
 
     await service.handleWebhook(body, signature);
 
-    expect(await ledger.balanceOf('u1')).toBe(250);
     expect(await subscriptions.findActiveByUser('u1')).not.toBeNull();
+    expect(await ledger.balanceOf('u1')).toBe(0); // membership fee is not ride money
     expect((await payments.findByReference(reference))?.status).toBe('paid');
   });
 
-  it('is idempotent — replaying the webhook does not double-grant', async () => {
-    const { service, ledger } = make();
-    const { reference } = await service.initialize('u1', 'monthly');
+  it('topup paid: grants tokens and does NOT activate a subscription', async () => {
+    const { service, ledger, subscriptions, payments } = make();
+    const { reference } = await service.initializeTopup('u1', 50);
     const { body, signature } = chargeSuccess(reference);
 
     await service.handleWebhook(body, signature);
-    await service.handleWebhook(body, signature); // replay
 
-    expect(await ledger.balanceOf('u1')).toBe(250); // not 500
+    expect(await ledger.balanceOf('u1')).toBe(50);
+    expect(await subscriptions.findActiveByUser('u1')).toBeNull();
+    expect((await payments.findByReference(reference))?.status).toBe('paid');
+  });
+
+  it('topup is idempotent — replay does not double-grant', async () => {
+    const { service, ledger } = make();
+    const { reference } = await service.initializeTopup('u1', 50);
+    const { body, signature } = chargeSuccess(reference);
+
+    await service.handleWebhook(body, signature);
+    await service.handleWebhook(body, signature);
+
+    expect(await ledger.balanceOf('u1')).toBe(50);
   });
 
   it('ignores non charge.success events and unknown references', async () => {
     const { service, ledger } = make();
-    const { reference } = await service.initialize('u1', 'monthly');
+    const { reference } = await service.initializeTopup('u1', 50);
 
     const failed = JSON.stringify({ event: 'charge.failed', data: { reference } });
     await service.handleWebhook(failed, paystackSignature(failed, FAKE_SECRET));
-
     const unknown = JSON.stringify({ event: 'charge.success', data: { reference: 'nope' } });
     await service.handleWebhook(unknown, paystackSignature(unknown, FAKE_SECRET));
 
     expect(await ledger.balanceOf('u1')).toBe(0);
   });
 
-  it('treats a unique-violation on activation as already-active (idempotent)', async () => {
+  it('treats a unique-violation on activation as already-active', async () => {
     const subscriptions: SubscriptionRepository = {
       findActiveByUser: async () => null,
       create: async () => {
         throw Object.assign(new Error('dup'), { code: '23505' });
       },
     };
-    const { service, ledger } = make(subscriptions);
-    const { reference } = await service.initialize('u1', 'monthly');
+    const { service } = make(subscriptions);
+    const { reference } = await service.initializeSubscription('u1', 'monthly');
     const { body, signature } = chargeSuccess(reference);
-
     await expect(service.handleWebhook(body, signature)).resolves.toBeUndefined();
-    expect(await ledger.balanceOf('u1')).toBe(250);
   });
 
   it('propagates non-unique errors from activation', async () => {
@@ -127,9 +144,8 @@ describe('PaymentsService.handleWebhook', () => {
       },
     };
     const { service } = make(subscriptions);
-    const { reference } = await service.initialize('u1', 'monthly');
+    const { reference } = await service.initializeSubscription('u1', 'monthly');
     const { body, signature } = chargeSuccess(reference);
-
     await expect(service.handleWebhook(body, signature)).rejects.toThrow('db down');
   });
 });


### PR DESCRIPTION
## Why
A subscription is a **fee to be on the platform** — it is **not** a token grant. **Tokens** are loaded separately (top-up) to pay ride fares. #65 conflated them (a subscription payment granted tokens). This corrects the model.

This matches system-design §4.3 — boarding checks **both** an active subscription **and** sufficient balance (two gates). The bug was the `subscription_grant` ledger reason in §4.1.

## Changes
- **migration `008`**: `payments.purpose` (`subscription` | `topup`), `plan` nullable; `token_ledger` reason → `('topup','boarding','refund')`.
- **Webhook branches on purpose:** `subscription` → activate membership (no tokens); `topup` → grant tokens (no membership).
- **Routes:** `POST /payments/subscribe` (membership fee) + `POST /payments/topup` (load GHS) — replacing the single `/payments/initialize`.
- **Config:** `SUBSCRIPTION_FEES_GHS` (the membership fee) replaces the conflated price map (placeholders — set real values).
- Ledger reason `subscription_grant` → `topup`; **ADR-0011 amended** with the correction.

## Verification
- `pnpm check` green; **104 tests, ~98% coverage**.
- **Live smoke:** top-up → balance **40** (granted); subscribe → balance **still 40** (membership only, no tokens). ✅

## Note
The strategy `system-design §4.1/§4.2` still describes the old (conflated) model — it should be updated to match. I can do that in the `strategy` repo if you want.

Follow-up to #21 (corrects #65).