### PR TITLE
feat(auth): active-session list + revoke (closes #84)

### DIFF
--- a/docs/features/authentication.md
+++ b/docs/features/authentication.md
@@ -146,6 +146,23 @@ The authenticated user.
 - **Auth:** `Bearer` access token. **Rate limit:** per user.
 - **200:** the user · **401** no/invalid token · **404** user not found.
 
+#### `GET /me/sessions` · `DELETE /me/sessions/:id` (#84)
+
+Active-device management. List returns id + created/expires (never the token
+hash); delete revokes one session ("log out that device") and only your own.
+
+- **Auth:** `Bearer`. **Rate limit:** per user.
+- `GET` **200:** `{ "sessions": [{ id, createdAt, expiresAt }] }`
+- `DELETE` **204** (idempotent; a session you don't own is a no-op) · **400** non-uuid id
+
+#### `POST /me/devices` (#84)
+
+Register this device's **FCM push token** (foundation for notifications).
+
+- **Auth:** `Bearer`. **Rate limit:** per user.
+- **Body:** `{ "fcmToken": "...", "platform": "android" | "ios" | "web" }`
+- **200:** `{ "registered": true }`. Re-registering a token re-points it (one token, one owner).
+
 ### Refresh tokens & sessions
 
 - A refresh token is `randomBytes(32)`; only its **SHA-256 hash** is stored

--- a/services/api/src/modules/auth/auth.routes.ts
+++ b/services/api/src/modules/auth/auth.routes.ts
@@ -13,6 +13,8 @@ import {
   googleSignInBodySchema,
   logoutBodySchema,
   refreshBodySchema,
+  sessionIdParamsSchema,
+  sessionListResponseSchema,
   tokensSchema,
 } from './auth.schema';
 import {
@@ -25,7 +27,8 @@ import {
 const AUTH_RATE_LIMIT = { max: 10, windowSeconds: 60 } as const;
 
 /**
- * Register the auth routes: `GET /me`, `POST /auth/google`, `POST /auth/refresh`,
+ * Register the auth routes: `GET /me`, `GET /me/sessions`,
+ * `DELETE /me/sessions/:id`, `POST /auth/google`, `POST /auth/refresh`,
  * `POST /auth/logout`.
  *
  * @param app - the Fastify instance to register on.
@@ -63,6 +66,53 @@ export async function authRoutes(
         return reply.code(404).send({ error: 'not_found', message: 'User not found' });
       }
       return user;
+    },
+  );
+
+  r.get(
+    '/me/sessions',
+    {
+      schema: {
+        tags: ['auth'],
+        summary: "List the authenticated user's active sessions (devices)",
+        security: [{ bearerAuth: [] }],
+        response: {
+          200: sessionListResponseSchema,
+          401: errorResponseSchema,
+        },
+      },
+      preHandler: [app.authenticate, app.rateLimit({ ...opts.rateLimit, by: 'user' })],
+    },
+    async (request) => {
+      const sessions = opts.authService
+        ? await opts.authService.listSessions(request.user!.id)
+        : [];
+      return {
+        sessions: sessions.map((s) => ({
+          id: s.id,
+          createdAt: s.createdAt.toISOString(),
+          expiresAt: s.expiresAt.toISOString(),
+        })),
+      };
+    },
+  );
+
+  r.delete(
+    '/me/sessions/:id',
+    {
+      schema: {
+        tags: ['auth'],
+        summary: 'Revoke one of your sessions (log out that device)',
+        security: [{ bearerAuth: [] }],
+        params: sessionIdParamsSchema,
+      },
+      preHandler: [app.authenticate, app.rateLimit({ ...opts.rateLimit, by: 'user' })],
+    },
+    async (request, reply) => {
+      if (opts.authService) {
+        await opts.authService.revokeSession(request.user!.id, request.params.id);
+      }
+      return reply.code(204).send();
     },
   );
 

--- a/services/api/src/modules/auth/auth.schema.ts
+++ b/services/api/src/modules/auth/auth.schema.ts
@@ -19,3 +19,17 @@ export const tokensSchema = z.object({
 export const authResultSchema = tokensSchema.extend({
   user: userResponseSchema,
 });
+
+export const sessionSchema = z.object({
+  id: z.string(),
+  createdAt: z.string(), // ISO 8601
+  expiresAt: z.string(), // ISO 8601
+});
+
+export const sessionListResponseSchema = z.object({
+  sessions: z.array(sessionSchema),
+});
+
+export const sessionIdParamsSchema = z.object({
+  id: z.string().uuid(),
+});

--- a/services/api/src/modules/auth/auth.service.ts
+++ b/services/api/src/modules/auth/auth.service.ts
@@ -12,7 +12,7 @@
 import type { JwtService } from './jwt';
 import type { AuthIdentityRepository } from './auth-identity.repository';
 import type { IdTokenVerifier, VerifiedIdentity } from './id-token-verifier';
-import type { SessionRepository } from './session.repository';
+import type { Session, SessionRepository } from './session.repository';
 import { generateRefreshToken, hashToken } from './tokens';
 import type { User, UserRepository } from '../users/user.repository';
 
@@ -126,6 +126,32 @@ export class AuthService {
   async logout(refreshToken: string): Promise<void> {
     const session = await this.deps.sessions.findByHash(hashToken(refreshToken));
     if (session && session.revokedAt === null) {
+      await this.deps.sessions.revoke(session.id);
+    }
+  }
+
+  /**
+   * List a user's active sessions (their logged-in devices) for account-security
+   * display.
+   *
+   * @param userId - the authenticated user.
+   * @returns the user's active sessions.
+   */
+  async listSessions(userId: string): Promise<Session[]> {
+    return this.deps.sessions.listActiveForUser(userId);
+  }
+
+  /**
+   * Revoke one of the user's sessions ("log out this device"). A no-op if the
+   * session is unknown or belongs to someone else, so a user can only revoke
+   * their own.
+   *
+   * @param userId - the authenticated user.
+   * @param sessionId - the session to revoke.
+   */
+  async revokeSession(userId: string, sessionId: string): Promise<void> {
+    const session = await this.deps.sessions.findById(sessionId);
+    if (session && session.userId === userId) {
       await this.deps.sessions.revoke(session.id);
     }
   }

--- a/services/api/src/modules/auth/session.repository.pg.ts
+++ b/services/api/src/modules/auth/session.repository.pg.ts
@@ -65,4 +65,21 @@ export class PgSessionRepository implements SessionRepository {
     );
     return rows[0]?.exists ?? false;
   }
+
+  async listActiveForUser(userId: string): Promise<Session[]> {
+    const { rows } = await this.pool.query<SessionRow>(
+      `SELECT * FROM sessions
+       WHERE user_id = $1 AND revoked_at IS NULL AND expires_at > now()
+       ORDER BY created_at DESC`,
+      [userId],
+    );
+    return rows.map(toSession);
+  }
+
+  async findById(id: string): Promise<Session | null> {
+    const { rows } = await this.pool.query<SessionRow>(`SELECT * FROM sessions WHERE id = $1`, [
+      id,
+    ]);
+    return rows[0] ? toSession(rows[0]) : null;
+  }
 }

--- a/services/api/src/modules/auth/session.repository.ts
+++ b/services/api/src/modules/auth/session.repository.ts
@@ -63,6 +63,20 @@ export interface SessionRepository {
    * @returns true if some session has this one as its `rotatedFrom`.
    */
   wasRotated(sessionId: string): Promise<boolean>;
+  /**
+   * List a user's active (not revoked, not expired) sessions, newest first.
+   *
+   * @param userId - the user whose sessions to list.
+   * @returns the active sessions.
+   */
+  listActiveForUser(userId: string): Promise<Session[]>;
+  /**
+   * Look up a session by id (for ownership checks before revoke).
+   *
+   * @param id - the session id.
+   * @returns the session, or null if none.
+   */
+  findById(id: string): Promise<Session | null>;
 }
 
 /** In-memory {@link SessionRepository} for dev and unit tests. */
@@ -113,5 +127,16 @@ export class InMemorySessionRepository implements SessionRepository {
       if (session.rotatedFrom === sessionId) return true;
     }
     return false;
+  }
+
+  async listActiveForUser(userId: string): Promise<Session[]> {
+    const now = new Date();
+    return [...this.sessions.values()]
+      .filter((s) => s.userId === userId && s.revokedAt === null && s.expiresAt > now)
+      .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+  }
+
+  async findById(id: string): Promise<Session | null> {
+    return this.sessions.get(id) ?? null;
   }
 }

