### PR TITLE
docs: TSDoc across CTO modules + eslint-plugin-jsdoc (warn)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,6 +129,9 @@ importers:
       eslint:
         specifier: ^9.17.0
         version: 9.39.4
+      eslint-plugin-jsdoc:
+        specifier: ^63.0.10
+        version: 63.0.10(eslint@9.39.4)
       globals:
         specifier: ^15.14.0
         version: 15.15.0
@@ -176,6 +179,14 @@ packages:
 
   '@borewit/text-codec@0.2.2':
     resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
+
+  '@es-joy/jsdoccomment@0.87.0':
+    resolution: {integrity: sha512-mFXZloZMzuJZXSHUmAFu/pXTk0ZJTJBluuAkrvbzidpTN8W6F2bpRFuedSH+85kbdlRLJqc+gfN+kD3JOLJK5g==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@es-joy/resolve.exports@1.2.0':
+    resolution: {integrity: sha512-Q9hjxWI5xBM+qW2enxfe8wDKdFWMfd0Z29k5ZJnuBqD/CasY5Zryj09aCA6owbGATWz+39p5uIdaHXpopOcG8g==}
+    engines: {node: '>=10'}
 
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
@@ -1224,6 +1235,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@sindresorhus/base62@1.0.0':
+    resolution: {integrity: sha512-TeheYy0ILzBEI/CO55CP6zJCSdSWeRtGnHy8U8dWSUH4I68iqTsy7HkMktR4xakThc9jotkPQUXT4ITdbV7cHA==}
+    engines: {node: '>=18'}
+
   '@tokenizer/inflate@0.4.1':
     resolution: {integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==}
     engines: {node: '>=18'}
@@ -1422,6 +1437,10 @@ packages:
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
+  are-docs-informative@0.0.2:
+    resolution: {integrity: sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==}
+    engines: {node: '>=14'}
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -1576,6 +1595,10 @@ packages:
   commander@8.3.0:
     resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
     engines: {node: '>= 12'}
+
+  comment-parser@1.4.7:
+    resolution: {integrity: sha512-0h+uSNtQGW3D98eQt3jJ8L06Fves8hncB4V/PKdw/Qb8Hnk19VaKuTr55UNRYiSoVa7WwrFls+rh3ux9agmkeQ==}
+    engines: {node: '>= 12.0.0'}
 
   compare-versions@6.1.1:
     resolution: {integrity: sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==}
@@ -1736,6 +1759,12 @@ packages:
     engines: {node: '>=6.0'}
     hasBin: true
 
+  eslint-plugin-jsdoc@63.0.10:
+    resolution: {integrity: sha512-A9UIWsCquaKnit7rasXxYf12hhGIdDRjv65/RUE3AxbT6rdKBvr3MjH37g3gP+g4ipQMXuMn9slFKjO+vqNfkg==}
+    engines: {node: ^22.13.0 || >=24}
+    peerDependencies:
+      eslint: ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0
+
   eslint-scope@8.4.0:
     resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1765,6 +1794,10 @@ packages:
   espree@10.4.0:
     resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  espree@11.2.0:
+    resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
@@ -1995,6 +2028,9 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
+  html-entities@2.6.0:
+    resolution: {integrity: sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
@@ -2129,6 +2165,10 @@ packages:
   js-yaml@4.3.0:
     resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
+
+  jsdoc-type-pratt-parser@7.2.0:
+    resolution: {integrity: sha512-dh140MMgjyg3JhJZY/+iEzW+NO5xR2gpbDFKHqotCmexElVntw7GjWjt511+C/Ef02RU5TKYrJo/Xlzk+OLaTw==}
+    engines: {node: '>=20.0.0'}
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
@@ -2319,6 +2359,9 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
+  object-deep-merge@2.0.1:
+    resolution: {integrity: sha512-aKttDKcU3pyZqKcCkDhsMn70WmZFG2JGDQLP9EcLyTSIFQRCPWLAmBZRLJnrVUrhPG1jETEEbfdgbNtJf1LyMg==}
+
   on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
@@ -2362,6 +2405,12 @@ packages:
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
+
+  parse-imports-exports@0.2.4:
+    resolution: {integrity: sha512-4s6vd6dx1AotCx/RCI2m7t7GCh5bDRUtGNvRfHSP2wbBQdMi67pPe7mtzmgwcaQ8VKK/6IB7Glfyu3qdZJPybQ==}
+
+  parse-statements@1.0.11:
+    resolution: {integrity: sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -2599,6 +2648,10 @@ packages:
     resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
     engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
 
+  reserved-identifiers@1.2.0:
+    resolution: {integrity: sha512-yE7KUfFvaBFzGPs5H3Ops1RevfUEsDc5Iz65rOwWg4lE8HJSYtle77uul3+573457oHvBKuHYDl/xqUkKpEEdw==}
+    engines: {node: '>=18'}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -2716,6 +2769,15 @@ packages:
     resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
     engines: {node: '>= 12'}
 
+  spdx-exceptions@2.5.0:
+    resolution: {integrity: sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==}
+
+  spdx-expression-parse@4.0.0:
+    resolution: {integrity: sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==}
+
+  spdx-license-ids@3.0.23:
+    resolution: {integrity: sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==}
+
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
@@ -2825,6 +2887,10 @@ packages:
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  to-valid-identifier@1.0.0:
+    resolution: {integrity: sha512-41wJyvKep3yT2tyPqX/4blcfybknGB4D+oETKLs7Q76UiPqRpUJK3hr1nxelyYO0PHKVzJwlu0aCeEAsGI6rpw==}
+    engines: {node: '>=20'}
 
   toad-cache@3.7.1:
     resolution: {integrity: sha512-5DXWzE4Vz7xNHsv+xQ+MGfJYyC78Aok3tEr0MNwHoRf7vZnga1mQXZ4/Nsodld4VR6Wd+VhfmqnNrsRJyYPfrQ==}
@@ -3090,6 +3156,16 @@ snapshots:
   '@bcoe/v8-coverage@0.2.3': {}
 
   '@borewit/text-codec@0.2.2': {}
+
+  '@es-joy/jsdoccomment@0.87.0':
+    dependencies:
+      '@types/estree': 1.0.9
+      '@typescript-eslint/types': 8.62.0
+      comment-parser: 1.4.7
+      esquery: 1.7.0
+      jsdoc-type-pratt-parser: 7.2.0
+
+  '@es-joy/resolve.exports@1.2.0': {}
 
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
@@ -3999,6 +4075,8 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.62.2':
     optional: true
 
+  '@sindresorhus/base62@1.0.0': {}
+
   '@tokenizer/inflate@0.4.1':
     dependencies:
       debug: 4.4.3
@@ -4249,6 +4327,8 @@ snapshots:
 
   any-promise@1.3.0: {}
 
+  are-docs-informative@0.0.2: {}
+
   argparse@2.0.1: {}
 
   assertion-error@2.0.1: {}
@@ -4387,6 +4467,8 @@ snapshots:
   commander@4.1.1: {}
 
   commander@8.3.0: {}
+
+  comment-parser@1.4.7: {}
 
   compare-versions@6.1.1: {}
 
@@ -4588,6 +4670,26 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
+  eslint-plugin-jsdoc@63.0.10(eslint@9.39.4):
+    dependencies:
+      '@es-joy/jsdoccomment': 0.87.0
+      '@es-joy/resolve.exports': 1.2.0
+      are-docs-informative: 0.0.2
+      comment-parser: 1.4.7
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      eslint: 9.39.4
+      espree: 11.2.0
+      esquery: 1.7.0
+      html-entities: 2.6.0
+      object-deep-merge: 2.0.1
+      parse-imports-exports: 0.2.4
+      semver: 7.8.5
+      spdx-expression-parse: 4.0.0
+      to-valid-identifier: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-scope@8.4.0:
     dependencies:
       esrecurse: 4.3.0
@@ -4643,6 +4745,12 @@ snapshots:
       acorn: 8.17.0
       acorn-jsx: 5.3.2(acorn@8.17.0)
       eslint-visitor-keys: 4.2.1
+
+  espree@11.2.0:
+    dependencies:
+      acorn: 8.17.0
+      acorn-jsx: 5.3.2(acorn@8.17.0)
+      eslint-visitor-keys: 5.0.1
 
   esprima@4.0.1: {}
 
@@ -4893,6 +5001,8 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  html-entities@2.6.0: {}
+
   html-escaper@2.0.2: {}
 
   http-errors@2.0.1:
@@ -5030,6 +5140,8 @@ snapshots:
   js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
+
+  jsdoc-type-pratt-parser@7.2.0: {}
 
   json-buffer@3.0.1: {}
 
@@ -5214,6 +5326,8 @@ snapshots:
 
   object-assign@4.1.1: {}
 
+  object-deep-merge@2.0.1: {}
+
   on-exit-leak-free@2.1.2: {}
 
   onetime@6.0.0:
@@ -5268,6 +5382,12 @@ snapshots:
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
+
+  parse-imports-exports@0.2.4:
+    dependencies:
+      parse-statements: 1.0.11
+
+  parse-statements@1.0.11: {}
 
   path-exists@4.0.0: {}
 
@@ -5479,6 +5599,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  reserved-identifiers@1.2.0: {}
+
   resolve-from@4.0.0: {}
 
   resolve-from@5.0.0: {}
@@ -5597,6 +5719,15 @@ snapshots:
 
   source-map@0.7.6: {}
 
+  spdx-exceptions@2.5.0: {}
+
+  spdx-expression-parse@4.0.0:
+    dependencies:
+      spdx-exceptions: 2.5.0
+      spdx-license-ids: 3.0.23
+
+  spdx-license-ids@3.0.23: {}
+
   split2@4.2.0: {}
 
   stackback@0.0.2: {}
@@ -5699,6 +5830,11 @@ snapshots:
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  to-valid-identifier@1.0.0:
+    dependencies:
+      '@sindresorhus/base62': 1.0.0
+      reserved-identifiers: 1.2.0
 
   toad-cache@3.7.1: {}
 

--- a/services/api/eslint.config.js
+++ b/services/api/eslint.config.js
@@ -1,4 +1,5 @@
 import globals from 'globals';
+import jsdoc from 'eslint-plugin-jsdoc';
 import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
@@ -10,6 +11,50 @@ export default tseslint.config(
     },
     rules: {
       '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+    },
+  },
+  // Docstrings on the public API surface — TSDoc style (describe meaning; types
+  // are TypeScript's job, so no `@param {type}`). WARN for now while modules are
+  // documented; flip to `error` (+ `--max-warnings 0`) to make a missing or
+  // incomplete docstring fail CI. Impl/integration files (*.pg, *.redis, *.live,
+  // *.google), zod schemas, the entrypoint and db scripts are exempt — they
+  // implement an already-documented interface or are wiring.
+  {
+    files: ['src/**/*.ts'],
+    ignores: [
+      'src/**/*.pg.ts',
+      'src/**/*.redis.ts',
+      'src/**/*.live.ts',
+      'src/**/*.google.ts',
+      'src/**/*.schema.ts',
+      'src/server.ts',
+      'src/db/**',
+    ],
+    plugins: { jsdoc },
+    settings: { jsdoc: { mode: 'typescript' } },
+    rules: {
+      'jsdoc/require-jsdoc': [
+        'warn',
+        {
+          publicOnly: true,
+          require: {
+            FunctionDeclaration: true,
+            ClassDeclaration: true,
+          },
+          // Document the contract (interfaces + their methods) + exported classes
+          // and functions. Class method bodies (incl. InMemory/Pg impls) aren't
+          // forced to restate the interface; any docstring that IS present must
+          // still be complete (require-param/returns below).
+          contexts: ['TSInterfaceDeclaration', 'TSMethodSignature'],
+          exemptEmptyConstructors: true,
+        },
+      ],
+      'jsdoc/require-param': 'warn',
+      'jsdoc/require-param-description': 'warn',
+      'jsdoc/require-returns': 'warn',
+      'jsdoc/require-returns-description': 'warn',
+      'jsdoc/check-param-names': 'warn',
+      'jsdoc/check-alignment': 'warn',
     },
   },
 );

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -50,6 +50,7 @@
     "@types/pg": "^8.11.10",
     "@vitest/coverage-v8": "^2.1.8",
     "eslint": "^9.17.0",
+    "eslint-plugin-jsdoc": "^63.0.10",
     "globals": "^15.14.0",
     "tsup": "^8.3.5",
     "tsx": "^4.19.2",

--- a/services/api/src/app.ts
+++ b/services/api/src/app.ts
@@ -55,6 +55,14 @@ export interface AppDeps {
   logger?: boolean;
 }
 
+/**
+ * Build the Fastify app — registers OpenAPI docs, metrics, guards, and all
+ * routes. Dependencies are injected so tests pass in-memory implementations and
+ * production wires the real ones.
+ *
+ * @param deps - repositories, services, and config; sensible defaults applied.
+ * @returns the configured Fastify instance (not yet listening).
+ */
 export async function buildApp(deps: AppDeps = {}): Promise<FastifyInstance> {
   const app = Fastify({ logger: deps.logger ?? false });
 

--- a/services/api/src/config/dotenv.ts
+++ b/services/api/src/config/dotenv.ts
@@ -5,6 +5,8 @@ import { existsSync } from 'node:fs';
  * (Node 20.12+ / 22). Production injects env vars directly, so a missing file is
  * a no-op. The path is overridable to keep this testable without touching a real
  * project `.env`.
+ *
+ * @param path - the dotenv file to load; overridable for tests.
  */
 export function loadDotenv(path = '.env'): void {
   if (existsSync(path)) {

--- a/services/api/src/config/env.ts
+++ b/services/api/src/config/env.ts
@@ -46,6 +46,13 @@ const envSchema = z
 
 export type Env = z.infer<typeof envSchema>;
 
+/**
+ * Parse and validate environment variables, applying defaults.
+ *
+ * @param source - the raw env map to read (defaults to `process.env`).
+ * @returns the validated, typed config.
+ * @throws Error if the environment fails validation (e.g. missing prod secrets).
+ */
 export function loadEnv(source: Record<string, string | undefined> = process.env): Env {
   const parsed = envSchema.safeParse(source);
   if (!parsed.success) {

--- a/services/api/src/kv/kv.store.ts
+++ b/services/api/src/kv/kv.store.ts
@@ -3,19 +3,46 @@
 // one by REDIS_URL, mirroring the repository pattern. Consumers (rate limiting,
 // idempotency keys, caching) depend on this interface, not on Redis directly.
 
+/** A small key-value store; backed by Redis in prod, in-memory in dev/tests. */
 export interface KvStore {
+  /**
+   * Read a value.
+   *
+   * @param key - the key to read.
+   * @returns the stored string, or null if absent/expired.
+   */
   get(key: string): Promise<string | null>;
-  /** Set a value, optionally expiring after `ttlSeconds`. */
+  /**
+   * Set a value, optionally expiring after `ttlSeconds`.
+   *
+   * @param key - the key to write.
+   * @param value - the value to store.
+   * @param ttlSeconds - optional time-to-live; omit for no expiry.
+   */
   set(key: string, value: string, ttlSeconds?: number): Promise<void>;
+  /**
+   * Delete a key (no-op if absent).
+   *
+   * @param key - the key to remove.
+   */
   del(key: string): Promise<void>;
   /**
    * Atomically increment a counter, returning the new value. The TTL is set
    * only when the counter is first created, so the window does not slide on each
    * hit — the building block for fixed-window rate limiting.
+   *
+   * @param key - the counter key.
+   * @param ttlSeconds - lifetime of the window, applied on first creation only.
+   * @returns the counter's new value.
    */
   increment(key: string, ttlSeconds: number): Promise<number>;
-  /** Liveness check for the readiness probe. */
+  /**
+   * Liveness check for the readiness probe.
+   *
+   * @returns true if the store is reachable.
+   */
   ping(): Promise<boolean>;
+  /** Release resources (connections, timers). */
   close(): Promise<void>;
 }
 
@@ -25,10 +52,16 @@ interface Entry {
   expiresAt: number | null;
 }
 
+/** In-memory {@link KvStore} for dev and unit tests (no Redis). */
 export class InMemoryKvStore implements KvStore {
   private readonly store = new Map<string, Entry>();
 
-  /** Return a live entry, lazily evicting it if it has expired. */
+  /**
+   * Return a live entry, lazily evicting it if it has expired.
+   *
+   * @param key - the key to read.
+   * @returns the entry, or undefined if absent/expired.
+   */
   private read(key: string): Entry | undefined {
     const entry = this.store.get(key);
     if (!entry) return undefined;

--- a/services/api/src/modules/auth/auth-identity.repository.ts
+++ b/services/api/src/modules/auth/auth-identity.repository.ts
@@ -4,25 +4,44 @@
 
 import type { AuthProvider } from './id-token-verifier';
 
+/** Links a provider account (provider + subject id) to a Trotxi user. */
 export interface AuthIdentity {
   id: string;
   userId: string;
   provider: AuthProvider;
+  /** The provider's stable subject id. */
   providerId: string;
   createdAt: Date;
 }
 
+/** Fields needed to link a new provider identity to a user. */
 export interface NewAuthIdentity {
   userId: string;
   provider: AuthProvider;
   providerId: string;
 }
 
+/** Persistence for provider-identity links; `(provider, providerId)` is unique. */
 export interface AuthIdentityRepository {
+  /**
+   * Find the identity for a provider account.
+   *
+   * @param provider - the auth provider (e.g. `google`).
+   * @param providerId - the provider's subject id.
+   * @returns the linked identity, or null if this account is new.
+   */
   findByProvider(provider: AuthProvider, providerId: string): Promise<AuthIdentity | null>;
+  /**
+   * Link a provider identity to a user.
+   *
+   * @param input - the user id, provider, and provider subject id.
+   * @returns the persisted identity.
+   * @throws on a unique-violation if the identity already exists (race).
+   */
   create(input: NewAuthIdentity): Promise<AuthIdentity>;
 }
 
+/** In-memory {@link AuthIdentityRepository} for dev and unit tests. */
 export class InMemoryAuthIdentityRepository implements AuthIdentityRepository {
   private readonly identities = new Map<string, AuthIdentity>();
 

--- a/services/api/src/modules/auth/auth.routes.ts
+++ b/services/api/src/modules/auth/auth.routes.ts
@@ -24,6 +24,16 @@ import {
 // Strict per-IP limit for the credential endpoints (brute-force / abuse guard).
 const AUTH_RATE_LIMIT = { max: 10, windowSeconds: 60 } as const;
 
+/**
+ * Register the auth routes: `GET /me`, `POST /auth/google`, `POST /auth/refresh`,
+ * `POST /auth/logout`.
+ *
+ * @param app - the Fastify instance to register on.
+ * @param opts - route dependencies.
+ * @param opts.users - the user repository (for `GET /me`).
+ * @param opts.authService - the AuthService (routes 503 when absent).
+ * @param opts.rateLimit - rate-limit config for the credential endpoints.
+ */
 export async function authRoutes(
   app: FastifyInstance,
   opts: { users?: UserRepository; authService?: AuthService; rateLimit: RateLimitConfig },

--- a/services/api/src/modules/auth/auth.service.ts
+++ b/services/api/src/modules/auth/auth.service.ts
@@ -14,36 +14,63 @@ import type { SessionRepository } from './session.repository';
 import { generateRefreshToken, hashToken } from './tokens';
 import type { User, UserRepository } from '../users/user.repository';
 
+/** Thrown when sign-in is attempted but no verifier is configured (prod without GOOGLE_CLIENT_ID). Routes map it to 503. */
 export class SignInNotConfiguredError extends Error {}
+
+/** Thrown when a refresh/logout token is missing, expired, or revoked. Routes map it to 401. */
 export class InvalidRefreshTokenError extends Error {}
 
+/** An access token (short-lived) paired with a refresh token (long-lived). */
 export interface AuthTokens {
   accessToken: string;
   refreshToken: string;
 }
 
+/** A successful sign-in: the user plus their fresh token pair. */
 export interface AuthResult extends AuthTokens {
   user: User;
 }
 
+/** Collaborators for {@link AuthService}, injected at app wiring (app.ts). */
 export interface AuthServiceDeps {
+  /** User records. */
   users: UserRepository;
+  /** Links a provider identity (e.g. Google) to a user. */
   authIdentities: AuthIdentityRepository;
+  /** Refresh-token sessions (hashed, rotated, revocable). */
   sessions: SessionRepository;
+  /** Signs/verifies access tokens. */
   jwt: JwtService;
   /** Undefined when sign-in isn't configured (e.g. prod without GOOGLE_CLIENT_ID). */
   verifier?: IdTokenVerifier;
+  /** Refresh-token lifetime in days. */
   refreshTtlDays: number;
 }
 
+/**
+ * True when a pg error is a unique-constraint violation (SQLSTATE 23505).
+ *
+ * @param err - the caught error (unknown shape).
+ * @returns whether it is a Postgres unique-violation.
+ */
 function isUniqueViolation(err: unknown): boolean {
   return (err as { code?: string }).code === '23505';
 }
 
+/** Sign-in, refresh, and logout orchestration (see the file header). */
 export class AuthService {
+  /** @param deps - repositories, the JWT service, and the ID-token verifier. */
   constructor(private readonly deps: AuthServiceDeps) {}
 
-  /** Verify a provider ID token, find-or-create the user, and issue tokens. */
+  /**
+   * Verify a provider ID token, find-or-create the matching user, and issue a
+   * fresh access + refresh token pair.
+   *
+   * @param idToken - the provider ID token from the client.
+   * @returns the user and their new tokens.
+   * @throws SignInNotConfiguredError when no verifier is wired.
+   * @throws when the ID token is invalid/untrusted (from the verifier).
+   */
   async signIn(idToken: string): Promise<AuthResult> {
     if (!this.deps.verifier) {
       throw new SignInNotConfiguredError('Sign-in is not configured');
@@ -54,7 +81,14 @@ export class AuthService {
     return { user, ...tokens };
   }
 
-  /** Rotate a valid refresh token: revoke the old session, issue a new pair. */
+  /**
+   * Rotate a valid refresh token: revoke the presented session and issue a new
+   * token pair (single-use refresh tokens).
+   *
+   * @param refreshToken - the raw refresh token presented by the client.
+   * @returns a new access + refresh token pair.
+   * @throws InvalidRefreshTokenError if the token is unknown, revoked, or expired.
+   */
   async refresh(refreshToken: string): Promise<AuthTokens> {
     const session = await this.deps.sessions.findByHash(hashToken(refreshToken));
     if (!session || session.revokedAt !== null || session.expiresAt <= new Date()) {
@@ -68,7 +102,12 @@ export class AuthService {
     return this.issueTokens(user, session.id);
   }
 
-  /** Revoke the session for a refresh token. Idempotent — unknown tokens no-op. */
+  /**
+   * Revoke the session behind a refresh token. Idempotent — an unknown or
+   * already-revoked token is a no-op.
+   *
+   * @param refreshToken - the raw refresh token to invalidate.
+   */
   async logout(refreshToken: string): Promise<void> {
     const session = await this.deps.sessions.findByHash(hashToken(refreshToken));
     if (session && session.revokedAt === null) {
@@ -76,6 +115,13 @@ export class AuthService {
     }
   }
 
+  /**
+   * Create a session and mint the access + refresh token pair for a user.
+   *
+   * @param user - the authenticated user.
+   * @param rotatedFrom - the prior session id when this is a refresh rotation.
+   * @returns the new token pair.
+   */
   private async issueTokens(user: User, rotatedFrom?: string): Promise<AuthTokens> {
     const refresh = generateRefreshToken(this.deps.refreshTtlDays);
     await this.deps.sessions.create({
@@ -88,6 +134,14 @@ export class AuthService {
     return { accessToken, refreshToken: refresh.token };
   }
 
+  /**
+   * Resolve the user for a verified identity, creating the user + auth_identity
+   * on first sign-in. Handles the concurrent-first-sign-in race by reusing the
+   * winner's identity.
+   *
+   * @param identity - the verified provider identity.
+   * @returns the existing or newly created user.
+   */
   private async findOrCreateUser(identity: VerifiedIdentity): Promise<User> {
     const existing = await this.deps.authIdentities.findByProvider(
       identity.provider,

--- a/services/api/src/modules/auth/id-token-verifier.ts
+++ b/services/api/src/modules/auth/id-token-verifier.ts
@@ -16,8 +16,15 @@ export interface VerifiedIdentity {
   displayName: string | null;
 }
 
+/** Verifies a provider ID token and extracts the trusted identity. */
 export interface IdTokenVerifier {
-  /** Resolve the identity, or reject if the token is invalid/untrusted. */
+  /**
+   * Verify a provider ID token.
+   *
+   * @param idToken - the provider-issued ID token to verify.
+   * @returns the trusted identity extracted from it.
+   * @throws if the token is invalid or untrusted.
+   */
   verify(idToken: string): Promise<VerifiedIdentity>;
 }
 

--- a/services/api/src/modules/auth/jwt.ts
+++ b/services/api/src/modules/auth/jwt.ts
@@ -30,9 +30,22 @@ const accessPayloadSchema = z.object({
   role: z.enum(USER_ROLES),
 });
 
+/** Signs and verifies short-lived access tokens (HS256). */
 export interface JwtService {
+  /**
+   * Sign an access token.
+   *
+   * @param claims - the user id and role to embed.
+   * @returns the signed JWT string.
+   */
   signAccessToken(claims: AccessTokenClaims): Promise<string>;
-  /** Resolves with the claims, or rejects if the token is invalid/expired. */
+  /**
+   * Verify and decode an access token.
+   *
+   * @param token - the bearer token to verify.
+   * @returns the decoded claims.
+   * @throws if the token is invalid, expired, or carries unexpected claims.
+   */
   verifyAccessToken(token: string): Promise<AccessTokenClaims>;
 }
 
@@ -47,6 +60,12 @@ export const DEV_AUTH_CONFIG: AuthConfig = {
   audience: 'trotxi-api',
 };
 
+/**
+ * Create a {@link JwtService} bound to the given signing config.
+ *
+ * @param config - secret, access-token TTL, issuer and audience.
+ * @returns a service that signs and verifies access tokens.
+ */
 export function createJwtService(config: AuthConfig): JwtService {
   const key = new TextEncoder().encode(config.secret);
   const verifyOptions = { issuer: config.issuer, audience: config.audience };

--- a/services/api/src/modules/auth/session.repository.ts
+++ b/services/api/src/modules/auth/session.repository.ts
@@ -1,29 +1,55 @@
 // Refresh-token sessions. One row per issued refresh token (stored hashed),
 // rotated on use and revocable on logout. Backs the refresh half of ADR-0007.
 
+/** A persisted refresh-token session (the token itself is stored hashed). */
 export interface Session {
   id: string;
   userId: string;
+  /** SHA-256 of the refresh token; the raw token is never stored. */
   refreshTokenHash: string;
   expiresAt: Date;
+  /** When the session was revoked (logout/rotation), or null if active. */
   revokedAt: Date | null;
+  /** The session this one replaced on rotation, if any. */
   rotatedFrom: string | null;
   createdAt: Date;
 }
 
+/** Fields needed to create a session. */
 export interface NewSession {
   userId: string;
+  /** SHA-256 of the refresh token. */
   refreshTokenHash: string;
   expiresAt: Date;
+  /** The prior session id when this is a rotation. */
   rotatedFrom?: string | null;
 }
 
+/** Persistence for refresh-token sessions. */
 export interface SessionRepository {
+  /**
+   * Create a new session.
+   *
+   * @param input - the session to create.
+   * @returns the persisted session.
+   */
   create(input: NewSession): Promise<Session>;
+  /**
+   * Look up a session by its refresh-token hash.
+   *
+   * @param refreshTokenHash - SHA-256 of the presented refresh token.
+   * @returns the session, or null if none matches.
+   */
   findByHash(refreshTokenHash: string): Promise<Session | null>;
+  /**
+   * Revoke a session (no-op if already revoked).
+   *
+   * @param id - the session id to revoke.
+   */
   revoke(id: string): Promise<void>;
 }
 
+/** In-memory {@link SessionRepository} for dev and unit tests. */
 export class InMemorySessionRepository implements SessionRepository {
   private readonly sessions = new Map<string, Session>();
 

--- a/services/api/src/modules/auth/tokens.ts
+++ b/services/api/src/modules/auth/tokens.ts
@@ -4,18 +4,32 @@
 
 import { createHash, randomBytes } from 'node:crypto';
 
+/**
+ * SHA-256 a token to its hex digest — what we persist and look up by.
+ *
+ * @param token - the raw token.
+ * @returns the hex-encoded SHA-256 hash.
+ */
 export function hashToken(token: string): string {
   return createHash('sha256').update(token).digest('hex');
 }
 
+/** A freshly minted refresh token plus the hash and expiry we persist. */
 export interface GeneratedRefreshToken {
   /** Raw token — returned to the client, never persisted. */
   token: string;
   /** SHA-256 of the token — what we store and look up by. */
   hash: string;
+  /** When the token expires. */
   expiresAt: Date;
 }
 
+/**
+ * Generate a new random refresh token with its hash and expiry.
+ *
+ * @param ttlDays - token lifetime in days.
+ * @returns the raw token (client-only), its hash, and the expiry date.
+ */
 export function generateRefreshToken(ttlDays: number): GeneratedRefreshToken {
   const token = randomBytes(32).toString('base64url');
   return {

--- a/services/api/src/modules/ledger/ledger.repository.ts
+++ b/services/api/src/modules/ledger/ledger.repository.ts
@@ -3,9 +3,13 @@
 // a stored column. Writes are exactly-once via idempotency_key, so a retried
 // grant or debit is a no-op rather than a double-spend.
 
+/** Why a ledger entry exists: a wallet top-up, a boarding spend, or a refund. */
 export type LedgerReason = 'topup' | 'boarding' | 'refund';
+
+/** What an entry references: the payment that funded it, or the boarding that spent it. */
 export type LedgerRefType = 'payment' | 'boarding';
 
+/** One immutable wallet movement. The balance is the SUM of these deltas. */
 export interface LedgerEntry {
   id: string;
   userId: string;
@@ -13,28 +17,45 @@ export interface LedgerEntry {
   delta: number;
   reason: LedgerReason;
   refType: LedgerRefType;
+  /** The id of the referenced payment/boarding, if any. */
   refId: string | null;
+  /** Unique key making the append exactly-once (no double grant/spend). */
   idempotencyKey: string;
   createdAt: Date;
 }
 
+/** Fields needed to append a ledger entry. */
 export interface NewLedgerEntry {
   userId: string;
+  /** Pesewas; positive to grant, negative to spend. */
   delta: number;
   reason: LedgerReason;
   refType: LedgerRefType;
   refId?: string | null;
+  /** Unique key; a repeated key is a no-op (returns the existing entry). */
   idempotencyKey: string;
 }
 
+/** The append-only token wallet. Backed by Postgres in prod, in-memory in dev/tests. */
 export interface LedgerRepository {
-  /** Append an entry; if the idempotency key already exists, return the existing
-   *  row unchanged (idempotent — no second write). */
+  /**
+   * Append an entry. If the idempotency key already exists, returns the existing
+   * row unchanged (idempotent — no second write).
+   *
+   * @param entry - the movement to record.
+   * @returns the persisted (or pre-existing) entry.
+   */
   append(entry: NewLedgerEntry): Promise<LedgerEntry>;
-  /** Derived balance for a user = SUM(delta). 0 when there are no entries. */
+  /**
+   * Derived balance for a user = SUM(delta).
+   *
+   * @param userId - the wallet owner.
+   * @returns the balance in pesewas (0 when there are no entries).
+   */
   balanceOf(userId: string): Promise<number>;
 }
 
+/** In-memory {@link LedgerRepository} for dev and unit tests. */
 export class InMemoryLedgerRepository implements LedgerRepository {
   private readonly entries: LedgerEntry[] = [];
   private readonly byKey = new Map<string, LedgerEntry>();

--- a/services/api/src/modules/ledger/ledger.routes.ts
+++ b/services/api/src/modules/ledger/ledger.routes.ts
@@ -9,6 +9,14 @@ import type { RateLimitConfig } from '../ratelimit/ratelimit.plugin';
 import type { LedgerRepository } from './ledger.repository';
 import { balanceResponseSchema } from './ledger.schema';
 
+/**
+ * Register the wallet routes (`GET /me/balance`).
+ *
+ * @param app - the Fastify instance to register on.
+ * @param opts - route dependencies.
+ * @param opts.ledger - the token-ledger repository (derived balance reads).
+ * @param opts.rateLimit - per-user rate-limit config.
+ */
 export async function ledgerRoutes(
   app: FastifyInstance,
   opts: { ledger?: LedgerRepository; rateLimit: RateLimitConfig },

--- a/services/api/src/modules/metrics/metrics.plugin.ts
+++ b/services/api/src/modules/metrics/metrics.plugin.ts
@@ -11,6 +11,7 @@ import type { FastifyReply, FastifyRequest } from 'fastify';
 import fp from 'fastify-plugin';
 import { collectDefaultMetrics, Histogram, Registry } from 'prom-client';
 
+/** Controls how the `/metrics` endpoint is exposed and protected. */
 export interface MetricsOptions {
   /** When set, GET /metrics requires `Authorization: Bearer <token>`. */
   token?: string;

--- a/services/api/src/modules/payments/payment.repository.ts
+++ b/services/api/src/modules/payments/payment.repository.ts
@@ -4,39 +4,70 @@
 
 import type { SubscriptionPlan } from '../subscriptions/subscription.repository';
 
+/** Lifecycle of a payment; only `pending` may transition (never mutate `paid`). */
 export type PaymentStatus = 'pending' | 'paid' | 'failed';
+
+/** Why the payment exists: a platform membership fee, or a wallet top-up. */
 export type PaymentPurpose = 'subscription' | 'topup';
 
+/** A persisted payment record. */
 export interface Payment {
+  /** Server-generated id. */
   id: string;
+  /** The user who initiated the payment. */
   userId: string;
+  /** Unique reference shared with Paystack; dedupes retried webhooks. */
   reference: string;
+  /** Subscription fee or wallet top-up. */
   purpose: PaymentPurpose;
   /** Set for subscription payments; null for top-ups. */
   plan: SubscriptionPlan | null;
-  amount: number; // pesewas (1 GHS = 100 pesewas)
+  /** Amount in pesewas (1 GHS = 100 pesewas). */
+  amount: number;
+  /** ISO 4217 currency code (currently always `GHS`). */
   currency: string;
+  /** Current lifecycle state. */
   status: PaymentStatus;
   createdAt: Date;
   updatedAt: Date;
 }
 
+/** Fields needed to create a payment; the rest (id, status, timestamps) are set by the repo. */
 export interface NewPayment {
   userId: string;
   reference: string;
   purpose: PaymentPurpose;
   plan: SubscriptionPlan | null;
+  /** Amount in pesewas (1 GHS = 100 pesewas). */
   amount: number;
   currency: string;
 }
 
+/** Persistence for payments. Backed by Postgres in prod, in-memory in dev/tests. */
 export interface PaymentRepository {
+  /**
+   * Insert a new payment in `pending` state.
+   *
+   * @param input - the payment to create (reference must be unique).
+   * @returns the persisted payment, including its generated id and timestamps.
+   */
   create(input: NewPayment): Promise<Payment>;
+  /**
+   * Look up a payment by its unique reference.
+   *
+   * @param reference - the reference shared with Paystack.
+   * @returns the payment, or null if no payment has that reference.
+   */
   findByReference(reference: string): Promise<Payment | null>;
-  /** Transition pending → paid. No-op if already paid (never mutate a paid row). */
+  /**
+   * Transition `pending → paid`. No-op if already paid (never mutate a paid row).
+   *
+   * @param reference - the payment to mark paid.
+   */
   markPaid(reference: string): Promise<void>;
 }
 
+/** In-memory {@link PaymentRepository} for dev and unit tests (no database). */
 export class InMemoryPaymentRepository implements PaymentRepository {
   private readonly byReference = new Map<string, Payment>();
 

--- a/services/api/src/modules/payments/payments.routes.ts
+++ b/services/api/src/modules/payments/payments.routes.ts
@@ -24,6 +24,15 @@ import {
 // Webhooks come from Paystack's IPs, not users — a generous per-IP cap is enough.
 const WEBHOOK_RATE_LIMIT = { max: 60, windowSeconds: 60 } as const;
 
+/**
+ * Register the payment routes: `POST /payments/subscribe`, `POST /payments/topup`,
+ * and `POST /webhooks/paystack`.
+ *
+ * @param app - the Fastify instance to register on.
+ * @param opts - route dependencies.
+ * @param opts.paymentsService - the payments orchestrator (routes 503 when absent).
+ * @param opts.rateLimit - rate-limit config (applied per user).
+ */
 export async function paymentRoutes(
   app: FastifyInstance,
   opts: { paymentsService?: PaymentsService; rateLimit: RateLimitConfig },

--- a/services/api/src/modules/payments/payments.service.ts
+++ b/services/api/src/modules/payments/payments.service.ts
@@ -21,7 +21,16 @@ import type {
 import type { NewPayment, PaymentRepository } from './payment.repository';
 import type { PaystackClient } from './paystack.client';
 
+/**
+ * Thrown when a payments operation is attempted but no Paystack client is wired
+ * (e.g. production without `PAYSTACK_SECRET_KEY`). Routes map it to HTTP 503.
+ */
 export class PaymentsNotConfiguredError extends Error {}
+
+/**
+ * Thrown when an incoming Paystack webhook fails signature verification. Routes
+ * map it to HTTP 401.
+ */
 export class InvalidWebhookError extends Error {}
 
 /**
@@ -34,9 +43,13 @@ export const SUBSCRIPTION_FEES_PESEWAS: Record<SubscriptionPlan, number> = {
   annual: 20000, // GHS 200
 };
 
+/** Collaborators for {@link PaymentsService}, injected at app wiring (app.ts). */
 export interface PaymentsServiceDeps {
+  /** Persists payment records (the pending → paid|failed state machine). */
   payments: PaymentRepository;
+  /** The token wallet — credited on a successful top-up. */
   ledger: LedgerRepository;
+  /** Platform memberships — activated on a successful subscription payment. */
   subscriptions: SubscriptionRepository;
   /** Undefined when payments aren't configured (e.g. prod without a Paystack key). */
   paystack?: PaystackClient;
@@ -44,24 +57,45 @@ export interface PaymentsServiceDeps {
   subscriptionFees: Record<SubscriptionPlan, number>;
 }
 
+/** True when a pg error is a unique-constraint violation (SQLSTATE 23505). */
 function isUniqueViolation(err: unknown): boolean {
   return (err as { code?: string }).code === '23505';
 }
 
+/** The subset of Paystack's webhook payload we read. */
 interface PaystackWebhookEvent {
   event?: string;
   data?: { reference?: string };
 }
 
+/** What initiating a checkout returns to the caller (and the route). */
 export interface CheckoutResult {
+  /** Paystack hosted-checkout URL to redirect the user to. */
   authorizationUrl: string;
+  /** Our unique payment reference, echoed back by the webhook for reconciliation. */
   reference: string;
 }
 
+/**
+ * Orchestrates the two money-in flows — subscription membership fees and wallet
+ * top-ups — on top of Paystack: it initiates checkouts and processes the
+ * `charge.success` webhook that confirms them. See the file header for the
+ * idempotency model.
+ */
 export class PaymentsService {
+  /** @param deps - repositories, the Paystack client, and the fee table. */
   constructor(private readonly deps: PaymentsServiceDeps) {}
 
-  /** Start a checkout for the platform membership fee (activates on success). */
+  /**
+   * Start a Paystack checkout for the platform membership fee. Records a
+   * `pending` payment and returns a hosted checkout URL; the subscription is
+   * activated later, by {@link handleWebhook} on `charge.success` — not here.
+   *
+   * @param userId - the authenticated user subscribing.
+   * @param plan - membership tier (`monthly` | `annual`); selects the fee.
+   * @returns the Paystack `authorizationUrl` and our payment `reference`.
+   * @throws PaymentsNotConfiguredError when no Paystack client is wired.
+   */
   async initializeSubscription(userId: string, plan: SubscriptionPlan): Promise<CheckoutResult> {
     return this.startCheckout({
       userId,
@@ -72,7 +106,15 @@ export class PaymentsService {
     });
   }
 
-  /** Start a checkout to load `amountPesewas` of ride tokens into the wallet. */
+  /**
+   * Start a Paystack checkout to load ride tokens into the wallet. Records a
+   * `pending` top-up; tokens are granted later by {@link handleWebhook}.
+   *
+   * @param userId - the authenticated user topping up.
+   * @param amountPesewas - amount to load, in pesewas (1 GHS = 100 pesewas).
+   * @returns the Paystack `authorizationUrl` and our payment `reference`.
+   * @throws PaymentsNotConfiguredError when no Paystack client is wired.
+   */
   async initializeTopup(userId: string, amountPesewas: number): Promise<CheckoutResult> {
     return this.startCheckout({
       userId,
@@ -83,6 +125,14 @@ export class PaymentsService {
     });
   }
 
+  /**
+   * Shared checkout path: persist a pending payment and open a Paystack
+   * transaction for it.
+   *
+   * @param input - the new payment minus its `reference` (generated here).
+   * @returns the checkout URL and the generated reference.
+   * @throws PaymentsNotConfiguredError when no Paystack client is wired.
+   */
   private async startCheckout(input: Omit<NewPayment, 'reference'>): Promise<CheckoutResult> {
     if (!this.deps.paystack) {
       throw new PaymentsNotConfiguredError('Payments are not configured');
@@ -99,7 +149,17 @@ export class PaymentsService {
     return { authorizationUrl: result.authorizationUrl, reference };
   }
 
-  /** Verify + process a Paystack webhook. Idempotent; safe to replay. */
+  /**
+   * Verify and process a Paystack webhook. On a valid `charge.success`: a
+   * top-up credits the ledger; a subscription activates membership. Idempotent
+   * and safe to replay (keyed ledger grant, guarded activation, pending→paid
+   * markPaid); unknown references and non-`charge.success` events are ignored.
+   *
+   * @param rawBody - the exact raw request body (required for the HMAC check).
+   * @param signature - the `x-paystack-signature` header, if present.
+   * @throws PaymentsNotConfiguredError when no Paystack client is wired.
+   * @throws InvalidWebhookError when the signature doesn't verify.
+   */
   async handleWebhook(rawBody: string, signature: string | undefined): Promise<void> {
     if (!this.deps.paystack) {
       throw new PaymentsNotConfiguredError('Payments are not configured');
@@ -134,6 +194,13 @@ export class PaymentsService {
     await this.deps.payments.markPaid(reference);
   }
 
+  /**
+   * Create the user's active subscription, treating the one-active-per-user
+   * unique-violation as success (so a replayed webhook is a no-op).
+   *
+   * @param userId - the subscriber.
+   * @param plan - the membership tier to activate.
+   */
   private async activateSubscription(userId: string, plan: SubscriptionPlan): Promise<void> {
     try {
       await this.deps.subscriptions.create({ userId, plan });

--- a/services/api/src/modules/payments/payments.service.ts
+++ b/services/api/src/modules/payments/payments.service.ts
@@ -57,7 +57,12 @@ export interface PaymentsServiceDeps {
   subscriptionFees: Record<SubscriptionPlan, number>;
 }
 
-/** True when a pg error is a unique-constraint violation (SQLSTATE 23505). */
+/**
+ * True when a pg error is a unique-constraint violation (SQLSTATE 23505).
+ *
+ * @param err - the caught error (unknown shape).
+ * @returns whether it is a Postgres unique-violation.
+ */
 function isUniqueViolation(err: unknown): boolean {
   return (err as { code?: string }).code === '23505';
 }

--- a/services/api/src/modules/payments/paystack.client.ts
+++ b/services/api/src/modules/payments/paystack.client.ts
@@ -5,29 +5,63 @@
 
 import { createHmac, timingSafeEqual } from 'node:crypto';
 
+/** Inputs to open a Paystack checkout transaction. */
 export interface PaystackInitParams {
+  /** Customer email — Paystack's customer key. */
   email: string;
   /** Amount in pesewas (GHS * 100) — Paystack's smallest unit. */
   amountPesewas: number;
+  /** Our unique payment reference, echoed back on the webhook. */
   reference: string;
 }
 
+/** Result of opening a Paystack checkout. */
 export interface PaystackInitResult {
+  /** Hosted-checkout URL to redirect the user to. */
   authorizationUrl: string;
+  /** The reference Paystack recorded (matches the one we sent). */
   reference: string;
 }
 
+/** The slice of Paystack we depend on; swap the impl (real/fake) per environment. */
 export interface PaystackClient {
+  /**
+   * Open a checkout transaction.
+   *
+   * @param params - email, amount (pesewas), and our reference.
+   * @returns the hosted `authorizationUrl` and the reference.
+   */
   initializeTransaction(params: PaystackInitParams): Promise<PaystackInitResult>;
+  /**
+   * Verify a webhook's HMAC signature against the raw body.
+   *
+   * @param rawBody - the exact bytes Paystack POSTed (re-serialized JSON won't match).
+   * @param signature - the `x-paystack-signature` header, if present.
+   * @returns true only if the signature is valid.
+   */
   verifyWebhookSignature(rawBody: string, signature: string | undefined): boolean;
 }
 
-/** HMAC-SHA512(rawBody, secret) as hex — how Paystack signs webhooks. */
+/**
+ * Compute Paystack's webhook signature: HMAC-SHA512 of the raw body, hex-encoded.
+ *
+ * @param rawBody - the exact request body bytes.
+ * @param secret - the Paystack secret key.
+ * @returns the hex signature.
+ */
 export function paystackSignature(rawBody: string, secret: string): string {
   return createHmac('sha512', secret).update(rawBody).digest('hex');
 }
 
-/** Constant-time hex compare; false on length mismatch (never throws). */
+/**
+ * Constant-time comparison of a webhook signature against the expected HMAC.
+ * Never throws; returns false on a missing signature or length mismatch.
+ *
+ * @param rawBody - the exact request body bytes.
+ * @param signature - the `x-paystack-signature` header, if present.
+ * @param secret - the Paystack secret key.
+ * @returns true only if the signature matches.
+ */
 export function verifySignature(
   rawBody: string,
   signature: string | undefined,
@@ -45,8 +79,15 @@ export function verifySignature(
  * sign a payload. Never wired in production (see server.ts).
  */
 export class FakePaystackClient implements PaystackClient {
+  /** @param secret - the shared secret tests sign payloads with. */
   constructor(private readonly secret = 'fake-paystack-secret') {}
 
+  /**
+   * Return a deterministic stub checkout URL (no network call).
+   *
+   * @param params - checkout inputs; only `reference` is used here.
+   * @returns a fake `authorizationUrl` derived from the reference.
+   */
   async initializeTransaction(params: PaystackInitParams): Promise<PaystackInitResult> {
     return {
       authorizationUrl: `https://checkout.paystack.test/${params.reference}`,
@@ -54,6 +95,13 @@ export class FakePaystackClient implements PaystackClient {
     };
   }
 
+  /**
+   * Verify a signature with real HMAC against the fake secret.
+   *
+   * @param rawBody - the exact request body bytes.
+   * @param signature - the `x-paystack-signature` header, if present.
+   * @returns true only if the signature is valid.
+   */
   verifyWebhookSignature(rawBody: string, signature: string | undefined): boolean {
     return verifySignature(rawBody, signature, this.secret);
   }

--- a/services/api/src/modules/ratelimit/ratelimit.plugin.ts
+++ b/services/api/src/modules/ratelimit/ratelimit.plugin.ts
@@ -9,11 +9,15 @@ import type { FastifyReply, FastifyRequest, preHandlerHookHandler } from 'fastif
 import fp from 'fastify-plugin';
 import type { KvStore } from '../../kv/kv.store';
 
+/** Fixed-window thresholds for a rate limit. */
 export interface RateLimitConfig {
+  /** Max requests allowed per window. */
   max: number;
+  /** Window length in seconds. */
   windowSeconds: number;
 }
 
+/** Per-route rate-limit options: thresholds plus the bucketing key. */
 export interface RateLimitOptions extends RateLimitConfig {
   /** Bucket by client IP (default) or by authenticated user id. */
   by?: 'ip' | 'user';

--- a/services/api/src/modules/subscriptions/subscription.repository.ts
+++ b/services/api/src/modules/subscriptions/subscription.repository.ts
@@ -1,6 +1,7 @@
 export type SubscriptionPlan = 'monthly' | 'annual';
 export type SubscriptionStatus = 'active' | 'cancelled' | 'expired';
 
+/** A user's platform membership. */
 export interface Subscription {
   id: string;
   userId: string;
@@ -9,16 +10,32 @@ export interface Subscription {
   createdAt: Date;
 }
 
+/** Fields needed to create a subscription. */
 export interface NewSubscription {
   userId: string;
   plan: SubscriptionPlan;
 }
 
+/** Persistence for memberships; one active subscription per user. */
 export interface SubscriptionRepository {
+  /**
+   * Create a subscription (active).
+   *
+   * @param input - the user and plan to subscribe.
+   * @returns the persisted subscription.
+   * @throws on a unique-violation if the user already has an active subscription.
+   */
   create(input: NewSubscription): Promise<Subscription>;
+  /**
+   * Find a user's active subscription, if any.
+   *
+   * @param userId - the user to check.
+   * @returns the active subscription, or null.
+   */
   findActiveByUser(userId: string): Promise<Subscription | null>;
 }
 
+/** In-memory {@link SubscriptionRepository} for dev and unit tests. */
 export class InMemorySubscriptionRepository implements SubscriptionRepository {
   private readonly subscriptions = new Map<string, Subscription>();
 

--- a/services/api/src/modules/users/user.repository.ts
+++ b/services/api/src/modules/users/user.repository.ts
@@ -5,6 +5,7 @@
 export const USER_ROLES = ['commuter', 'driver', 'admin'] as const;
 export type UserRole = (typeof USER_ROLES)[number];
 
+/** A platform user (commuter, driver, or admin). */
 export interface User {
   id: string;
   displayName: string;
@@ -14,17 +15,33 @@ export interface User {
   createdAt: Date;
 }
 
+/** Fields needed to create a user; the rest default or are server-set. */
 export interface NewUser {
   displayName: string;
   phone?: string | null;
+  /** Defaults to `commuter` when omitted. */
   role?: UserRole;
 }
 
+/** Persistence for users. Backed by Postgres in prod, in-memory in dev/tests. */
 export interface UserRepository {
+  /**
+   * Create a user.
+   *
+   * @param input - the user to create.
+   * @returns the persisted user, with generated id and defaults applied.
+   */
   create(input: NewUser): Promise<User>;
+  /**
+   * Look up a user by id.
+   *
+   * @param id - the user id.
+   * @returns the user, or null if not found.
+   */
   findById(id: string): Promise<User | null>;
 }
 
+/** In-memory {@link UserRepository} for dev and unit tests. */
 export class InMemoryUserRepository implements UserRepository {
   private readonly users = new Map<string, User>();
 


### PR DESCRIPTION
Adds **TSDoc docstrings across the public API surface of the CTO-owned modules** and wires the lint rule that will enforce them.

## Docstrings
Every **exported class, function, interface (and interface method)** now documents **purpose + `@param` meanings + `@returns` + `@throws`**. Types are left to TypeScript (no redundant `@param {type}`). Covered: payments (service/repo/client/routes), ledger, auth (jwt, tokens, id-token-verifier, auth.service, session/auth-identity repos, routes), ratelimit, metrics, kv, users, subscriptions, env, dotenv, app.

**Scope:** public/exported API (your pick). Private helpers and the `*.pg`/`*.redis` impl classes are skipped — they implement an already-documented interface.

## Enforcement (the "make it strict" part)
`eslint-plugin-jsdoc` (publicOnly, TypeScript mode), running in the existing `lint` CI gate, at **`warn`** for now. Impl/integration files (`*.pg`, `*.redis`, `*.live`, `*.google`), zod schemas, the entrypoint and db scripts are exempt. **Lint is clean — 0 jsdoc warnings.**

**To go strict:** flip the jsdoc rules `warn → error` (one line in `eslint.config.js`) and a missing/incomplete public-API docstring **fails CI**. Worth timing deliberately — once strict, teammates' open/future PRs (e.g. Foyade's mobility/subscriptions) must include docstrings too.

Logic untouched; typecheck + lint + 108 tests green.