### PR TITLE
docs(features): authentication + wallet/payments feature docs

### DIFF
--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -1,0 +1,38 @@
+# Feature documentation
+
+Living, per-feature documentation for `mobility-core` — what each feature does,
+its API contract, how it works, how to configure it, and its security/edge-case
+notes. Aimed at backend engineers building on a feature and frontend engineers
+consuming it.
+
+These docs describe **behaviour and contracts**; the **why** behind a decision
+lives in an [ADR](../adr/), and the deep design lives in the private `strategy`
+repo (`system-design.md`, `security.md`). Each doc links to both.
+
+> A feature doc is the source of truth for _how to use_ a feature. When code and
+> a doc disagree, the code wins — fix the doc in the same PR.
+
+## Index
+
+| Feature                                                                       | Doc                                                         | Status  |
+| ----------------------------------------------------------------------------- | ----------------------------------------------------------- | ------- |
+| Authentication — access tokens, route guard, sign-in/refresh/logout           | [authentication.md](authentication.md)                      | ✅ live |
+| Wallet & payments — token ledger, balance, subscriptions & top-ups (Paystack) | [payments-and-wallet.md](payments-and-wallet.md)            | ✅ live |
+| Mobility — routes, stops, browse                                              | _(in review — #57)_                                         | 🚧      |
+| Rate limiting                                                                 | see [ADR-0023 / ratelimit](authentication.md#rate-limiting) | ✅      |
+| Observability (RED metrics)                                                   | _(not started — #28)_                                       | ❌      |
+
+## Conventions for a feature doc
+
+One doc per feature (roughly one `services/api/src/modules/*` area). Each should
+cover, in this order:
+
+1. **Overview** — what it is, in two or three sentences, and its status.
+2. **Concepts / model** — the key ideas a reader must hold.
+3. **API** — every endpoint: method, path, auth, request, responses + status codes.
+4. **How it works** — the flow (a diagram when it helps).
+5. **Configuration** — env vars and their effect.
+6. **Security** — what protects it and what to watch for.
+7. **Local development & testing** — how to run/exercise it with zero infra.
+8. **Where the code lives** — the files.
+9. **Related** — ADRs and design-doc sections.

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -1,5 +1,7 @@
 # Feature documentation
 
+**Owner:** Godfred Awuku · **Last updated:** 2026-06-28
+
 Living, per-feature documentation for `mobility-core` — what each feature does,
 its API contract, how it works, how to configure it, and its security/edge-case
 notes. Aimed at backend engineers building on a feature and frontend engineers
@@ -14,13 +16,13 @@ repo (`system-design.md`, `security.md`). Each doc links to both.
 
 ## Index
 
-| Feature                                                                       | Doc                                                                      | Status  |
-| ----------------------------------------------------------------------------- | ------------------------------------------------------------------------ | ------- |
-| Authentication — access tokens, route guard, sign-in/refresh/logout           | [authentication.md](authentication.md)                                   | ✅ live |
-| Wallet & payments — token ledger, balance, subscriptions & top-ups (Paystack) | [payments-and-wallet.md](payments-and-wallet.md)                         | ✅ live |
-| Mobility — routes, stops, browse                                              | _(in review — #57)_                                                      | 🚧      |
-| Rate limiting (#23)                                                           | see [authentication.md → Rate limiting](authentication.md#rate-limiting) | ✅      |
-| Observability (RED metrics)                                                   | _(not started — #28)_                                                    | ❌      |
+| Feature                                                                       | Doc                                              | Status  |
+| ----------------------------------------------------------------------------- | ------------------------------------------------ | ------- |
+| Authentication — access tokens, route guard, sign-in/refresh/logout           | [authentication.md](authentication.md)           | ✅ live |
+| Wallet & payments — token ledger, balance, subscriptions & top-ups (Paystack) | [payments-and-wallet.md](payments-and-wallet.md) | ✅ live |
+| Mobility — routes, stops, browse                                              | _(in review — #57)_                              | 🚧      |
+| Rate limiting (#23)                                                           | [rate-limiting.md](rate-limiting.md)             | ✅ live |
+| Observability (RED metrics)                                                   | _(not started — #28)_                            | ❌      |
 
 ## Conventions for a feature doc
 

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -14,13 +14,13 @@ repo (`system-design.md`, `security.md`). Each doc links to both.
 
 ## Index
 
-| Feature                                                                       | Doc                                                         | Status  |
-| ----------------------------------------------------------------------------- | ----------------------------------------------------------- | ------- |
-| Authentication — access tokens, route guard, sign-in/refresh/logout           | [authentication.md](authentication.md)                      | ✅ live |
-| Wallet & payments — token ledger, balance, subscriptions & top-ups (Paystack) | [payments-and-wallet.md](payments-and-wallet.md)            | ✅ live |
-| Mobility — routes, stops, browse                                              | _(in review — #57)_                                         | 🚧      |
-| Rate limiting                                                                 | see [ADR-0023 / ratelimit](authentication.md#rate-limiting) | ✅      |
-| Observability (RED metrics)                                                   | _(not started — #28)_                                       | ❌      |
+| Feature                                                                       | Doc                                                                      | Status  |
+| ----------------------------------------------------------------------------- | ------------------------------------------------------------------------ | ------- |
+| Authentication — access tokens, route guard, sign-in/refresh/logout           | [authentication.md](authentication.md)                                   | ✅ live |
+| Wallet & payments — token ledger, balance, subscriptions & top-ups (Paystack) | [payments-and-wallet.md](payments-and-wallet.md)                         | ✅ live |
+| Mobility — routes, stops, browse                                              | _(in review — #57)_                                                      | 🚧      |
+| Rate limiting (#23)                                                           | see [authentication.md → Rate limiting](authentication.md#rate-limiting) | ✅      |
+| Observability (RED metrics)                                                   | _(not started — #28)_                                                    | ❌      |
 
 ## Conventions for a feature doc
 

--- a/docs/features/authentication.md
+++ b/docs/features/authentication.md
@@ -1,5 +1,7 @@
 # Authentication
 
+**Owner:** Godfred Awuku · **Last updated:** 2026-06-28
+
 **Status:** ✅ live (slices 1 + 2). Apple sign-in and OTP fallback are deferred.
 
 How Trotxi proves _who_ is calling and decides _what_ they may do. It has two

--- a/docs/features/authentication.md
+++ b/docs/features/authentication.md
@@ -1,0 +1,237 @@
+# Authentication
+
+**Status:** ✅ live (slices 1 + 2). Apple sign-in and OTP fallback are deferred.
+
+How Trotxi proves _who_ is calling and decides _what_ they may do. It has two
+layers:
+
+1. **Access tokens + a route guard** — short-lived JWTs verified statelessly on
+   every request (slice 1).
+2. **Sign-in / refresh / logout** — social sign-in (Google) that issues those
+   tokens, plus rotating refresh tokens for long-lived sessions (slice 2,
+   orchestrated by `AuthService`).
+
+Design rationale: [ADR-0007](../adr/0007-jwt-auth-guard.md); deep design in
+`strategy/security.md §3–4`.
+
+---
+
+## Concepts
+
+- **Access token** — a signed JWT the client sends on every request. Short-lived
+  (15 min) and **stateless**: the server verifies the signature, no DB hit.
+- **Refresh token** — a long-lived, opaque random token used only to get a new
+  access token. Stored **hashed** in `sessions`, **rotated** on each use, and
+  **revocable** (logout). The raw token is shown to the client exactly once.
+- **Principal** — `request.user = { id, role }`, set by the guard after a valid
+  access token.
+- **RBAC** — authorization is by the `role` claim (`commuter` | `driver` |
+  `admin`). Ownership/relationship checks (e.g. "is this _your_ trip?") are done
+  **per-route**, not by the guard.
+- **Provider identity** — a `(provider, providerId)` pair (`auth_identity`) links
+  a Google account to one Trotxi user. A returning user maps to the same account.
+
+---
+
+## Part 1 — Access tokens & the route guard
+
+### Token format
+
+Signed JWT, **HS256**. Claims:
+
+| Claim         | Meaning                                 |
+| ------------- | --------------------------------------- |
+| `sub`         | the user id                             |
+| `role`        | `commuter` \| `driver` \| `admin`       |
+| `iss` / `aud` | `trotxi` / `trotxi-api` (verified)      |
+| `iat` / `exp` | issued-at / expiry (default **15 min**) |
+
+The client sends it as `Authorization: Bearer <token>`. Verification also
+**validates the decoded payload** (zod) — a structurally valid token with an
+unknown role or missing subject is rejected.
+
+### The guard (decorators on the Fastify instance)
+
+| Decorator                   | Effect                                                                                                         |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `app.authenticate`          | preHandler — **401** if the bearer token is missing/malformed/expired/invalid; on success sets `request.user`. |
+| `app.requireRole(...roles)` | preHandler factory — **403** if `request.user.role` isn't in `roles`. Compose **after** `authenticate`.        |
+| `app.jwt`                   | the token service (`signAccessToken` / `verifyAccessToken`) — used by the sign-in routes.                      |
+
+### Protecting a route
+
+```ts
+// must be logged in
+app.get('/account', { preHandler: app.authenticate }, async (req) => getAccount(req.user!.id));
+
+// must be an admin
+app.post('/admin/routes', { preHandler: [app.authenticate, app.requireRole('admin')] }, handler);
+
+// per-route ownership (the guard does NOT do this for you)
+app.get('/trips/:id', { preHandler: app.authenticate }, async (req, reply) => {
+  const trip = await trips.findById(req.params.id);
+  if (trip?.driverId !== req.user!.id) return reply.code(403).send();
+  return trip;
+});
+```
+
+`GET /me` is the worked example in `auth.routes.ts`.
+
+### Configuration (Part 1)
+
+| Env var                       | Default                 | Notes                                                                                                     |
+| ----------------------------- | ----------------------- | --------------------------------------------------------------------------------------------------------- |
+| `JWT_SECRET`                  | dev-only fallback       | **Required in production** (min 32 chars); the API refuses to boot without it. `openssl rand -base64 48`. |
+| `JWT_ACCESS_TTL`              | `15m`                   | access-token lifetime                                                                                     |
+| `JWT_ISSUER` / `JWT_AUDIENCE` | `trotxi` / `trotxi-api` |                                                                                                           |
+
+---
+
+## Part 2 — Sign-in, refresh & logout (`AuthService`)
+
+`AuthService` is the first service-layer service: routes are thin, it owns the
+orchestration (verify → find-or-create user → session → tokens).
+
+### Flow
+
+```
+client (app)                         API
+  │  Google ID token                  │
+  ├──POST /auth/google───────────────▶│ verify ID token (Google JWKS, aud)
+  │                                    │ find-or-create user + auth_identity
+  │                                    │ create session (refresh token, hashed)
+  │                                    │ sign access token
+  │◀──{ user, accessToken, refreshToken }
+  │                                    │
+  │  ...15 min later, access expires   │
+  ├──POST /auth/refresh───────────────▶│ look up session by hash → rotate
+  │◀──{ accessToken, refreshToken }    │   (old refresh token is now dead)
+  │                                    │
+  ├──POST /auth/logout────────────────▶│ revoke the session
+  │◀──204                              │
+```
+
+### API
+
+#### `POST /auth/google`
+
+Sign in (or sign up on first use) with a Google ID token.
+
+- **Auth:** none. **Rate limit:** 10/min per IP.
+- **Body:** `{ "idToken": "<google ID token>" }`
+- **200:** `{ "user": { id, displayName, phone, avatarUrl, role, createdAt }, "accessToken": "...", "refreshToken": "..." }`
+- **401** invalid token · **429** rate-limited · **503** sign-in not configured
+
+#### `POST /auth/refresh`
+
+Exchange a refresh token for a new pair (**rotates** — the old refresh token is invalidated).
+
+- **Auth:** none (the refresh token is the credential). **Rate limit:** 10/min per IP.
+- **Body:** `{ "refreshToken": "..." }`
+- **200:** `{ "accessToken": "...", "refreshToken": "..." }`
+- **401** invalid/expired/revoked · **503** not configured
+
+#### `POST /auth/logout`
+
+Revoke a refresh token. Idempotent.
+
+- **Body:** `{ "refreshToken": "..." }` → **204** (always, even for an unknown token).
+
+#### `GET /me`
+
+The authenticated user.
+
+- **Auth:** `Bearer` access token. **Rate limit:** per user.
+- **200:** the user · **401** no/invalid token · **404** user not found.
+
+### Refresh tokens & sessions
+
+- A refresh token is `randomBytes(32)`; only its **SHA-256 hash** is stored
+  (`sessions.refresh_token_hash`) — a DB leak exposes no usable tokens.
+- **Rotation:** `/auth/refresh` revokes the presented session and issues a new
+  one (`rotated_from` links them). Reusing a rotated token → 401.
+- **Revocation:** logout sets `revoked_at`. (Refresh-reuse _detection_ — revoking
+  the whole family on replay — is slice-3 hardening, not yet implemented.)
+
+### The verifier (how Google is wired)
+
+`AuthService` depends on an `IdTokenVerifier` interface, selected at startup:
+
+| Condition              | Verifier                                                                  | `/auth/google`                  |
+| ---------------------- | ------------------------------------------------------------------------- | ------------------------------- |
+| `GOOGLE_CLIENT_ID` set | **GoogleIdTokenVerifier** (jose JWKS; checks signature, issuer, audience) | real sign-in                    |
+| unset, non-production  | **FakeIdTokenVerifier**                                                   | dev/test (see below)            |
+| unset, production      | none                                                                      | **503** (keeps staging booting) |
+
+### Configuration (Part 2)
+
+| Env var                | Default | Notes                                                                                                                                         |
+| ---------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GOOGLE_CLIENT_ID`     | unset   | the Google **"Web"** OAuth client ID = the token audience. **Public, not a secret.** No client _secret_ needed (we only verify the ID token). |
+| `JWT_REFRESH_TTL_DAYS` | `30`    | refresh-token lifetime                                                                                                                        |
+
+> The mobile apps additionally need **Android + iOS** OAuth client IDs in the
+> same Google project; the backend only needs the Web client ID.
+
+---
+
+## Rate limiting
+
+`/auth/google` and `/auth/refresh` are capped at **10 requests/min per IP** (the
+credential-endpoint brute-force guard). `/me` is limited per user. Over the
+limit → **429** with a `Retry-After` header. Backed by the KV store (in-memory
+in dev, Redis in prod); it **fails open** if the store is down.
+
+## Security notes
+
+- **Access tokens can't be revoked before they expire** — hence the short TTL.
+  Real "sign out" is the refresh/session layer (logout).
+- **Role changes are eventually consistent** — a promotion/demotion takes effect
+  on the next refresh, not instantly. Destructive actions should re-check
+  server-side.
+- **HS256** (shared secret) is correct while one service both signs and verifies.
+  Splitting issuer/verifier later → move to RS256/EdDSA (would supersede ADR-0007).
+- **Client storage:** keep the refresh token in secure storage (Keychain /
+  Keystore), not plain prefs.
+
+## Local development & testing
+
+No Google setup needed in dev — the **fake verifier** is wired when
+`GOOGLE_CLIENT_ID` is unset (non-production). The `idToken` is just a JSON blob
+of claims:
+
+```bash
+# sign in
+curl -s localhost:3000/auth/google -H 'content-type: application/json' \
+  -d '{ "idToken": "{\"sub\":\"g-1\",\"name\":\"Ama\"}" }'
+# → { user, accessToken, refreshToken }
+
+# call a protected route with the accessToken (NOT the idToken)
+curl localhost:3000/me -H "authorization: Bearer <accessToken>"
+```
+
+In Swagger (`/docs`): call `POST /auth/google`, copy the `accessToken` from the
+response, click **Authorize**, paste just that token.
+
+## Where the code lives
+
+```
+services/api/src/modules/auth/
+  jwt.ts                     # token sign/verify service (HS256)
+  auth.plugin.ts             # app.authenticate / app.requireRole / request.user
+  id-token-verifier.ts       # IdTokenVerifier interface + FakeIdTokenVerifier
+  id-token-verifier.google.ts# GoogleIdTokenVerifier (JWKS; excluded from unit coverage)
+  session.repository.ts(.pg) # refresh-token sessions (hashed, rotate, revoke)
+  auth-identity.repository.*  # provider identity → user link
+  auth.service.ts            # AuthService: signIn / refresh / logout
+  auth.routes.ts             # /me, /auth/google, /auth/refresh, /auth/logout
+  auth.schema.ts             # request/response zod schemas
+  tokens.ts                  # refresh-token generation + hashing
+```
+
+## Related
+
+- [ADR-0007 — JWT access tokens & guard](../adr/0007-jwt-auth-guard.md)
+- [ADR-0008 — zod + OpenAPI contract](../adr/0008-zod-openapi-contract.md)
+- [ADR-0009 — repository pattern](../adr/0009-repository-pattern.md)
+- `strategy/security.md §3 (authentication), §4 (authorization)`

--- a/docs/features/payments-and-wallet.md
+++ b/docs/features/payments-and-wallet.md
@@ -1,0 +1,206 @@
+# Wallet & Payments (the money system)
+
+**Status:** ✅ live. Reflects the model as of **#66** (subscription vs. top-up
+separated). The token-debit-on-boarding side is [#20](https://github.com/TROTXI/mobility-core/issues/20)
+(deferred).
+
+The money system has two **separate** flows — keep them straight:
+
+|            | **Subscription**                                     | **Tokens (wallet)**                        |
+| ---------- | ---------------------------------------------------- | ------------------------------------------ |
+| What       | A recurring **membership fee** to be on the platform | A **prepaid GHS wallet** to pay ride fares |
+| Funded by  | `POST /payments/subscribe`                           | `POST /payments/topup`                     |
+| On payment | Activates the subscription — **grants no tokens**    | **Grants tokens** — no membership change   |
+| Spent by   | (gates boarding)                                     | Boarding debits the fare (#20)             |
+
+**Boarding requires _both_** — an active subscription **and** enough balance.
+1 token = 1 GHS. Rationale: [ADR-0011](../adr/0011-token-ledger.md); deep design
+in `strategy/system-design.md §4` + `security.md §7`.
+
+---
+
+## Concepts
+
+- **Append-only ledger, not a balance column.** The wallet is `token_ledger` —
+  every credit (+) and debit (−) is one immutable row. **Balance = `SUM(delta)`**
+  (derived; cache later, but never the source of truth). A mutable balance column
+  loses money under concurrency/crashes and has no audit trail.
+- **Exactly-once writes** via a unique `idempotency_key` — a retried grant/debit
+  is a no-op, never a double-write.
+- **Payment = state machine** `pending → paid|failed`, **never mutated once
+  `paid`**. `reference` is unique (ours and Paystack's) and dedupes webhooks.
+- **Server-authoritative amounts** — the fare and the membership fee come from
+  the server, never from the client.
+
+---
+
+## The wallet (token ledger)
+
+`token_ledger(id, user_id, delta, reason, ref_type, ref_id, idempotency_key
+unique, created_at)`.
+
+- `delta` is GHS-denominated (`+50` top-up, `-3` fare).
+- `reason` ∈ `topup` | `boarding` | `refund`. `ref_type` ∈ `payment` | `boarding`.
+- **Balance** = `SUM(delta)` for the user (0 when empty).
+
+### `GET /me/balance`
+
+The authenticated rider's GHS balance (the home screen, app #35).
+
+- **Auth:** `Bearer`. **Rate limit:** per user.
+- **200:** `{ "balanceGhs": 240 }` · **401** no/invalid token.
+
+---
+
+## Payments (Paystack)
+
+`payments(id, user_id, reference unique, purpose, plan, amount, currency, status,
+created_at, updated_at)`. `purpose` ∈ `subscription` | `topup`; `plan`
+(`monthly` | `annual`) is set **only** for subscriptions.
+
+### Flow
+
+```
+client (app)                          API                         Paystack
+  ├─POST /payments/{subscribe|topup}──▶│ create pending payment
+  │                                     ├──initialize transaction──▶│
+  │◀──{ authorizationUrl, reference }───┤◀──authorization_url────────┤
+  │                                     │
+  │  (user pays in Paystack checkout)   │                            │
+  │                                     │◀───POST /webhooks/paystack─┤ charge.success
+  │                                     │  verify HMAC-SHA512 sig
+  │                                     │  purpose=topup → grant tokens
+  │                                     │  purpose=subscription → activate
+  │                                     │  mark payment paid
+  │                                     ├──200 { received: true }────▶│
+```
+
+### API
+
+#### `POST /payments/subscribe`
+
+Start a checkout for the platform **membership fee**.
+
+- **Auth:** `Bearer`. **Rate limit:** per user.
+- **Body:** `{ "plan": "monthly" | "annual" }`
+- **200:** `{ "authorizationUrl": "https://checkout.paystack.com/...", "reference": "trotxi_..." }`
+- **401** · **429** · **503** payments not configured
+
+#### `POST /payments/topup`
+
+Start a checkout to **load ride tokens** (GHS) into the wallet.
+
+- **Auth:** `Bearer`. **Rate limit:** per user.
+- **Body:** `{ "amountGhs": 50 }` (integer ≥ 1)
+- **200:** `{ "authorizationUrl": "...", "reference": "..." }` · **401** · **429** · **503**
+
+#### `POST /webhooks/paystack`
+
+Paystack's payment confirmation. **Public**, but signature-verified.
+
+- **Header:** `x-paystack-signature` — HMAC-SHA512 of the **raw** body, keyed by
+  the secret key. **Mandatory** — without it anyone could mint tokens.
+- **200:** `{ "received": true }` (also for ignored/duplicate events — idempotent)
+- **401** bad/missing signature · **503** not configured
+- On `charge.success`: **top-up** → grants `amount` tokens (`reason: topup`);
+  **subscription** → activates the subscription. Neither does the other.
+
+### Idempotency & fail-safe
+
+Per `system-design §4.2` ("idempotent webhooks"), the webhook is **not** one big
+transaction — each step is independently idempotent, so a retried/partial webhook
+converges:
+
+- the ledger grant is keyed `topup:<reference>` → no double grant;
+- subscription activation is guarded by the one-active-per-user index → no double
+  activate;
+- `markPaid` only does `pending → paid`.
+
+Paystack retries delivery; a **nightly reconciliation** against Paystack's
+settlement (future) backstops anything it gives up on. We never mutate a `paid`
+payment.
+
+### Configuration
+
+| Env var               | Default | Notes                                                                                                                                                                                            |
+| --------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `PAYSTACK_SECRET_KEY` | unset   | the `sk_...` **secret** key — for API calls **and** webhook signature verification. A real secret → Render dashboard only, never committed. Unset → dev fake client (non-prod) / **503** (prod). |
+
+Other server-side config (in `payments.service.ts`):
+
+- `SUBSCRIPTION_FEES_GHS` — the membership fee per plan (**placeholders** —
+  set real values).
+
+> The `sk_...` secret key is the **backend's**. The mobile app uses the
+> **`pk_...` public** key in the Paystack SDK.
+
+---
+
+## Security notes
+
+- **Verify the webhook signature** — non-negotiable. We compute HMAC-SHA512 over
+  the **raw** request bytes (via `fastify-raw-body`); a re-serialized JSON would
+  not match.
+- **No double-spend / double-grant** — the unique `idempotency_key` on every
+  ledger write.
+- **No lost payment** — state machine + idempotent webhooks + (future)
+  reconciliation; a `paid` row is immutable.
+- **Server-authoritative amounts** — never trust a client-reported fare/price/
+  balance.
+- **Degrade safe** — if Paystack is down, riding with _existing_ tokens still
+  works; only new top-ups/subscriptions block.
+
+## Local development & testing
+
+No keys needed — a **fake Paystack client** is wired when `PAYSTACK_SECRET_KEY`
+is unset (non-production). It returns a stub checkout URL and signs/verifies
+webhooks with a known dev secret (`fake-paystack-secret`):
+
+```bash
+B=http://localhost:3000
+AT=...   # an access token (see authentication.md)
+
+# top up 40 GHS
+REF=$(curl -s $B/payments/topup -H "authorization: Bearer $AT" \
+  -H 'content-type: application/json' -d '{"amountGhs":40}' | jq -r .reference)
+
+# simulate the webhook (sign the exact body with the dev secret)
+BODY="{\"event\":\"charge.success\",\"data\":{\"reference\":\"$REF\"}}"
+SIG=$(node -e "const c=require('crypto');process.stdout.write(c.createHmac('sha512','fake-paystack-secret').update(process.argv[1]).digest('hex'))" "$BODY")
+curl -s $B/webhooks/paystack -H 'content-type: application/json' \
+  -H "x-paystack-signature: $SIG" -d "$BODY"
+
+curl -s $B/me/balance -H "authorization: Bearer $AT"   # → { "balanceGhs": 40 }
+```
+
+A `subscribe` payment, by contrast, leaves the balance unchanged and activates
+the subscription.
+
+## Going live (production)
+
+1. Set `PAYSTACK_SECRET_KEY` (the `sk_live_...`) in the Render dashboard.
+2. Register the webhook URL in the Paystack dashboard → `https://…/webhooks/paystack`.
+3. Set the real `SUBSCRIPTION_FEES_GHS`.
+
+## Where the code lives
+
+```
+services/api/src/modules/ledger/
+  ledger.repository.ts(.pg)     # append-only ledger: append (idempotent) + balanceOf
+  ledger.routes.ts             # GET /me/balance
+services/api/src/modules/payments/
+  payment.repository.ts(.pg)    # payment state machine (purpose, pending→paid)
+  paystack.client.ts           # PaystackClient interface + signature helper + Fake
+  paystack.client.live.ts      # real HTTP client (excluded from unit coverage)
+  payments.service.ts          # initializeSubscription / initializeTopup / handleWebhook
+  payments.routes.ts           # /payments/subscribe, /payments/topup, /webhooks/paystack
+  payments.schema.ts
+services/api/src/db/migrations/
+  006_token_ledger.sql · 007_payments.sql · 008_payment_purpose.sql
+```
+
+## Related
+
+- [ADR-0011 — append-only token ledger](../adr/0011-token-ledger.md)
+- [ADR-0009 — repository pattern](../adr/0009-repository-pattern.md)
+- `strategy/system-design.md §4 (data model)` · `security.md §7 (money controls)`

--- a/docs/features/payments-and-wallet.md
+++ b/docs/features/payments-and-wallet.md
@@ -1,5 +1,7 @@
 # Wallet & Payments (the money system)
 
+**Owner:** Godfred Awuku · **Last updated:** 2026-06-28
+
 **Status:** ✅ live. Reflects the model as of **#66** (subscription vs. top-up
 separated). The token-debit-on-boarding side is [#20](https://github.com/TROTXI/mobility-core/issues/20)
 (deferred).

--- a/docs/features/rate-limiting.md
+++ b/docs/features/rate-limiting.md
@@ -1,0 +1,114 @@
+# Rate limiting
+
+**Owner:** Godfred Awuku · **Last updated:** 2026-06-28
+
+**Status:** ✅ live (#23).
+
+A reusable guard that caps how often a client can hit a route — protecting
+credential and abuse-prone endpoints from brute force, scraping, and basic DoS.
+Fixed-window counting, backed by the KV store. Deep design: `strategy/security.md
+§8`; storage: [ADR-0010](../adr/0010-kv-redis.md).
+
+---
+
+## Concepts
+
+- **Fixed window.** A counter per `(route, subject)` with a TTL set **once**, on
+  the first hit — the window doesn't slide. Built on `KvStore.increment`.
+- **Subject = IP or user.** `by: 'ip'` (default) buckets per client IP — used for
+  pre-auth endpoints. `by: 'user'` buckets per authenticated user — used for
+  logged-in abuse. `by: 'user'` falls back to IP if there's no principal, so the
+  limit is never silently skipped.
+- **Fails open.** If the KV store is unavailable the request is **allowed** (a
+  cache outage must not take the API down) — logged as a warning.
+- **Backing store.** In-memory in dev/tests, Redis in prod ([ADR-0010](../adr/0010-kv-redis.md)).
+
+---
+
+## Usage
+
+`app.rateLimit(options)` is a preHandler factory (decorator on the Fastify
+instance):
+
+```ts
+// per IP (e.g. a public or pre-auth endpoint)
+app.post('/auth/google', { preHandler: [app.rateLimit({ max: 10, windowSeconds: 60 })] }, h);
+
+// per user (compose AFTER authenticate)
+app.get(
+  '/me',
+  { preHandler: [app.authenticate, app.rateLimit({ max: 100, windowSeconds: 60, by: 'user' })] },
+  h,
+);
+```
+
+| Option          | Default | Meaning                        |
+| --------------- | ------- | ------------------------------ |
+| `max`           | —       | requests allowed per window    |
+| `windowSeconds` | —       | window length                  |
+| `by`            | `'ip'`  | bucket key: `'ip'` or `'user'` |
+
+## Response
+
+- Under the limit → the route runs, with headers:
+  - `X-RateLimit-Limit` — the cap
+  - `X-RateLimit-Remaining` — remaining in the window
+- Over the limit → **429** with `Retry-After: <windowSeconds>` and body
+  `{ "error": "rate_limited", "message": "Too many requests. Try again later." }`.
+
+Clients should honour `Retry-After` and back off.
+
+## Where it's applied today
+
+| Endpoint(s)                                      | Limit                                            |
+| ------------------------------------------------ | ------------------------------------------------ |
+| `POST /auth/google`, `POST /auth/refresh`        | **10/min per IP** (strict, credential endpoints) |
+| `GET /me`, `GET /me/balance`, `POST /payments/*` | default, **per user**                            |
+| `POST /webhooks/paystack`                        | 60/min per IP                                    |
+
+Public browse endpoints (mobility) should also opt in per IP as they land.
+
+## Configuration
+
+| Env var                     | Default | Notes                                                              |
+| --------------------------- | ------- | ------------------------------------------------------------------ |
+| `RATE_LIMIT_MAX`            | `100`   | default per-window cap (the value passed to per-user route limits) |
+| `RATE_LIMIT_WINDOW_SECONDS` | `60`    | default window                                                     |
+
+Auth/webhook endpoints use their own stricter inline limits (above); the env
+defaults drive the general per-user limits.
+
+## Security notes
+
+- **Per-IP for pre-auth** (login/refresh) is the brute-force guard; **per-user**
+  protects authenticated abuse.
+- **Fail-open is a deliberate trade-off** — availability over strictness. A
+  determined attacker who can take down Redis could bypass limits; acceptable for
+  the pilot, revisit if it becomes a vector.
+- It is **not** a substitute for auth or ownership checks — it only throttles.
+
+## Local development & testing
+
+Works with zero infra (in-memory KV). To see it trigger, hit a tightly-limited
+route repeatedly:
+
+```bash
+# /auth/refresh is 10/min per IP — the 11th call in a minute returns 429
+for i in $(seq 1 11); do
+  curl -s -o /dev/null -w "%{http_code}\n" -XPOST localhost:3000/auth/refresh \
+    -H 'content-type: application/json' -d '{"refreshToken":"x"}'
+done
+# → 401 ×10 (bad token, but allowed), then 429
+```
+
+## Where the code lives
+
+```
+services/api/src/modules/ratelimit/ratelimit.plugin.ts   # app.rateLimit(...)
+```
+
+## Related
+
+- [ADR-0010 — KV/Redis](../adr/0010-kv-redis.md) (the backing store)
+- `strategy/security.md §8 (rate limiting & abuse)`
+- Issue #23


### PR DESCRIPTION
## What
Adds **`docs/features/`** — per-feature documentation (contract + how-it-works + config + security + local testing), with an index and conventions. First two features (the ones fully built):

- **`authentication.md`** — access tokens + route guard (JWT, slice 1) and sign-in/refresh/logout (`AuthService`, slice 2): token format, the guard decorators, full endpoint contracts, refresh/session rotation, the Google-vs-fake verifier, config, rate limiting, security notes, and the local fake-token flow.
- **`payments-and-wallet.md`** — the money system: append-only token ledger + `GET /me/balance`, and **subscriptions vs top-ups** (Paystack) with the signed webhook, idempotency/fail-safe, config, and a local fake-Paystack walkthrough.

## Notes
- The money doc reflects the **corrected model (#66)** — subscription = membership fee, tokens = top-up wallet. So this reads correctly once **#66 is merged** (its endpoints `/payments/subscribe` + `/payments/topup` are what's documented).
- Docs-only; links to the relevant ADRs (0007–0011) and the `strategy` design docs.

This sets the `docs/features/` pattern; mobility/observability/etc. get docs as they land.