### PR TITLE
feat(auth): device push-token registry (#84, part 1)

### DIFF
--- a/services/api/src/app.ts
+++ b/services/api/src/app.ts
@@ -11,6 +11,11 @@ import { z } from 'zod';
 import { InMemoryKvStore, type KvStore } from './kv/kv.store';
 import { ledgerRoutes } from './modules/ledger/ledger.routes';
 import type { LedgerRepository } from './modules/ledger/ledger.repository';
+import {
+  InMemoryDeviceTokenRepository,
+  type DeviceTokenRepository,
+} from './modules/devices/device-token.repository';
+import { deviceRoutes } from './modules/devices/devices.routes';
 import { metricsPlugin, type MetricsOptions } from './modules/metrics/metrics.plugin';
 import { paymentRoutes } from './modules/payments/payments.routes';
 import type { PaymentsService } from './modules/payments/payments.service';
@@ -40,6 +45,8 @@ export interface AppDeps {
   subscriptions?: SubscriptionRepository;
   /** Token wallet ledger (in-memory vs Postgres). Derived balance + grants/debits. */
   ledger?: LedgerRepository;
+  /** Device push-token registry (in-memory vs Postgres). Defaults to in-memory. */
+  deviceTokens?: DeviceTokenRepository;
   /** Selected by REDIS_URL (in-memory vs Redis). For rate limits, idempotency, cache. */
   kv?: KvStore;
   /** JWT/auth settings. Defaults to a dev-only config when unset (tests, local). */
@@ -119,6 +126,10 @@ export async function buildApp(deps: AppDeps = {}): Promise<FastifyInstance> {
   });
   await app.register(ledgerRoutes, {
     ledger: deps.ledger,
+    rateLimit: deps.rateLimit ?? DEFAULT_RATE_LIMIT,
+  });
+  await app.register(deviceRoutes, {
+    deviceTokens: deps.deviceTokens ?? new InMemoryDeviceTokenRepository(),
     rateLimit: deps.rateLimit ?? DEFAULT_RATE_LIMIT,
   });
   await app.register(paymentRoutes, {

--- a/services/api/src/db/migrations/009_device_tokens.sql
+++ b/services/api/src/db/migrations/009_device_tokens.sql
@@ -1,0 +1,13 @@
+-- 009_device_tokens: FCM push-token registry per user/device (#84).
+-- One row per push token. UNIQUE(fcm_token) so re-registering just re-points the
+-- token (e.g. after an account switch on the same device) — one token, one owner.
+-- Tokens cascade with the user. Foundation for push notifications.
+CREATE TABLE IF NOT EXISTS device_tokens (
+  id         uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id    uuid NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+  fcm_token  text NOT NULL UNIQUE,
+  platform   text NOT NULL CHECK (platform IN ('android', 'ios', 'web')),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_device_tokens_user ON device_tokens (user_id);

--- a/services/api/src/modules/devices/device-token.repository.pg.ts
+++ b/services/api/src/modules/devices/device-token.repository.pg.ts
@@ -1,0 +1,50 @@
+import type { Pool } from 'pg';
+import type { DevicePlatform, DeviceToken, DeviceTokenRepository } from './device-token.repository';
+
+interface DeviceTokenRow {
+  id: string;
+  user_id: string;
+  fcm_token: string;
+  platform: DevicePlatform;
+  created_at: Date;
+  updated_at: Date;
+}
+
+function toDeviceToken(row: DeviceTokenRow): DeviceToken {
+  return {
+    id: row.id,
+    userId: row.user_id,
+    fcmToken: row.fcm_token,
+    platform: row.platform,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+export class PgDeviceTokenRepository implements DeviceTokenRepository {
+  constructor(private readonly pool: Pool) {}
+
+  async register(userId: string, fcmToken: string, platform: DevicePlatform): Promise<DeviceToken> {
+    const { rows } = await this.pool.query<DeviceTokenRow>(
+      `INSERT INTO device_tokens (user_id, fcm_token, platform)
+       VALUES ($1, $2, $3)
+       ON CONFLICT (fcm_token)
+       DO UPDATE SET user_id = EXCLUDED.user_id, platform = EXCLUDED.platform, updated_at = now()
+       RETURNING *`,
+      [userId, fcmToken, platform],
+    );
+    return toDeviceToken(rows[0]!);
+  }
+
+  async removeByToken(fcmToken: string): Promise<void> {
+    await this.pool.query(`DELETE FROM device_tokens WHERE fcm_token = $1`, [fcmToken]);
+  }
+
+  async listForUser(userId: string): Promise<DeviceToken[]> {
+    const { rows } = await this.pool.query<DeviceTokenRow>(
+      `SELECT * FROM device_tokens WHERE user_id = $1 ORDER BY updated_at DESC`,
+      [userId],
+    );
+    return rows.map(toDeviceToken);
+  }
+}

--- a/services/api/src/modules/devices/device-token.repository.ts
+++ b/services/api/src/modules/devices/device-token.repository.ts
@@ -1,0 +1,73 @@
+// Device push-token registry — FCM tokens per user/device (#84). The foundation
+// for push notifications: clients register a token at sign-in, and the future
+// notification service reads them to deliver messages. Repository pattern
+// (ADR-0009): interface + InMemory here, Postgres in *.pg.ts.
+
+/** Mobile platform a push token belongs to. */
+export type DevicePlatform = 'android' | 'ios' | 'web';
+
+/** A persisted FCM push token for one of a user's devices. */
+export interface DeviceToken {
+  id: string;
+  userId: string;
+  /** The FCM registration token from the device. */
+  fcmToken: string;
+  platform: DevicePlatform;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/** Persistence for device push tokens. */
+export interface DeviceTokenRepository {
+  /**
+   * Register (upsert) an FCM token for a user. A token already registered — even
+   * to another user — is re-pointed to this user (one token, one owner).
+   *
+   * @param userId - the owner of the token.
+   * @param fcmToken - the FCM registration token from the device.
+   * @param platform - the device platform.
+   * @returns the persisted device token.
+   */
+  register(userId: string, fcmToken: string, platform: DevicePlatform): Promise<DeviceToken>;
+  /**
+   * Remove a token (e.g. on logout or when the device unregisters). No-op if absent.
+   *
+   * @param fcmToken - the FCM token to remove.
+   */
+  removeByToken(fcmToken: string): Promise<void>;
+  /**
+   * List a user's registered device tokens (for delivering push).
+   *
+   * @param userId - the user whose tokens to list.
+   * @returns the user's device tokens.
+   */
+  listForUser(userId: string): Promise<DeviceToken[]>;
+}
+
+/** In-memory {@link DeviceTokenRepository} for dev and unit tests. */
+export class InMemoryDeviceTokenRepository implements DeviceTokenRepository {
+  private readonly byToken = new Map<string, DeviceToken>();
+
+  async register(userId: string, fcmToken: string, platform: DevicePlatform): Promise<DeviceToken> {
+    const now = new Date();
+    const existing = this.byToken.get(fcmToken);
+    const token: DeviceToken = {
+      id: existing?.id ?? crypto.randomUUID(),
+      userId,
+      fcmToken,
+      platform,
+      createdAt: existing?.createdAt ?? now,
+      updatedAt: now,
+    };
+    this.byToken.set(fcmToken, token);
+    return token;
+  }
+
+  async removeByToken(fcmToken: string): Promise<void> {
+    this.byToken.delete(fcmToken);
+  }
+
+  async listForUser(userId: string): Promise<DeviceToken[]> {
+    return [...this.byToken.values()].filter((t) => t.userId === userId);
+  }
+}

--- a/services/api/src/modules/devices/devices.routes.ts
+++ b/services/api/src/modules/devices/devices.routes.ts
@@ -1,0 +1,47 @@
+// Device routes. POST /me/devices registers the caller's FCM push token (#84) —
+// the foundation for push notifications. Auth + per-user rate limited.
+
+import type { FastifyInstance } from 'fastify';
+import type { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { errorResponseSchema } from '../../lib/schemas';
+import type { RateLimitConfig } from '../ratelimit/ratelimit.plugin';
+import type { DeviceTokenRepository } from './device-token.repository';
+import { registerDeviceBodySchema, registerDeviceResponseSchema } from './devices.schema';
+
+/**
+ * Register the device routes (`POST /me/devices`).
+ *
+ * @param app - the Fastify instance to register on.
+ * @param opts - route dependencies.
+ * @param opts.deviceTokens - the device-token repository.
+ * @param opts.rateLimit - per-user rate-limit config.
+ */
+export async function deviceRoutes(
+  app: FastifyInstance,
+  opts: { deviceTokens: DeviceTokenRepository; rateLimit: RateLimitConfig },
+): Promise<void> {
+  app.withTypeProvider<ZodTypeProvider>().post(
+    '/me/devices',
+    {
+      schema: {
+        tags: ['auth'],
+        summary: 'Register this device FCM push token for the authenticated user',
+        security: [{ bearerAuth: [] }],
+        body: registerDeviceBodySchema,
+        response: {
+          200: registerDeviceResponseSchema,
+          401: errorResponseSchema,
+        },
+      },
+      preHandler: [app.authenticate, app.rateLimit({ ...opts.rateLimit, by: 'user' })],
+    },
+    async (request) => {
+      await opts.deviceTokens.register(
+        request.user!.id,
+        request.body.fcmToken,
+        request.body.platform,
+      );
+      return { registered: true };
+    },
+  );
+}

--- a/services/api/src/modules/devices/devices.schema.ts
+++ b/services/api/src/modules/devices/devices.schema.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+
+export const registerDeviceBodySchema = z.object({
+  /** The FCM registration token from the device. */
+  fcmToken: z.string().min(1),
+  platform: z.enum(['android', 'ios', 'web']),
+});
+
+export const registerDeviceResponseSchema = z.object({
+  registered: z.boolean(),
+});

--- a/services/api/src/server.ts
+++ b/services/api/src/server.ts
@@ -34,6 +34,11 @@ import {
 } from './modules/ledger/ledger.repository';
 import { PgLedgerRepository } from './modules/ledger/ledger.repository.pg';
 import {
+  InMemoryDeviceTokenRepository,
+  type DeviceTokenRepository,
+} from './modules/devices/device-token.repository';
+import { PgDeviceTokenRepository } from './modules/devices/device-token.repository.pg';
+import {
   InMemoryPaymentRepository,
   type PaymentRepository,
 } from './modules/payments/payment.repository';
@@ -74,6 +79,7 @@ async function main(): Promise<void> {
   let authIdentities: AuthIdentityRepository;
   let ledger: LedgerRepository;
   let payments: PaymentRepository;
+  let deviceTokens: DeviceTokenRepository;
   if (env.DATABASE_URL) {
     pool = createPool(env.DATABASE_URL);
     users = new PgUserRepository(pool);
@@ -82,6 +88,7 @@ async function main(): Promise<void> {
     authIdentities = new PgAuthIdentityRepository(pool);
     ledger = new PgLedgerRepository(pool);
     payments = new PgPaymentRepository(pool);
+    deviceTokens = new PgDeviceTokenRepository(pool);
     console.log('Using Postgres repositories');
   } else {
     users = new InMemoryUserRepository();
@@ -90,6 +97,7 @@ async function main(): Promise<void> {
     authIdentities = new InMemoryAuthIdentityRepository();
     ledger = new InMemoryLedgerRepository();
     payments = new InMemoryPaymentRepository();
+    deviceTokens = new InMemoryDeviceTokenRepository();
     console.log('Using in-memory repositories (no DATABASE_URL set)');
   }
 
@@ -157,6 +165,7 @@ async function main(): Promise<void> {
     users,
     subscriptions,
     ledger,
+    deviceTokens,
     authService,
     paymentsService,
     kv,

--- a/services/api/tests/devices.routes.test.ts
+++ b/services/api/tests/devices.routes.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { buildApp } from '../src/app';
+import { InMemoryDeviceTokenRepository } from '../src/modules/devices/device-token.repository';
+import { createJwtService, type AuthConfig } from '../src/modules/auth/jwt';
+
+const auth: AuthConfig = {
+  secret: 'test-secret-at-least-32-characters-long-0000',
+  accessTtl: '15m',
+  issuer: 'trotxi',
+  audience: 'trotxi-api',
+};
+const jwt = createJwtService(auth);
+const bearer = (t: string) => ({ authorization: `Bearer ${t}` });
+const body = (fcmToken: string, platform = 'android') => ({ fcmToken, platform });
+
+describe('POST /me/devices', () => {
+  it('rejects an unauthenticated request', async () => {
+    const app = await buildApp({ auth });
+    const res = await app.inject({ method: 'POST', url: '/me/devices', payload: body('tok-1') });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('registers the FCM token for the authenticated user', async () => {
+    const deviceTokens = new InMemoryDeviceTokenRepository();
+    const app = await buildApp({ auth, deviceTokens });
+    const token = await jwt.signAccessToken({ userId: 'rider-1', role: 'commuter' });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/me/devices',
+      headers: bearer(token),
+      payload: body('fcm-abc', 'ios'),
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ registered: true });
+
+    const tokens = await deviceTokens.listForUser('rider-1');
+    expect(tokens).toHaveLength(1);
+    expect(tokens[0]).toMatchObject({ fcmToken: 'fcm-abc', platform: 'ios', userId: 'rider-1' });
+  });
+
+  it('rejects an invalid platform', async () => {
+    const app = await buildApp({ auth, deviceTokens: new InMemoryDeviceTokenRepository() });
+    const token = await jwt.signAccessToken({ userId: 'rider-1', role: 'commuter' });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/me/devices',
+      headers: bearer(token),
+      payload: { fcmToken: 'x', platform: 'windows' },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('re-registering a token re-points it to the new user (upsert)', async () => {
+    const deviceTokens = new InMemoryDeviceTokenRepository();
+    const app = await buildApp({ auth, deviceTokens });
+    const t1 = await jwt.signAccessToken({ userId: 'rider-1', role: 'commuter' });
+    const t2 = await jwt.signAccessToken({ userId: 'rider-2', role: 'commuter' });
+
+    await app.inject({
+      method: 'POST',
+      url: '/me/devices',
+      headers: bearer(t1),
+      payload: body('shared'),
+    });
+    await app.inject({
+      method: 'POST',
+      url: '/me/devices',
+      headers: bearer(t2),
+      payload: body('shared'),
+    });
+
+    expect(await deviceTokens.listForUser('rider-1')).toHaveLength(0);
+    expect(await deviceTokens.listForUser('rider-2')).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
First half of #84 — the **FCM device-token registry**, the foundation for push notifications (and the small "now-add" that pairs with FE #34's sign-in).

## What
- **`device_tokens`** table (migration `009`): one row per push token, `UNIQUE(fcm_token)` so re-registering re-points it; cascades with the user.
- **`DeviceTokenRepository`** (`register` upsert · `removeByToken` · `listForUser`) — InMemory + Pg.
- **`POST /me/devices`** `{ fcmToken, platform }` — auth + per-user rate limited; registers the caller's token.
- Wired into `app.ts` (defaults to in-memory) and `server.ts` (Pg when `DATABASE_URL` set).

## Tests
`devices.routes.test.ts`: 401 unauth · registers for the user · rejects bad platform (400) · re-register re-points (upsert). Full suite **112 green**; typecheck + lint clean.

## Scope note
The **active-session list/revoke** half of #84 touches `session.repository` + `auth.service`, which **#85 (reuse detection)** also changes. To avoid a needless conflict I'll do it as a fast-follow **after #85 merges**. This PR is all-new files + additive wiring — no overlap with #85.