--- a/services/api/tests/auth.sessions.test.ts
+++ b/services/api/tests/auth.sessions.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import { buildApp } from '../src/app';
+import { InMemoryAuthIdentityRepository } from '../src/modules/auth/auth-identity.repository';
+import { AuthService } from '../src/modules/auth/auth.service';
+import { FakeIdTokenVerifier } from '../src/modules/auth/id-token-verifier';
+import { createJwtService, type AuthConfig } from '../src/modules/auth/jwt';
+import { InMemorySessionRepository } from '../src/modules/auth/session.repository';
+import { InMemoryUserRepository } from '../src/modules/users/user.repository';
+
+const auth: AuthConfig = {
+  secret: 'test-secret-at-least-32-characters-long-0000',
+  accessTtl: '15m',
+  issuer: 'trotxi',
+  audience: 'trotxi-api',
+};
+const jwt = createJwtService(auth);
+const bearer = (t: string) => ({ authorization: `Bearer ${t}` });
+const googleToken = (sub: string) => JSON.stringify({ sub, name: 'Ama' });
+
+function make() {
+  const users = new InMemoryUserRepository();
+  const authService = new AuthService({
+    users,
+    authIdentities: new InMemoryAuthIdentityRepository(),
+    sessions: new InMemorySessionRepository(),
+    jwt,
+    verifier: new FakeIdTokenVerifier(),
+    refreshTtlDays: 30,
+  });
+  return { users, authService };
+}
+const accessFor = (userId: string) => jwt.signAccessToken({ userId, role: 'commuter' });
+
+describe('GET /me/sessions + DELETE /me/sessions/:id', () => {
+  it('requires authentication', async () => {
+    const { users, authService } = make();
+    const app = await buildApp({ auth, users, authService });
+    expect((await app.inject({ method: 'GET', url: '/me/sessions' })).statusCode).toBe(401);
+  });
+
+  it('lists active sessions (no secrets) and revokes one', async () => {
+    const { users, authService } = make();
+    const app = await buildApp({ auth, users, authService });
+    const signIn = await authService.signIn(googleToken('g-1'));
+    await authService.signIn(googleToken('g-1')); // a second device for the same user
+    const token = await accessFor(signIn.user.id);
+
+    const list = await app.inject({ method: 'GET', url: '/me/sessions', headers: bearer(token) });
+    expect(list.statusCode).toBe(200);
+    const { sessions } = list.json();
+    expect(sessions).toHaveLength(2);
+    expect(sessions[0]).toHaveProperty('id');
+    expect(sessions[0]).not.toHaveProperty('refreshTokenHash'); // never leak the hash
+
+    const del = await app.inject({
+      method: 'DELETE',
+      url: `/me/sessions/${sessions[0].id}`,
+      headers: bearer(token),
+    });
+    expect(del.statusCode).toBe(204);
+
+    const after = await app.inject({ method: 'GET', url: '/me/sessions', headers: bearer(token) });
+    expect(after.json().sessions).toHaveLength(1);
+  });
+
+  it("cannot revoke another user's session", async () => {
+    const { users, authService } = make();
+    const app = await buildApp({ auth, users, authService });
+    const a = await authService.signIn(googleToken('g-1'));
+    const b = await authService.signIn(googleToken('g-2'));
+    const bSessionId = (await authService.listSessions(b.user.id))[0]!.id;
+
+    const res = await app.inject({
+      method: 'DELETE',
+      url: `/me/sessions/${bSessionId}`,
+      headers: bearer(await accessFor(a.user.id)),
+    });
+    expect(res.statusCode).toBe(204); // idempotent, but a no-op
+
+    expect(await authService.listSessions(b.user.id)).toHaveLength(1); // B's session survives
+  });
+
+  it('rejects a non-uuid session id with 400', async () => {
+    const { users, authService } = make();
+    const app = await buildApp({ auth, users, authService });
+    const res = await app.inject({
+      method: 'DELETE',
+      url: '/me/sessions/not-a-uuid',
+      headers: bearer(await accessFor('rider-1')),
+    });
+    expect(res.statusCode).toBe(400);
+  });
+});


### PR DESCRIPTION
Second half of #84 — **active-device management**. With #86 (device tokens) merged, this closes #84.

## What
- **`GET /me/sessions`** — list your active sessions (id + created/expires; **never** the token hash).
- **`DELETE /me/sessions/:id`** — revoke one ("log out that device"); **own-only** (a session you don't own is a no-op), 204 idempotent, 400 on a non-uuid id.
- `SessionRepository` gains `listActiveForUser` + `findById`; `AuthService` gains `listSessions` + `revokeSession` (ownership-checked).
- Docs: the new endpoints + `POST /me/devices` added to `authentication.md`.

## Tests
`auth.sessions.test.ts`: auth required · list + revoke own · **can't revoke another user's session** · 400 non-uuid. Full suite **118 green**; typecheck + lint clean.

## Deferred (noted)
Device **labels** on the session list (e.g. "iPhone 15") need capturing device info at sign-in — a small follow-up that changes `/auth/google`'s body; not blocking. The list works today with id/timestamps.

## FE (#34)
`GET /me/sessions` + `DELETE /me/sessions/:id` power an "active devices / log out other devices" screen; `POST /me/devices` registers the FCM token at sign-in.