### PR TITLE
feat(auth): refresh-token reuse detection (#83)

### DIFF
--- a/docs/features/authentication.md
+++ b/docs/features/authentication.md
@@ -152,8 +152,11 @@ The authenticated user.
   (`sessions.refresh_token_hash`) — a DB leak exposes no usable tokens.
 - **Rotation:** `/auth/refresh` revokes the presented session and issues a new
   one (`rotated_from` links them). Reusing a rotated token → 401.
-- **Revocation:** logout sets `revoked_at`. (Refresh-reuse _detection_ — revoking
-  the whole family on replay — is slice-3 hardening, not yet implemented.)
+- **Reuse detection (#83):** replaying an already-**rotated** (consumed) token is
+  treated as theft — **every session for that user is revoked**, forcing re-auth
+  everywhere. A token revoked by _logout_ (no descendant) is just a 401 and does
+  not trigger this.
+- **Revocation:** logout sets `revoked_at`.
 
 ### The verifier (how Google is wired)
 

--- a/services/api/src/modules/auth/auth.service.ts
+++ b/services/api/src/modules/auth/auth.service.ts
@@ -5,7 +5,9 @@
 // Not wrapped in a DB transaction yet: on a concurrent *first* sign-in for a new
 // identity the loser may leave an orphan user row (harmless — never linked), and
 // refresh rotation revokes-then-creates (a crash mid-way just forces re-login).
-// Transactional sign-in + refresh-reuse detection are slice-3 hardening.
+// Transactional sign-in is slice-3 hardening. Refresh-token reuse detection is
+// implemented (#83): replaying an already-rotated token revokes every session
+// for the user.
 
 import type { JwtService } from './jwt';
 import type { AuthIdentityRepository } from './auth-identity.repository';
@@ -83,7 +85,9 @@ export class AuthService {
 
   /**
    * Rotate a valid refresh token: revoke the presented session and issue a new
-   * token pair (single-use refresh tokens).
+   * token pair (single-use refresh tokens). Detects **reuse** — if an
+   * already-rotated (consumed) token is replayed, every session for that user is
+   * revoked, since a valid refresh token appearing after rotation signals theft.
    *
    * @param refreshToken - the raw refresh token presented by the client.
    * @returns a new access + refresh token pair.
@@ -91,7 +95,18 @@ export class AuthService {
    */
   async refresh(refreshToken: string): Promise<AuthTokens> {
     const session = await this.deps.sessions.findByHash(hashToken(refreshToken));
-    if (!session || session.revokedAt !== null || session.expiresAt <= new Date()) {
+    if (!session || session.expiresAt <= new Date()) {
+      throw new InvalidRefreshTokenError('Invalid or expired refresh token');
+    }
+    if (session.revokedAt !== null) {
+      // A revoked token was presented. If it was consumed by *rotation* (a newer
+      // session was rotated from it), this is refresh-token reuse — a compromise
+      // signal — so revoke every session for the user (kills both the attacker's
+      // and the victim's tokens; everyone must re-authenticate). A token revoked
+      // by *logout* has no descendant, so it's just an invalid token.
+      if (await this.deps.sessions.wasRotated(session.id)) {
+        await this.deps.sessions.revokeAllForUser(session.userId);
+      }
       throw new InvalidRefreshTokenError('Invalid or expired refresh token');
     }
     const user = await this.deps.users.findById(session.userId);

--- a/services/api/src/modules/auth/session.repository.pg.ts
+++ b/services/api/src/modules/auth/session.repository.pg.ts
@@ -50,4 +50,19 @@ export class PgSessionRepository implements SessionRepository {
       [id],
     );
   }
+
+  async revokeAllForUser(userId: string): Promise<void> {
+    await this.pool.query(
+      `UPDATE sessions SET revoked_at = now() WHERE user_id = $1 AND revoked_at IS NULL`,
+      [userId],
+    );
+  }
+
+  async wasRotated(sessionId: string): Promise<boolean> {
+    const { rows } = await this.pool.query<{ exists: boolean }>(
+      `SELECT EXISTS(SELECT 1 FROM sessions WHERE rotated_from = $1) AS exists`,
+      [sessionId],
+    );
+    return rows[0]?.exists ?? false;
+  }
 }

--- a/services/api/src/modules/auth/session.repository.ts
+++ b/services/api/src/modules/auth/session.repository.ts
@@ -47,6 +47,22 @@ export interface SessionRepository {
    * @param id - the session id to revoke.
    */
   revoke(id: string): Promise<void>;
+  /**
+   * Revoke all of a user's active sessions — used on detected refresh-token
+   * reuse to force re-authentication on every device.
+   *
+   * @param userId - the user whose sessions to revoke.
+   */
+  revokeAllForUser(userId: string): Promise<void>;
+  /**
+   * Whether a session was consumed by rotation — i.e. a newer session was
+   * rotated from it. Distinguishes a reused (rotated) token from a plainly
+   * logged-out one.
+   *
+   * @param sessionId - the session to check for descendants.
+   * @returns true if some session has this one as its `rotatedFrom`.
+   */
+  wasRotated(sessionId: string): Promise<boolean>;
 }
 
 /** In-memory {@link SessionRepository} for dev and unit tests. */
@@ -81,5 +97,21 @@ export class InMemorySessionRepository implements SessionRepository {
     if (session && !session.revokedAt) {
       session.revokedAt = new Date();
     }
+  }
+
+  async revokeAllForUser(userId: string): Promise<void> {
+    const now = new Date();
+    for (const session of this.sessions.values()) {
+      if (session.userId === userId && session.revokedAt === null) {
+        session.revokedAt = now;
+      }
+    }
+  }
+
+  async wasRotated(sessionId: string): Promise<boolean> {
+    for (const session of this.sessions.values()) {
+      if (session.rotatedFrom === sessionId) return true;
+    }
+    return false;
   }
 }

--- a/services/api/tests/auth.service.test.ts
+++ b/services/api/tests/auth.service.test.ts
@@ -129,7 +129,7 @@ describe('AuthService.signIn', () => {
 });
 
 describe('AuthService.refresh', () => {
-  it('rotates: issues new tokens and invalidates the old refresh token', async () => {
+  it('rotates: issues a new pair and the rotated token continues the chain', async () => {
     const { service } = makeService();
     const { refreshToken } = await service.signIn(googleToken('g-1'));
 
@@ -137,8 +137,35 @@ describe('AuthService.refresh', () => {
     expect(rotated.accessToken).toBeTruthy();
     expect(rotated.refreshToken).not.toBe(refreshToken);
 
-    await expect(service.refresh(refreshToken)).rejects.toBeInstanceOf(InvalidRefreshTokenError);
+    // the rotated token keeps working (chain continues)
     expect((await service.refresh(rotated.refreshToken)).accessToken).toBeTruthy();
+  });
+
+  it('reuse detection: replaying a rotated token revokes the whole session family', async () => {
+    const { service } = makeService();
+    const { refreshToken } = await service.signIn(googleToken('g-1'));
+
+    const rotated = await service.refresh(refreshToken); // refreshToken now consumed
+
+    // replay the already-rotated (consumed) token → reuse detected
+    await expect(service.refresh(refreshToken)).rejects.toBeInstanceOf(InvalidRefreshTokenError);
+
+    // the whole family is revoked — even the currently-valid rotated token is dead
+    await expect(service.refresh(rotated.refreshToken)).rejects.toBeInstanceOf(
+      InvalidRefreshTokenError,
+    );
+  });
+
+  it("logout does not trigger reuse-revocation of the user's other sessions", async () => {
+    const { service } = makeService();
+    const a = await service.signIn(googleToken('g-1')); // device A
+    const b = await service.signIn(googleToken('g-1')); // device B (same user, new session)
+
+    await service.logout(a.refreshToken); // A revoked by logout (no descendant)
+
+    // replaying A's logged-out token is NOT reuse → device B stays valid
+    await expect(service.refresh(a.refreshToken)).rejects.toBeInstanceOf(InvalidRefreshTokenError);
+    expect((await service.refresh(b.refreshToken)).accessToken).toBeTruthy();
   });
 
   it('rejects an unknown refresh token', async () => {


### PR DESCRIPTION
Closes #83.

## What
Adds OAuth-style **refresh-token reuse detection**. If a refresh token that was already **rotated** (consumed) is replayed, we treat it as a compromise and **revoke every session for that user** — killing both the attacker's and the victim's tokens; everyone re-authenticates.

## How (no schema change)
- On refresh, a revoked token that **has a descendant** (`rotated_from` points to it) = it was consumed by rotation → **reuse** → `revokeAllForUser`.
- A token revoked by **logout** has no descendant → stays a plain 401 (no false-positive family wipe).
- `SessionRepository` gains `revokeAllForUser` + `wasRotated` (InMemory + Pg).

## Tests
- Reuse: replaying a rotated token kills the whole family (even the currently-valid rotated token dies).
- Logout: replaying a logged-out token does **not** revoke the user's other sessions.
- Full suite: 110 green; typecheck + lint clean.

**FE tie-in (#34):** the client's refresh interceptor should already route "refresh 401 → clear tokens → login". This lands transparently — reuse is just another cause of that 401.