### PR TITLE
money: finalize rider-side (pesewas) + put money system ON HOLD (commission model TBD)

### DIFF
--- a/docs/adr/0011-token-ledger.md
+++ b/docs/adr/0011-token-ledger.md
@@ -56,3 +56,16 @@ Boarding requires **both** an active subscription and sufficient balance
 (system-design §4.3) — two gates, not one. The ledger grant reason is now
 `topup` (migration `008`); `subscription_grant` is removed. The strategy
 `system-design §4.1/§4.2` should be updated to match.
+
+## Update — 2026-06-28 (units + on hold)
+
+- **Units:** amounts are stored and handled in **pesewas** (minor units;
+  1 GHS = 100 pesewas), matching Paystack — integers only, no sub-cedi precision
+  loss (#68). "1 token = 1 GHS" still holds at the GHS level; the client formats
+  GHS for display.
+- **On hold:** further money work is **paused** pending the product team's
+  **commission model** (how Trotxi charges its cut). The current build is
+  rider-side only (subscription + token wallet); commissions, driver payouts, and
+  the boarding debit (#20) are blocked on that decision because it shapes the
+  ledger and payout design. Full status:
+  `docs/features/payments-and-wallet.md` → "Status & roadmap (ON HOLD)".

--- a/docs/features/payments-and-wallet.md
+++ b/docs/features/payments-and-wallet.md
@@ -16,8 +16,9 @@ The money system has two **separate** flows — keep them straight:
 | Spent by   | (gates boarding)                                     | Boarding debits the fare (#20)             |
 
 **Boarding requires _both_** — an active subscription **and** enough balance.
-1 token = 1 GHS. Rationale: [ADR-0011](../adr/0011-token-ledger.md); deep design
-in `strategy/system-design.md §4` + `security.md §7`.
+1 token = 1 GHS; amounts are stored and exposed in **pesewas** (1 GHS = 100
+pesewas). Rationale: [ADR-0011](../adr/0011-token-ledger.md); deep design in
+`strategy/system-design.md §4` + `security.md §7`.
 
 ---
 
@@ -33,6 +34,9 @@ in `strategy/system-design.md §4` + `security.md §7`.
   `paid`**. `reference` is unique (ours and Paystack's) and dedupes webhooks.
 - **Server-authoritative amounts** — the fare and the membership fee come from
   the server, never from the client.
+- **Money unit: pesewas (minor units).** Every amount (`delta`, `amount`,
+  balances, API fields) is an integer in pesewas — `1 GHS = 100 pesewas`, matching
+  Paystack. Never floats. The app converts to/from GHS at the display edge.
 
 ---
 
@@ -41,16 +45,17 @@ in `strategy/system-design.md §4` + `security.md §7`.
 `token_ledger(id, user_id, delta, reason, ref_type, ref_id, idempotency_key
 unique, created_at)`.
 
-- `delta` is GHS-denominated (`+50` top-up, `-3` fare).
+- `delta` is in **pesewas** (`+5000` = GHS 50 top-up, `-300` = GHS 3 fare).
 - `reason` ∈ `topup` | `boarding` | `refund`. `ref_type` ∈ `payment` | `boarding`.
 - **Balance** = `SUM(delta)` for the user (0 when empty).
 
 ### `GET /me/balance`
 
-The authenticated rider's GHS balance (the home screen, app #35).
+The authenticated rider's wallet balance in pesewas (the home screen, app #35;
+the app formats GHS).
 
 - **Auth:** `Bearer`. **Rate limit:** per user.
-- **200:** `{ "balanceGhs": 240 }` · **401** no/invalid token.
+- **200:** `{ "balancePesewas": 24000 }` (= GHS 240) · **401** no/invalid token.
 
 ---
 
@@ -90,10 +95,10 @@ Start a checkout for the platform **membership fee**.
 
 #### `POST /payments/topup`
 
-Start a checkout to **load ride tokens** (GHS) into the wallet.
+Start a checkout to **load ride tokens** (pesewas) into the wallet.
 
 - **Auth:** `Bearer`. **Rate limit:** per user.
-- **Body:** `{ "amountGhs": 50 }` (integer ≥ 1)
+- **Body:** `{ "amountPesewas": 5000 }` (integer ≥ 100, i.e. GHS 1; = GHS 50 here)
 - **200:** `{ "authorizationUrl": "...", "reference": "..." }` · **401** · **429** · **503**
 
 #### `POST /webhooks/paystack`
@@ -130,8 +135,8 @@ payment.
 
 Other server-side config (in `payments.service.ts`):
 
-- `SUBSCRIPTION_FEES_GHS` — the membership fee per plan (**placeholders** —
-  set real values).
+- `SUBSCRIPTION_FEES_PESEWAS` — the membership fee per plan, in pesewas
+  (**placeholders** — set real values).
 
 > The `sk_...` secret key is the **backend's**. The mobile app uses the
 > **`pk_...` public** key in the Paystack SDK.
@@ -162,9 +167,9 @@ webhooks with a known dev secret (`fake-paystack-secret`):
 B=http://localhost:3000
 AT=...   # an access token (see authentication.md)
 
-# top up 40 GHS
+# top up GHS 40 (4000 pesewas)
 REF=$(curl -s $B/payments/topup -H "authorization: Bearer $AT" \
-  -H 'content-type: application/json' -d '{"amountGhs":40}' | jq -r .reference)
+  -H 'content-type: application/json' -d '{"amountPesewas":4000}' | jq -r .reference)
 
 # simulate the webhook (sign the exact body with the dev secret)
 BODY="{\"event\":\"charge.success\",\"data\":{\"reference\":\"$REF\"}}"
@@ -172,7 +177,7 @@ SIG=$(node -e "const c=require('crypto');process.stdout.write(c.createHmac('sha5
 curl -s $B/webhooks/paystack -H 'content-type: application/json' \
   -H "x-paystack-signature: $SIG" -d "$BODY"
 
-curl -s $B/me/balance -H "authorization: Bearer $AT"   # → { "balanceGhs": 40 }
+curl -s $B/me/balance -H "authorization: Bearer $AT"   # → { "balancePesewas": 4000 }
 ```
 
 A `subscribe` payment, by contrast, leaves the balance unchanged and activates
@@ -182,7 +187,7 @@ the subscription.
 
 1. Set `PAYSTACK_SECRET_KEY` (the `sk_live_...`) in the Render dashboard.
 2. Register the webhook URL in the Paystack dashboard → `https://…/webhooks/paystack`.
-3. Set the real `SUBSCRIPTION_FEES_GHS`.
+3. Set the real `SUBSCRIPTION_FEES_PESEWAS`.
 
 ## Where the code lives
 

--- a/docs/features/payments-and-wallet.md
+++ b/docs/features/payments-and-wallet.md
@@ -2,9 +2,15 @@
 
 **Owner:** Godfred Awuku · **Last updated:** 2026-06-28
 
-**Status:** ✅ live. Reflects the model as of **#66** (subscription vs. top-up
-separated). The token-debit-on-boarding side is [#20](https://github.com/TROTXI/mobility-core/issues/20)
-(deferred).
+**Status:** ⏸️ **ON HOLD** (as of 2026-06-28). The rider-side money system below
+is built and working; **further money work is paused** until the product team
+defines the **commission model** (how Trotxi charges its cut). See
+[Status & roadmap](#status--roadmap-on-hold).
+
+> ⏸️ **Paused.** Do not start new money features (boarding debit, driver payouts,
+> fee splits) until the commission model is decided — it changes the ledger and
+> payout design. The current build is a safe stopping point: rider-side only,
+> with no real funds processed.
 
 The money system has two **separate** flows — keep them straight:
 
@@ -19,6 +25,59 @@ The money system has two **separate** flows — keep them straight:
 1 token = 1 GHS; amounts are stored and exposed in **pesewas** (1 GHS = 100
 pesewas). Rationale: [ADR-0011](../adr/0011-token-ledger.md); deep design in
 `strategy/system-design.md §4` + `security.md §7`.
+
+---
+
+## Status & roadmap (ON HOLD)
+
+**Paused 2026-06-28**, pending the product team's commission-charging model.
+
+### ✅ Built & working (rider-side)
+
+- **Subscription** = platform membership fee → `POST /payments/subscribe`;
+  Paystack `charge.success` activates the subscription (grants no tokens).
+- **Token wallet** = prepaid balance → `POST /payments/topup` grants tokens;
+  `GET /me/balance` returns it. Append-only `token_ledger`, balance = `SUM(delta)`.
+- **Paystack integration** — checkout init + **signature-verified webhook**
+  (HMAC-SHA512 over the raw body), branching on payment `purpose`.
+- **Money safety** — exactly-once via `idempotency_key`, never mutate a `paid`
+  payment, server-authoritative amounts, fail-safe (idempotent) webhook steps.
+- **Pesewas units** end-to-end (minor units; #68).
+
+### ⏸️ Blocked on the commission decision
+
+The system today handles **rider-side money only**. It does **not** model the
+platform's revenue or the driver's side — both depend on how commissions work:
+
+- **Commissions** — how / where Trotxi takes its cut (undefined).
+- **Driver payouts** — paying drivers their fares, net of commission (unmodeled).
+- **Fare model & revenue split** — and whether the ledger needs driver
+  sub-accounts / commission + payout entries.
+
+**Open questions for product (to unblock):**
+
+1. **Basis** — % of fare, flat per ride, a cut of top-ups, or subscription-only?
+2. **Who bears it** — rider surcharge, driver deduction, or a split?
+3. **Timing** — charged at boarding, at payout, or at top-up?
+4. **Payouts** — how / when do drivers get paid, and how does commission net out?
+5. **Model fit** — does commission ride on the existing wallet/ledger, or need a
+   separate driver ledger + payout flow?
+
+### ⏳ Deferred (later, not all commission-blocked)
+
+- **Boarding debit** (#20) — spending tokens to board (QR/scan). Overlaps the
+  commission decision, so it should wait for it.
+- **Refunds** (`reason: refund` exists in the ledger; no flow yet).
+- **Nightly reconciliation** against Paystack settlement.
+- **SMS receipts** (mNotify; planning-phase, skipped).
+
+### Production posture while paused
+
+- Payments **fail safe**: with no `PAYSTACK_SECRET_KEY`, `/payments/*` return
+  **503** and staging stays up. No real funds are processed.
+- **Go-live is intentionally NOT done** — the live webhook URL and real
+  `SUBSCRIPTION_FEES_PESEWAS` are unset. Resume at [Going live](#going-live-production)
+  once the commission model lands.
 
 ---
 

--- a/services/api/src/modules/ledger/ledger.repository.ts
+++ b/services/api/src/modules/ledger/ledger.repository.ts
@@ -1,4 +1,4 @@
-// Token ledger — the rider's GHS wallet (system-design §4.1, ADR-0011).
+// Token ledger — the rider's wallet, in pesewas (system-design §4.1, ADR-0011).
 // Append-only: every entry is immutable; the balance is the SUM of deltas, never
 // a stored column. Writes are exactly-once via idempotency_key, so a retried
 // grant or debit is a no-op rather than a double-spend.
@@ -9,7 +9,7 @@ export type LedgerRefType = 'payment' | 'boarding';
 export interface LedgerEntry {
   id: string;
   userId: string;
-  /** GHS-denominated: positive for grants, negative for spends. */
+  /** Pesewas-denominated (1 GHS = 100 pesewas): + for grants, − for spends. */
   delta: number;
   reason: LedgerReason;
   refType: LedgerRefType;

--- a/services/api/src/modules/ledger/ledger.routes.ts
+++ b/services/api/src/modules/ledger/ledger.routes.ts
@@ -1,6 +1,6 @@
-// Wallet routes. GET /me/balance exposes the rider's derived GHS balance (the
-// home screen, app #35). Read-only here; grants come from payments (#21b),
-// debits from boarding (#20).
+// Wallet routes. GET /me/balance exposes the rider's derived balance in pesewas
+// (the home screen, app #35; the client formats GHS). Read-only here; grants come
+// from payments (#21b), debits from boarding (#20).
 
 import type { FastifyInstance } from 'fastify';
 import type { ZodTypeProvider } from 'fastify-type-provider-zod';
@@ -18,7 +18,7 @@ export async function ledgerRoutes(
     {
       schema: {
         tags: ['wallet'],
-        summary: 'Get the authenticated rider GHS token balance',
+        summary: 'Get the authenticated rider token balance (pesewas)',
         security: [{ bearerAuth: [] }],
         response: {
           200: balanceResponseSchema,
@@ -28,8 +28,8 @@ export async function ledgerRoutes(
       preHandler: [app.authenticate, app.rateLimit({ ...opts.rateLimit, by: 'user' })],
     },
     async (request) => {
-      const balanceGhs = opts.ledger ? await opts.ledger.balanceOf(request.user!.id) : 0;
-      return { balanceGhs };
+      const balancePesewas = opts.ledger ? await opts.ledger.balanceOf(request.user!.id) : 0;
+      return { balancePesewas };
     },
   );
 }

--- a/services/api/src/modules/ledger/ledger.schema.ts
+++ b/services/api/src/modules/ledger/ledger.schema.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
 export const balanceResponseSchema = z.object({
-  /** Remaining GHS value of the rider's tokens (1 token = 1 GHS). */
-  balanceGhs: z.number().int(),
+  /** Remaining wallet balance in pesewas (1 GHS = 100 pesewas). */
+  balancePesewas: z.number().int(),
 });

--- a/services/api/src/modules/payments/payment.repository.ts
+++ b/services/api/src/modules/payments/payment.repository.ts
@@ -14,7 +14,7 @@ export interface Payment {
   purpose: PaymentPurpose;
   /** Set for subscription payments; null for top-ups. */
   plan: SubscriptionPlan | null;
-  amount: number; // GHS
+  amount: number; // pesewas (1 GHS = 100 pesewas)
   currency: string;
   status: PaymentStatus;
   createdAt: Date;

--- a/services/api/src/modules/payments/payments.routes.ts
+++ b/services/api/src/modules/payments/payments.routes.ts
@@ -69,7 +69,7 @@ export async function paymentRoutes(
     {
       schema: {
         tags: ['payments'],
-        summary: 'Start a Paystack checkout to load ride tokens (GHS) into the wallet',
+        summary: 'Start a Paystack checkout to load ride tokens (pesewas) into the wallet',
         security: [{ bearerAuth: [] }],
         body: topupBodySchema,
         response: {
@@ -84,7 +84,10 @@ export async function paymentRoutes(
     async (request, reply) => {
       if (!opts.paymentsService) return reply.code(503).send(UNAVAILABLE);
       try {
-        return await opts.paymentsService.initializeTopup(request.user!.id, request.body.amountGhs);
+        return await opts.paymentsService.initializeTopup(
+          request.user!.id,
+          request.body.amountPesewas,
+        );
       } catch (err) {
         if (err instanceof PaymentsNotConfiguredError) return reply.code(503).send(UNAVAILABLE);
         throw err;

--- a/services/api/src/modules/payments/payments.schema.ts
+++ b/services/api/src/modules/payments/payments.schema.ts
@@ -10,8 +10,8 @@ export const subscribeBodySchema = z.object({
 });
 
 export const topupBodySchema = z.object({
-  /** GHS to load into the wallet (1 token = 1 GHS). */
-  amountGhs: z.number().int().min(1),
+  /** Pesewas to load into the wallet (1 GHS = 100 pesewas); min 100 = GHS 1. */
+  amountPesewas: z.number().int().min(100),
 });
 
 export const checkoutResponseSchema = z.object({

--- a/services/api/src/modules/payments/payments.service.ts
+++ b/services/api/src/modules/payments/payments.service.ts
@@ -1,8 +1,11 @@
 // PaymentsService — two distinct money flows, both via Paystack:
 //   subscription = a membership fee to be on the platform → ACTIVATES the
 //                  subscription on success (grants NO tokens).
-//   topup        = loading GHS into the wallet → GRANTS tokens on success.
+//   topup        = loading pesewas into the wallet → GRANTS tokens on success.
 // The webhook (charge.success) branches on the payment's purpose.
+//
+// Money unit: PESEWAS everywhere (1 GHS = 100 pesewas), matching Paystack — the
+// client converts to/from GHS for display. Integers only; never floats.
 //
 // Not wrapped in one DB transaction by design (system-design §4.2: "idempotent
 // webhooks") — each step is individually idempotent (ledger grant keyed; the
@@ -22,13 +25,13 @@ export class PaymentsNotConfiguredError extends Error {}
 export class InvalidWebhookError extends Error {}
 
 /**
- * Membership fee in GHS to be on the platform — this is NOT ride money (top-ups
- * fund rides). Server-authoritative (security.md §7). PLACEHOLDERS — set real
- * values here.
+ * Membership fee in PESEWAS to be on the platform — this is NOT ride money
+ * (top-ups fund rides). Server-authoritative (security.md §7). PLACEHOLDERS —
+ * set real values here.
  */
-export const SUBSCRIPTION_FEES_GHS: Record<SubscriptionPlan, number> = {
-  monthly: 20,
-  annual: 200,
+export const SUBSCRIPTION_FEES_PESEWAS: Record<SubscriptionPlan, number> = {
+  monthly: 2000, // GHS 20
+  annual: 20000, // GHS 200
 };
 
 export interface PaymentsServiceDeps {
@@ -37,7 +40,7 @@ export interface PaymentsServiceDeps {
   subscriptions: SubscriptionRepository;
   /** Undefined when payments aren't configured (e.g. prod without a Paystack key). */
   paystack?: PaystackClient;
-  /** Plan → membership fee in GHS (server-authoritative). */
+  /** Plan → membership fee in pesewas (server-authoritative). */
   subscriptionFees: Record<SubscriptionPlan, number>;
 }
 
@@ -69,13 +72,13 @@ export class PaymentsService {
     });
   }
 
-  /** Start a checkout to load `amountGhs` of ride tokens into the wallet. */
-  async initializeTopup(userId: string, amountGhs: number): Promise<CheckoutResult> {
+  /** Start a checkout to load `amountPesewas` of ride tokens into the wallet. */
+  async initializeTopup(userId: string, amountPesewas: number): Promise<CheckoutResult> {
     return this.startCheckout({
       userId,
       purpose: 'topup',
       plan: null,
-      amount: amountGhs,
+      amount: amountPesewas,
       currency: 'GHS',
     });
   }
@@ -90,7 +93,7 @@ export class PaymentsService {
       // We don't store email yet; a stable per-user address is fine as Paystack's
       // customer key (follow-up: capture the real email at sign-in).
       email: `${input.userId}@users.trotxi.app`,
-      amountPesewas: input.amount * 100,
+      amountPesewas: input.amount, // amounts are already stored in pesewas
       reference,
     });
     return { authorizationUrl: result.authorizationUrl, reference };

--- a/services/api/src/server.ts
+++ b/services/api/src/server.ts
@@ -37,7 +37,7 @@ import {
 import { PgPaymentRepository } from './modules/payments/payment.repository.pg';
 import { FakePaystackClient, type PaystackClient } from './modules/payments/paystack.client';
 import { PaystackHttpClient } from './modules/payments/paystack.client.live';
-import { PaymentsService, SUBSCRIPTION_FEES_GHS } from './modules/payments/payments.service';
+import { PaymentsService, SUBSCRIPTION_FEES_PESEWAS } from './modules/payments/payments.service';
 import { InMemoryUserRepository, type UserRepository } from './modules/users/user.repository';
 import { PgUserRepository } from './modules/users/user.repository.pg';
 
@@ -130,7 +130,7 @@ async function main(): Promise<void> {
     ledger,
     subscriptions,
     paystack,
-    subscriptionFees: SUBSCRIPTION_FEES_GHS,
+    subscriptionFees: SUBSCRIPTION_FEES_PESEWAS,
   });
 
   // Readiness pings every configured backing service (DB + KV).

--- a/services/api/tests/ledger.routes.test.ts
+++ b/services/api/tests/ledger.routes.test.ts
@@ -40,7 +40,7 @@ describe('GET /me/balance', () => {
 
     const res = await app.inject({ method: 'GET', url: '/me/balance', headers: bearer(token) });
     expect(res.statusCode).toBe(200);
-    expect(res.json()).toEqual({ balanceGhs: 240 });
+    expect(res.json()).toEqual({ balancePesewas: 240 });
   });
 
   it('returns 0 when no ledger is wired', async () => {
@@ -48,6 +48,6 @@ describe('GET /me/balance', () => {
     const token = await jwt.signAccessToken({ userId: 'rider-x', role: 'commuter' });
     const res = await app.inject({ method: 'GET', url: '/me/balance', headers: bearer(token) });
     expect(res.statusCode).toBe(200);
-    expect(res.json()).toEqual({ balanceGhs: 0 });
+    expect(res.json()).toEqual({ balancePesewas: 0 });
   });
 });

--- a/services/api/tests/payments.routes.test.ts
+++ b/services/api/tests/payments.routes.test.ts
@@ -56,8 +56,13 @@ describe('POST /payments/subscribe + /payments/topup', () => {
       ).statusCode,
     ).toBe(401);
     expect(
-      (await app.inject({ method: 'POST', url: '/payments/topup', payload: { amountGhs: 50 } }))
-        .statusCode,
+      (
+        await app.inject({
+          method: 'POST',
+          url: '/payments/topup',
+          payload: { amountPesewas: 5000 },
+        })
+      ).statusCode,
     ).toBe(401);
   });
 
@@ -76,7 +81,7 @@ describe('POST /payments/subscribe + /payments/topup', () => {
       method: 'POST',
       url: '/payments/topup',
       headers: bearer(token),
-      payload: { amountGhs: 50 },
+      payload: { amountPesewas: 5000 },
     });
     expect(top.statusCode).toBe(200);
   });
@@ -90,7 +95,7 @@ describe('POST /payments/subscribe + /payments/topup', () => {
           method: 'POST',
           url: '/payments/topup',
           headers: bearer(token),
-          payload: { amountGhs: 50 },
+          payload: { amountPesewas: 5000 },
         })
       ).statusCode,
     ).toBe(503);
@@ -107,14 +112,14 @@ describe('POST /webhooks/paystack', () => {
         method: 'POST',
         url: '/payments/topup',
         headers: bearer(token),
-        payload: { amountGhs: 50 },
+        payload: { amountPesewas: 5000 },
       })
     ).json();
 
     expect((await webhookFor(app, reference)).statusCode).toBe(200);
 
     const balance = await app.inject({ method: 'GET', url: '/me/balance', headers: bearer(token) });
-    expect(balance.json()).toEqual({ balanceGhs: 50 });
+    expect(balance.json()).toEqual({ balancePesewas: 5000 });
   });
 
   it('subscription: a signed charge.success activates membership without granting tokens', async () => {

--- a/services/api/tests/payments.service.test.ts
+++ b/services/api/tests/payments.service.test.ts
@@ -13,7 +13,7 @@ import {
 } from '../src/modules/subscriptions/subscription.repository';
 
 const FAKE_SECRET = 'fake-paystack-secret';
-const subscriptionFees = { monthly: 20, annual: 200 };
+const subscriptionFees = { monthly: 2000, annual: 20000 }; // pesewas (GHS 20 / 200)
 
 function make(subscriptions: SubscriptionRepository = new InMemorySubscriptionRepository()) {
   const payments = new InMemoryPaymentRepository();
@@ -41,18 +41,18 @@ describe('PaymentsService.initialize*', () => {
     expect(await payments.findByReference(reference)).toMatchObject({
       purpose: 'subscription',
       plan: 'monthly',
-      amount: 20,
+      amount: 2000,
       status: 'pending',
     });
   });
 
   it('topup: pending payment with no plan and the chosen amount', async () => {
     const { service, payments } = make();
-    const { reference } = await service.initializeTopup('u1', 50);
+    const { reference } = await service.initializeTopup('u1', 5000);
     expect(await payments.findByReference(reference)).toMatchObject({
       purpose: 'topup',
       plan: null,
-      amount: 50,
+      amount: 5000,
       status: 'pending',
     });
   });
@@ -64,7 +64,7 @@ describe('PaymentsService.initialize*', () => {
       subscriptions: new InMemorySubscriptionRepository(),
       subscriptionFees,
     });
-    await expect(service.initializeTopup('u1', 50)).rejects.toBeInstanceOf(
+    await expect(service.initializeTopup('u1', 5000)).rejects.toBeInstanceOf(
       PaymentsNotConfiguredError,
     );
   });
@@ -90,30 +90,30 @@ describe('PaymentsService.handleWebhook', () => {
 
   it('topup paid: grants tokens and does NOT activate a subscription', async () => {
     const { service, ledger, subscriptions, payments } = make();
-    const { reference } = await service.initializeTopup('u1', 50);
+    const { reference } = await service.initializeTopup('u1', 5000);
     const { body, signature } = chargeSuccess(reference);
 
     await service.handleWebhook(body, signature);
 
-    expect(await ledger.balanceOf('u1')).toBe(50);
+    expect(await ledger.balanceOf('u1')).toBe(5000);
     expect(await subscriptions.findActiveByUser('u1')).toBeNull();
     expect((await payments.findByReference(reference))?.status).toBe('paid');
   });
 
   it('topup is idempotent — replay does not double-grant', async () => {
     const { service, ledger } = make();
-    const { reference } = await service.initializeTopup('u1', 50);
+    const { reference } = await service.initializeTopup('u1', 5000);
     const { body, signature } = chargeSuccess(reference);
 
     await service.handleWebhook(body, signature);
     await service.handleWebhook(body, signature);
 
-    expect(await ledger.balanceOf('u1')).toBe(50);
+    expect(await ledger.balanceOf('u1')).toBe(5000);
   });
 
   it('ignores non charge.success events and unknown references', async () => {
     const { service, ledger } = make();
-    const { reference } = await service.initializeTopup('u1', 50);
+    const { reference } = await service.initializeTopup('u1', 5000);
 
     const failed = JSON.stringify({ event: 'charge.failed', data: { reference } });
     await service.handleWebhook(failed, paystackSignature(failed, FAKE_SECRET));


### PR DESCRIPTION
## What
The **last money change before we pause.** Two things:

1. **Pesewas units** — money is stored & handled in pesewas (minor units) end-to-end (`1 GHS = 100 pesewas`, integers only, matching Paystack). The app formats GHS at the display edge.
2. **ON HOLD status** — documents the current money status and **pauses further money work** pending the product team's **commission model** (how Trotxi charges its cut).

## Pesewas changes
- Storage: `token_ledger.delta`, `payments.amount` → pesewas (no migration — columns are already `integer`, no real rows yet).
- API: `GET /me/balance` → `{ balancePesewas }`; `POST /payments/topup` → `{ amountPesewas }` (min 100 = GHS 1).
- Config: `SUBSCRIPTION_FEES_GHS` → `SUBSCRIPTION_FEES_PESEWAS` (×100). Dropped the `×100` at Paystack init.
- Tests + `payments-and-wallet.md` updated.

## Hold
- `docs/features/payments-and-wallet.md` → **"Status & roadmap (ON HOLD)"**: what's built/working, what's blocked on commissions (commissions, driver payouts, fare/revenue split, boarding debit #20), open questions for product, and the safe production posture while paused.
- ADR-0011 updated (pesewas units + on-hold).

**FE impact:** `balancePesewas` / `amountPesewas` field renames — app ÷100 to show GHS, ×100 to send. Affects #35 (balance) and #36 (top-up).

Merging this is the official pause marker for the money system.