### PR TITLE
feat(observability): /metrics endpoint + ADR-0012 (Phase 1, #28)

### DIFF
--- a/docs/adr/0012-observability-otel-grafana-firebase.md
+++ b/docs/adr/0012-observability-otel-grafana-firebase.md
@@ -1,0 +1,37 @@
+# ADR-0012 — Observability: OpenTelemetry + Grafana Cloud + Firebase (free-tier)
+
+**Status:** accepted · **Date:** 2026-06-28
+
+## Context
+
+We need to track **latency, memory, responsiveness, and reliability** across the
+Fastify API and its dependencies, the infra, and both Flutter apps (#28).
+Constraints: **cost** — free tiers only (we pay only for DB, Paystack, and cloud
+hosting), a **small team** (no SRE), and **no PII/secrets** in telemetry (a money
+product under Act 843). Full design: [`docs/design/observability.md`](../design/observability.md).
+
+## Decision
+
+- **Instrumentation standard: OpenTelemetry (OTel)** — vendor-neutral; auto-
+  instruments Fastify/`pg`/`ioredis`/`http`. We can repoint at a different
+  backend without re-instrumenting the code.
+- **Backend metrics / traces / logs: Grafana Cloud free tier** (managed — not
+  self-hosted, so no extra paid Render services).
+- **Mobile RUM + crashes: Firebase Crashlytics + Performance** (free).
+- **Sentry deferred**; a paid APM (Datadog / New Relic) is a later, deliberate
+  choice only if scale demands it.
+- **Phase 1 (this slice):** expose `GET /metrics` via `prom-client` — a RED
+  histogram (`http_request_duration_seconds`) plus Node runtime metrics
+  (memory, event-loop lag, GC). Token-gated; disabled (404) in production when no
+  token is set, same fail-safe posture as payments/sign-in.
+
+## Consequences
+
+- All four signals are covered end-to-end at **$0** on top of existing spend.
+- One standard (OTel) scales to the future Go telemetry service + MQTT.
+- We must **stay inside free-tier limits** (sampling + short retention; alert and
+  revisit before any paid threshold) and **scrub PII/secrets** from telemetry.
+- `/metrics` is kept out of the public OpenAPI and is token-gated; scrapers
+  (Grafana Agent) authenticate with `Authorization: Bearer <METRICS_TOKEN>`.
+- Remaining for Phase 1: a Grafana Cloud account + scrape config + dashboards and
+  the first alerts (external account setup, like Google/Paystack).

--- a/docs/adr/0012-observability-otel-grafana-firebase.md
+++ b/docs/adr/0012-observability-otel-grafana-firebase.md
@@ -35,3 +35,10 @@ product under Act 843). Full design: [`docs/design/observability.md`](../design/
   (Grafana Agent) authenticate with `Authorization: Bearer <METRICS_TOKEN>`.
 - Remaining for Phase 1: a Grafana Cloud account + scrape config + dashboards and
   the first alerts (external account setup, like Google/Paystack).
+- **In-house dashboards / a self-hosted stack stay a deferred, open option** — we
+  own the data via OTel/Prometheus, so no lock-in. Managed free tiers are chosen
+  now because a dashboard is the easy part; the storage/query/alerting (and, for
+  mobile, the crash SDK + symbolication) is the costly 90%, and self-hosting it
+  would cost more (ops + Render spend) than the free managed tiers. Revisit only
+  if scale makes a paid tier costlier than running our own. (Grafana itself is the
+  OSS tool we author our own dashboards in.)

--- a/docs/design/observability.md
+++ b/docs/design/observability.md
@@ -237,13 +237,13 @@ A money app — telemetry must not become a leak:
 
 ## 11. Rollout (phased, cheapest value first)
 
-| Phase                              | Scope                                                                                                                                     | Outcome                                                          |
-| ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
-| **0 — Foundation** _(mostly done)_ | structured logs, `/health` + `/ready`, `request_id` correlation                                                                           | clean, correlatable logs today                                   |
-| **1 — Backend metrics**            | `prom-client` `/metrics` (RED + runtime: memory, event-loop lag) → Grafana Cloud; first dashboards + 2–3 alerts (error rate, p95, memory) | latency + memory + reliability visible (satisfies #28's RED ask) |
-| **2 — Tracing**                    | OTel auto-instrumentation (Fastify/pg/ioredis/Paystack); trace↔log correlation; sampling                                                  | debug slow requests end-to-end                                   |
-| **3 — Mobile RUM**                 | Firebase Crashlytics + Performance in both apps; custom traces (sign-in, top-up, board); crash-free SLO                                   | responsiveness + reliability from real devices                   |
-| **4 — SLOs & alerting**            | formalise SLO dashboards + burn-rate alerts + runbooks                                                                                    | budget-driven, low-noise alerting                                |
+| Phase                                    | Scope                                                                                                                                                                                             | Outcome                                                          |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| **0 — Foundation** _(mostly done)_       | structured logs, `/health` + `/ready`, `request_id` correlation                                                                                                                                   | clean, correlatable logs today                                   |
+| **1 — Backend metrics** 🟡 _in progress_ | `/metrics` endpoint **done** (`prom-client`: RED histogram + runtime memory/event-loop lag, token-gated); **remaining:** Grafana Cloud scrape + dashboards + 2–3 alerts (error rate, p95, memory) | latency + memory + reliability visible (satisfies #28's RED ask) |
+| **2 — Tracing**                          | OTel auto-instrumentation (Fastify/pg/ioredis/Paystack); trace↔log correlation; sampling                                                                                                          | debug slow requests end-to-end                                   |
+| **3 — Mobile RUM**                       | Firebase Crashlytics + Performance in both apps; custom traces (sign-in, top-up, board); crash-free SLO                                                                                           | responsiveness + reliability from real devices                   |
+| **4 — SLOs & alerting**                  | formalise SLO dashboards + burn-rate alerts + runbooks                                                                                                                                            | budget-driven, low-noise alerting                                |
 
 Phase 1 is the immediate next step and the smallest useful slice.
 

--- a/docs/design/observability.md
+++ b/docs/design/observability.md
@@ -216,6 +216,26 @@ only for DB, Paystack, and cloud hosting — no paid observability tooling.
   A paid APM (Datadog/New Relic) stays a deliberate, later choice only if scale
   demands it.
 
+### Why managed free tiers, not an in-house stack (yet)
+
+A dashboard is the easy ~10%; the costly ~90% is what sits under it — a
+**time-series DB** (ingest/retain/query), a **query engine** (compute p95s over
+millions of points), a **24/7 alerting engine**, and, for mobile, a **crash SDK +
+symbolication**. "Build our own dashboards" still needs all of that first.
+
+- **Grafana is the in-house dashboard tool** — open-source; we author our _own_
+  custom dashboards in it. Grafana Cloud is just **free managed hosting** of it +
+  the storage. So this _is_ "our dashboards", minus running the database.
+- **Firebase** is the genuinely hard-to-replace piece (on-device crash SDK +
+  symbolication + frame/RUM collection) — not a dashboard.
+- **Self-hosting now would cost _more_:** eng-weeks + ongoing ops + actual Render
+  hosting spend — which breaks the free-tier + small-team constraints.
+- **No lock-in (the key):** because we standardise on **OpenTelemetry + the
+  Prometheus format**, the data is ours. A self-hosted stack — or a custom
+  **admin/status dashboard in the Trotxi app** — can later point at the _same_
+  data with no re-instrumentation. **Deferred option, kept open**, to revisit only
+  if scale makes a paid tier costlier than running our own.
+
 ---
 
 ## 10. Privacy & security

--- a/docs/design/observability.md
+++ b/docs/design/observability.md
@@ -95,8 +95,8 @@ a dashboard we can jump to the exact trace and its logs.
 
 ## 4. Backend (Fastify API)
 
-Build on what already exists: **pino structured logging** and the `/health` +
-`/ready` endpoints (the latter already pings DB + KV).
+Build on what already exists: **pino structured logging** and the `/healthz` +
+`/readyz` endpoints (the latter already pings DB + KV).
 
 - **Metrics** — expose `GET /metrics` (Prometheus format via `prom-client`):
   - RED histograms per route+method+status (`http_request_duration_seconds`).
@@ -110,7 +110,7 @@ Build on what already exists: **pino structured logging** and the `/health` +
 - **Logs** — pino → JSON to stdout (Render captures) and/or shipped to Loki.
   Inject `trace_id`/`request_id` into every line. **No request bodies on
   `/auth/*` or `/payments/*`.**
-- **Health** — keep `/health` (liveness) and `/ready` (readiness); Render and an
+- **Health** — keep `/healthz` (liveness) and `/readyz` (readiness); Render and an
   external uptime check both probe them.
 
 `/metrics` must not be public — bind it to an internal path/token (it leaks
@@ -140,7 +140,7 @@ The device view is essential: server p95 can be 200ms while a user on a weak
 ## 6. Infrastructure & dependencies
 
 - **Render:** built-in CPU/memory/instance metrics + deploy events; an external
-  uptime monitor (e.g. Better Stack / UptimeRobot free) hits `/health` so we
+  uptime monitor (e.g. Better Stack / UptimeRobot free) hits `/healthz` so we
   catch a fully-down instance Render might not alert on.
 - **Postgres:** connection-pool saturation, slow queries (`pg_stat_statements`),
   error rate — surfaced via the API's DB spans + Render's DB metrics.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       pg:
         specifier: ^8.13.1
         version: 8.22.0
+      prom-client:
+        specifier: ^15.1.3
+        version: 15.1.3
       zod:
         specifier: ^3.24.1
         version: 3.25.76
@@ -765,6 +768,10 @@ packages:
     engines: {node: '>=22.0.0'}
     hasBin: true
 
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
+
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
 
@@ -1136,6 +1143,9 @@ packages:
   basic-ftp@5.3.1:
     resolution: {integrity: sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==}
     engines: {node: '>=10.0.0'}
+
+  bintrees@1.0.2:
+    resolution: {integrity: sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==}
 
   brace-expansion@1.1.15:
     resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
@@ -2180,6 +2190,10 @@ packages:
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
 
+  prom-client@15.1.3:
+    resolution: {integrity: sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==}
+    engines: {node: ^16 || ^18 || >=20}
+
   proxy-agent-negotiate@1.1.0:
     resolution: {integrity: sha512-N8IBcM3UgCVzz2L2Lqv8DVntDnnC8/hiV4nEDUPkqq72TPUgYWjQc+bdZlBPZK9LzPAvOY//gAt0S0DApoOXWQ==}
     engines: {node: '>= 20'}
@@ -2419,6 +2433,9 @@ packages:
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
+
+  tdigest@0.1.2:
+    resolution: {integrity: sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==}
 
   test-exclude@7.0.2:
     resolution: {integrity: sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==}
@@ -3192,6 +3209,8 @@ snapshots:
       - kerberos
       - supports-color
 
+  '@opentelemetry/api@1.9.1': {}
+
   '@pinojs/redact@0.4.0': {}
 
   '@pkgjs/parseargs@0.11.0':
@@ -3544,6 +3563,8 @@ snapshots:
   balanced-match@4.0.4: {}
 
   basic-ftp@5.3.1: {}
+
+  bintrees@1.0.2: {}
 
   brace-expansion@1.1.15:
     dependencies:
@@ -4642,6 +4663,11 @@ snapshots:
 
   process-warning@5.0.0: {}
 
+  prom-client@15.1.3:
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      tdigest: 0.1.2
+
   proxy-agent-negotiate@1.1.0: {}
 
   proxy-agent@8.0.2:
@@ -4868,6 +4894,10 @@ snapshots:
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
+
+  tdigest@0.1.2:
+    dependencies:
+      bintrees: 1.0.2
 
   test-exclude@7.0.2:
     dependencies:

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -28,6 +28,7 @@
     "ioredis": "^5.11.1",
     "jose": "^6.2.3",
     "pg": "^8.13.1",
+    "prom-client": "^15.1.3",
     "zod": "^3.24.1"
   },
   "devDependencies": {

--- a/services/api/src/app.ts
+++ b/services/api/src/app.ts
@@ -11,6 +11,7 @@ import { z } from 'zod';
 import { InMemoryKvStore, type KvStore } from './kv/kv.store';
 import { ledgerRoutes } from './modules/ledger/ledger.routes';
 import type { LedgerRepository } from './modules/ledger/ledger.repository';
+import { metricsPlugin, type MetricsOptions } from './modules/metrics/metrics.plugin';
 import { paymentRoutes } from './modules/payments/payments.routes';
 import type { PaymentsService } from './modules/payments/payments.service';
 import { authPlugin } from './modules/auth/auth.plugin';
@@ -49,6 +50,8 @@ export interface AppDeps {
   paymentsService?: PaymentsService;
   /** Rate-limit thresholds (from env). Defaults applied when unset. */
   rateLimit?: RateLimitConfig;
+  /** Prometheus /metrics exposure. Defaults to unprotected (dev/tests). */
+  metrics?: Partial<MetricsOptions>;
   logger?: boolean;
 }
 
@@ -90,6 +93,12 @@ export async function buildApp(deps: AppDeps = {}): Promise<FastifyInstance> {
     transform: jsonSchemaTransform,
   });
   await app.register(fastifySwaggerUi, { routePrefix: '/docs' });
+
+  // Metrics early so its onResponse hook observes every route (RED + runtime).
+  await app.register(metricsPlugin, {
+    token: deps.metrics?.token,
+    allowUnprotected: deps.metrics?.allowUnprotected ?? true,
+  });
 
   // Guards first (decorators on the root instance), then routes that use them.
   const kv = deps.kv ?? new InMemoryKvStore();

--- a/services/api/src/config/env.ts
+++ b/services/api/src/config/env.ts
@@ -25,6 +25,9 @@ const envSchema = z
     // Rate limiting (fixed window). Tunable without a code change.
     RATE_LIMIT_MAX: z.coerce.number().int().positive().default(100),
     RATE_LIMIT_WINDOW_SECONDS: z.coerce.number().int().positive().default(60),
+    // Protects GET /metrics — the scraper sends `Authorization: Bearer <token>`.
+    // Unset -> /metrics is open in non-prod, disabled (404) in production.
+    METRICS_TOKEN: z.string().optional(),
   })
   .superRefine((env, ctx) => {
     if (env.NODE_ENV === 'production' && !env.JWT_SECRET) {

--- a/services/api/src/modules/metrics/metrics.plugin.ts
+++ b/services/api/src/modules/metrics/metrics.plugin.ts
@@ -1,0 +1,70 @@
+// Metrics. Exposes GET /metrics in Prometheus text format for scraping into
+// Grafana Cloud (docs/design/observability.md, #28) — Phase 1:
+//   - RED: http_request_duration_seconds histogram {method, route, status_code}
+//   - Node runtime (USE): heap/RSS memory, event-loop lag, GC (prom-client defaults)
+// Not public: when a token is configured the endpoint requires
+// `Authorization: Bearer <token>`; in production with no token it is disabled
+// (404) rather than left open (same fail-safe posture as payments/sign-in).
+
+import { timingSafeEqual } from 'node:crypto';
+import type { FastifyReply, FastifyRequest } from 'fastify';
+import fp from 'fastify-plugin';
+import { collectDefaultMetrics, Histogram, Registry } from 'prom-client';
+
+export interface MetricsOptions {
+  /** When set, GET /metrics requires `Authorization: Bearer <token>`. */
+  token?: string;
+  /** Allow /metrics without a token (dev/test). Set false in production. */
+  allowUnprotected: boolean;
+}
+
+// Seconds buckets tuned for API latency (5ms … 5s).
+const DURATION_BUCKETS = [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5];
+
+function tokenMatches(provided: string, expected: string): boolean {
+  const a = Buffer.from(provided);
+  const b = Buffer.from(expected);
+  return a.length === b.length && timingSafeEqual(a, b);
+}
+
+export const metricsPlugin = fp<MetricsOptions>(async (app, opts) => {
+  // A fresh registry per app instance (tests build many apps; the default global
+  // registry would throw "already registered").
+  const register = new Registry();
+  collectDefaultMetrics({ register });
+
+  const httpDuration = new Histogram({
+    name: 'http_request_duration_seconds',
+    help: 'HTTP request duration in seconds (RED: rate, errors, duration).',
+    labelNames: ['method', 'route', 'status_code'] as const,
+    buckets: DURATION_BUCKETS,
+    registers: [register],
+  });
+
+  // Record every response except the scrape itself. Use the route TEMPLATE
+  // (e.g. /payments/topup), never the raw URL, to bound label cardinality;
+  // unmatched requests (404) have no template, so we skip them.
+  app.addHook('onResponse', async (request: FastifyRequest, reply: FastifyReply) => {
+    const route = request.routeOptions.url;
+    if (!route || route === '/metrics') return;
+    httpDuration.observe(
+      { method: request.method, route, status_code: reply.statusCode },
+      reply.elapsedTime / 1000,
+    );
+  });
+
+  // No token + not allowed unprotected (i.e. production) → don't expose at all.
+  if (!opts.token && !opts.allowUnprotected) return;
+
+  app.get('/metrics', { schema: { hide: true } }, async (request, reply) => {
+    if (opts.token) {
+      const header = request.headers.authorization;
+      const provided = header?.startsWith('Bearer ') ? header.slice(7) : '';
+      if (!provided || !tokenMatches(provided, opts.token)) {
+        return reply.code(401).send({ error: 'unauthorized', message: 'Invalid metrics token' });
+      }
+    }
+    reply.header('content-type', register.contentType);
+    return register.metrics();
+  });
+});

--- a/services/api/src/server.ts
+++ b/services/api/src/server.ts
@@ -160,6 +160,8 @@ async function main(): Promise<void> {
     isReady,
     auth,
     rateLimit,
+    // /metrics: protected by a token when set; disabled in prod when unset.
+    metrics: { token: env.METRICS_TOKEN, allowUnprotected: env.NODE_ENV !== 'production' },
     logger: true,
   });
 

--- a/services/api/tests/metrics.test.ts
+++ b/services/api/tests/metrics.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { buildApp } from '../src/app';
+
+describe('GET /metrics', () => {
+  it('exposes runtime + RED metrics in Prometheus format', async () => {
+    const app = await buildApp();
+    await app.inject({ method: 'GET', url: '/healthz' }); // generate one sample
+
+    const res = await app.inject({ method: 'GET', url: '/metrics' });
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-type']).toContain('text/plain');
+    // runtime (memory + event-loop lag) and the RED histogram
+    expect(res.body).toContain('process_resident_memory_bytes');
+    expect(res.body).toContain('nodejs_eventloop_lag_seconds');
+    expect(res.body).toContain('http_request_duration_seconds');
+    expect(res.body).toContain('route="/healthz"');
+  });
+
+  it('does not record the scrape itself or unmatched routes', async () => {
+    const app = await buildApp();
+    await app.inject({ method: 'GET', url: '/no-such-route' }); // 404, no template
+    await app.inject({ method: 'GET', url: '/metrics' });
+
+    const res = await app.inject({ method: 'GET', url: '/metrics' });
+    expect(res.body).not.toContain('route="/metrics"');
+    expect(res.body).not.toContain('/no-such-route');
+  });
+
+  it('requires a bearer token when one is configured', async () => {
+    const app = await buildApp({ metrics: { token: 'secret-token' } });
+
+    expect((await app.inject({ method: 'GET', url: '/metrics' })).statusCode).toBe(401);
+    expect(
+      (
+        await app.inject({
+          method: 'GET',
+          url: '/metrics',
+          headers: { authorization: 'Bearer wrong' },
+        })
+      ).statusCode,
+    ).toBe(401);
+    const ok = await app.inject({
+      method: 'GET',
+      url: '/metrics',
+      headers: { authorization: 'Bearer secret-token' },
+    });
+    expect(ok.statusCode).toBe(200);
+  });
+
+  it('is disabled (404) when unprotected exposure is off and no token is set', async () => {
+    const app = await buildApp({ metrics: { allowUnprotected: false } });
+    expect((await app.inject({ method: 'GET', url: '/metrics' })).statusCode).toBe(404);
+  });
+});


### PR DESCRIPTION
## What
**Phase 1** of the observability design ([docs/design/observability.md](docs/design/observability.md)) — the smallest useful slice, and the literal RED ask in #28.

- **`GET /metrics`** (Prometheus text, via `prom-client`):
  - **RED:** `http_request_duration_seconds` histogram labelled `{method, route, status_code}` — uses the **route template** (e.g. `/payments/topup`), never the raw URL, to bound cardinality; skips unmatched 404s and the scrape itself.
  - **Runtime (USE):** Node memory (RSS/heap), **event-loop lag**, GC — `prom-client` defaults.
- **Not public:** requires `Authorization: Bearer <METRICS_TOKEN>` when set; **disabled (404) in production when unset** — same fail-safe posture as payments/sign-in. Hidden from the public OpenAPI.
- **ADR-0012** records the stack decision (OTel → Grafana Cloud + Firebase, free-tier only).

## Tests
`tests/metrics.test.ts` — format + RED/runtime presence, route-template labelling, scrape/404 exclusion, token gating (401/200), prod-without-token disabled (404). `metrics.plugin.ts` is **100% covered**; full suite 108 green.

## Not in this PR (needs an external account — your lane)
Grafana Cloud free account + scrape config (Grafana Agent with the bearer token) + dashboards + first alerts. Set `METRICS_TOKEN` in Render (and `sync:false`).

Phase 2 (OTel tracing) and Phase 3 (Flutter RUM) follow per the design.