### PR TITLE
ci(lint): enforce docstrings (jsdoc warn → error)

### DIFF
--- a/services/api/eslint.config.js
+++ b/services/api/eslint.config.js
@@ -14,11 +14,11 @@ export default tseslint.config(
     },
   },
   // Docstrings on the public API surface — TSDoc style (describe meaning; types
-  // are TypeScript's job, so no `@param {type}`). WARN for now while modules are
-  // documented; flip to `error` (+ `--max-warnings 0`) to make a missing or
-  // incomplete docstring fail CI. Impl/integration files (*.pg, *.redis, *.live,
-  // *.google), zod schemas, the entrypoint and db scripts are exempt — they
-  // implement an already-documented interface or are wiring.
+  // are TypeScript's job, so no `@param {type}`). ENFORCED: a missing or
+  // incomplete public-API docstring is an error and fails CI (`pnpm lint`).
+  // Impl/integration files (*.pg, *.redis, *.live, *.google), zod schemas, the
+  // entrypoint and db scripts are exempt — they implement an already-documented
+  // interface or are wiring.
   {
     files: ['src/**/*.ts'],
     ignores: [
@@ -34,7 +34,7 @@ export default tseslint.config(
     settings: { jsdoc: { mode: 'typescript' } },
     rules: {
       'jsdoc/require-jsdoc': [
-        'warn',
+        'error',
         {
           publicOnly: true,
           require: {
@@ -49,12 +49,12 @@ export default tseslint.config(
           exemptEmptyConstructors: true,
         },
       ],
-      'jsdoc/require-param': 'warn',
-      'jsdoc/require-param-description': 'warn',
-      'jsdoc/require-returns': 'warn',
-      'jsdoc/require-returns-description': 'warn',
-      'jsdoc/check-param-names': 'warn',
-      'jsdoc/check-alignment': 'warn',
+      'jsdoc/require-param': 'error',
+      'jsdoc/require-param-description': 'error',
+      'jsdoc/require-returns': 'error',
+      'jsdoc/require-returns-description': 'error',
+      'jsdoc/check-param-names': 'error',
+      'jsdoc/check-alignment': 'error',
     },
   },
 );


### PR DESCRIPTION
Follow-up to #75, which merged with the jsdoc rules at **`warn`** — so a missing docstring did **not** fail CI. This flips them to **`error`**, making the public-API docstring standard actually enforced in the `API` lint gate.

- Verified: the current `main` tree passes (all public API is documented from #75); an undocumented exported function fails with `jsdoc/require-jsdoc`.
- Exemptions unchanged: `*.pg`/`*.redis`/`*.live`/`*.google`, zod schemas, the entrypoint, db scripts.

**Team impact:** once merged, open/future PRs (Foyade's #57, #59) must include public-API docstrings to pass CI.