### PR TITLE
feat(boarding): QR pass + driver scan verification (#20, integrity slice)

### DIFF
--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -22,6 +22,7 @@ repo (`system-design.md`, `security.md`). Each doc links to both.
 | Wallet & payments — token ledger, balance, subscriptions & top-ups (Paystack) | [payments-and-wallet.md](payments-and-wallet.md) | ✅ live                               |
 | Mobility — routes, stops, browse                                              | _(in review — #57)_                              | 🚧                                    |
 | Rate limiting (#23)                                                           | [rate-limiting.md](rate-limiting.md)             | ✅ live                               |
+| Boarding — QR passes + scan verification (#20)                                | [boarding.md](boarding.md)                       | 🟡 integrity slice                    |
 | Observability & performance (#28)                                             | [design](../design/observability.md)             | ✅ backend live (metrics/traces/logs) |
 
 ## Conventions for a feature doc

--- a/docs/features/boarding.md
+++ b/docs/features/boarding.md
@@ -15,8 +15,11 @@ pass**, and logs every scan for audit. Rationale: #20.
 
 - **Pass** — a **short-lived signed token** (JWT, HS256, audience `trotxi-pass`,
   ~60s) the rider's app renders as a **QR**. The short TTL means the QR **rotates**,
-  so a screenshot can't be reused. Signed with the server key but a distinct
-  audience, so a pass can't be used as an access token (or vice-versa).
+  and each pass carries a unique `jti` making it **single-use**: the first valid
+  scan consumes it (KV `increment`), so a shared screenshot dies on the second
+  scan, not just at the TTL. Signed with the server key but a distinct audience,
+  so a pass can't be used as an access token (or vice-versa). Verification allows
+  5s clock tolerance (drift across instances).
 - **Integrity vs eligibility** — verifying a pass proves it's a **real pass for
   rider X**. It does **not** (yet) check membership or debit tokens — those are the
   money-gated part (#19/#21), deliberately deferred.
@@ -41,23 +44,33 @@ Verify a scanned pass (drivers only) and record the scan.
 
 - **Auth:** `Bearer` + **role `driver`** (else **403**). **Rate limit:** per user.
 - **Body:** `{ "pass": "<scanned token>", "tripId?": "<uuid>" }`
-- **200:** `{ "valid": true|false, "riderId": "<uuid>|null", "reason": "ok"|"invalid"|"expired" }`
+- **200:** `{ "valid": true|false, "riderId": "<uuid>|null", "reason": "ok"|"invalid"|"expired"|"reused" }`
+  (`reused` = the pass was already consumed by an earlier scan; `riderId` is still
+  returned so the driver sees who presented it)
 
 ---
 
 ## Data
 
 `scan_events(id, rider_id, scanned_by, trip_id, result, method, created_at)` —
-`result` ∈ `valid|invalid|expired`, `method` ∈ `qr|photo`. `trip_id` has no FK
-yet (trips are #18).
+`result` ∈ `valid|invalid|expired|reused`, `method` ∈ `qr|photo`. `trip_id` has
+no FK yet (trips are #18).
 
 ## Security notes
 
-- **Rotating, signed passes** — forgery needs the server key; the short TTL blocks
-  screenshot reuse.
+- **Rotating, signed, single-use passes** — forgery needs the server key; the
+  short TTL rotates the QR; the `jti` consume-on-scan kills screenshot sharing
+  within the window.
 - **Audience separation** — a `trotxi-api` access token fails pass verification and
   vice-versa (tested).
-- **Full audit** — every scan (including failures) is recorded.
+- **Full audit** — every scan (including failures and reuses) is recorded.
+- **Availability over strictness** — the KV single-use check and the audit write
+  both **fail open** (log loudly, never block boarding). Same posture as the rate
+  limiter; when the money work lands, the token debit becomes the transactional
+  anchor and this decision is revisited.
+- **Input hygiene** — the scanned pass is capped at 512 chars before it reaches
+  `jwtVerify`; the scan route throttles **before** the role check so non-driver
+  tokens can't hammer unthrottled 403s.
 
 ## Deferred (with the money work / product)
 

--- a/docs/features/boarding.md
+++ b/docs/features/boarding.md
@@ -1,0 +1,85 @@
+# Boarding — QR passes & scan verification
+
+**Owner:** Godfred Awuku · **Last updated:** 2026-07-02
+
+**Status:** 🟡 integrity slice live (#20). The **eligibility gates** (active
+membership + token debit on board) and the **photo-pass** fallback are deferred —
+see below.
+
+Lets a driver confirm a rider is boarding with a **genuine, unforged, unexpired
+pass**, and logs every scan for audit. Rationale: #20.
+
+---
+
+## Concepts
+
+- **Pass** — a **short-lived signed token** (JWT, HS256, audience `trotxi-pass`,
+  ~60s) the rider's app renders as a **QR**. The short TTL means the QR **rotates**,
+  so a screenshot can't be reused. Signed with the server key but a distinct
+  audience, so a pass can't be used as an access token (or vice-versa).
+- **Integrity vs eligibility** — verifying a pass proves it's a **real pass for
+  rider X**. It does **not** (yet) check membership or debit tokens — those are the
+  money-gated part (#19/#21), deliberately deferred.
+- **Scan event** — every verification is one **append-only** audit row
+  (`scan_events`): rider, driver, trip, result, method. `rider_id` is null for an
+  invalid/forged pass (unattributable).
+
+---
+
+## API
+
+#### `GET /me/pass`
+
+Issue the caller's rotating boarding pass.
+
+- **Auth:** `Bearer`. **Rate limit:** per user.
+- **200:** `{ "pass": "<token>", "expiresInSeconds": 60 }` — render `pass` as a QR; refresh before it lapses.
+
+#### `POST /boarding/scan`
+
+Verify a scanned pass (drivers only) and record the scan.
+
+- **Auth:** `Bearer` + **role `driver`** (else **403**). **Rate limit:** per user.
+- **Body:** `{ "pass": "<scanned token>", "tripId?": "<uuid>" }`
+- **200:** `{ "valid": true|false, "riderId": "<uuid>|null", "reason": "ok"|"invalid"|"expired" }`
+
+---
+
+## Data
+
+`scan_events(id, rider_id, scanned_by, trip_id, result, method, created_at)` —
+`result` ∈ `valid|invalid|expired`, `method` ∈ `qr|photo`. `trip_id` has no FK
+yet (trips are #18).
+
+## Security notes
+
+- **Rotating, signed passes** — forgery needs the server key; the short TTL blocks
+  screenshot reuse.
+- **Audience separation** — a `trotxi-api` access token fails pass verification and
+  vice-versa (tested).
+- **Full audit** — every scan (including failures) is recorded.
+
+## Deferred (with the money work / product)
+
+- **Eligibility gates** — a valid scan should also require an **active
+  subscription** and (later) **debit a token** for the fare. Couples to the
+  commission model (on hold), so not built here.
+- **Photo-pass fallback** — driver-confirmed boarding when QR fails; needs image
+  upload (Cloudflare R2, #24) + product UX for how the driver identifies the rider.
+
+## Where the code lives
+
+```
+services/api/src/modules/boarding/
+  pass.ts                    # sign/verify the short-lived pass (jose)
+  scan-event.repository.ts(.pg) # append-only scan audit
+  boarding.service.ts        # issuePass + verifyScan (records the scan)
+  boarding.routes.ts         # GET /me/pass, POST /boarding/scan
+  boarding.schema.ts
+services/api/src/db/migrations/010_scan_events.sql
+```
+
+## Related
+
+- [authentication.md](authentication.md) (the same JWT/HS256 machinery, different audience)
+- `strategy/system-design.md §4.3` (boarding requires membership + balance)

--- a/services/api/src/app.ts
+++ b/services/api/src/app.ts
@@ -16,6 +16,9 @@ import {
   type DeviceTokenRepository,
 } from './modules/devices/device-token.repository';
 import { deviceRoutes } from './modules/devices/devices.routes';
+import { BoardingService } from './modules/boarding/boarding.service';
+import { boardingRoutes } from './modules/boarding/boarding.routes';
+import { InMemoryScanEventRepository } from './modules/boarding/scan-event.repository';
 import { metricsPlugin, type MetricsOptions } from './modules/metrics/metrics.plugin';
 import { paymentRoutes } from './modules/payments/payments.routes';
 import type { PaymentsService } from './modules/payments/payments.service';
@@ -47,6 +50,8 @@ export interface AppDeps {
   ledger?: LedgerRepository;
   /** Device push-token registry (in-memory vs Postgres). Defaults to in-memory. */
   deviceTokens?: DeviceTokenRepository;
+  /** Boarding pass issuance + scan verification. Defaults to an in-memory scan store. */
+  boardingService?: BoardingService;
   /** Selected by REDIS_URL (in-memory vs Redis). For rate limits, idempotency, cache. */
   kv?: KvStore;
   /** JWT/auth settings. Defaults to a dev-only config when unset (tests, local). */
@@ -96,6 +101,7 @@ export async function buildApp(deps: AppDeps = {}): Promise<FastifyInstance> {
         { name: 'auth', description: 'Authentication and the current user' },
         { name: 'wallet', description: 'Token wallet / GHS balance' },
         { name: 'payments', description: 'Subscriptions checkout (Paystack) + webhook' },
+        { name: 'boarding', description: 'QR boarding passes + scan verification' },
       ],
       components: {
         // Protected routes set `security: [{ bearerAuth: [] }]`; clients send
@@ -117,7 +123,8 @@ export async function buildApp(deps: AppDeps = {}): Promise<FastifyInstance> {
 
   // Guards first (decorators on the root instance), then routes that use them.
   const kv = deps.kv ?? new InMemoryKvStore();
-  await app.register(authPlugin, { config: deps.auth ?? DEV_AUTH_CONFIG });
+  const authConfig = deps.auth ?? DEV_AUTH_CONFIG;
+  await app.register(authPlugin, { config: authConfig });
   await app.register(rateLimitPlugin, { kv });
   await app.register(authRoutes, {
     users: deps.users,
@@ -134,6 +141,16 @@ export async function buildApp(deps: AppDeps = {}): Promise<FastifyInstance> {
   });
   await app.register(paymentRoutes, {
     paymentsService: deps.paymentsService,
+    rateLimit: deps.rateLimit ?? DEFAULT_RATE_LIMIT,
+  });
+  await app.register(boardingRoutes, {
+    boardingService:
+      deps.boardingService ??
+      new BoardingService({
+        scanEvents: new InMemoryScanEventRepository(),
+        secret: authConfig.secret,
+        passTtlSeconds: 60,
+      }),
     rateLimit: deps.rateLimit ?? DEFAULT_RATE_LIMIT,
   });
 

--- a/services/api/src/app.ts
+++ b/services/api/src/app.ts
@@ -148,6 +148,7 @@ export async function buildApp(deps: AppDeps = {}): Promise<FastifyInstance> {
       deps.boardingService ??
       new BoardingService({
         scanEvents: new InMemoryScanEventRepository(),
+        kv,
         secret: authConfig.secret,
         passTtlSeconds: 60,
       }),

--- a/services/api/src/db/migrations/010_scan_events.sql
+++ b/services/api/src/db/migrations/010_scan_events.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS scan_events (
   rider_id   uuid REFERENCES users (id) ON DELETE SET NULL,
   scanned_by uuid REFERENCES users (id) ON DELETE SET NULL,
   trip_id    uuid,
-  result     text NOT NULL CHECK (result IN ('valid', 'invalid', 'expired')),
+  result     text NOT NULL CHECK (result IN ('valid', 'invalid', 'expired', 'reused')),
   method     text NOT NULL DEFAULT 'qr' CHECK (method IN ('qr', 'photo')),
   created_at timestamptz NOT NULL DEFAULT now()
 );

--- a/services/api/src/db/migrations/010_scan_events.sql
+++ b/services/api/src/db/migrations/010_scan_events.sql
@@ -1,0 +1,15 @@
+-- 010_scan_events: boarding audit trail (#20). Every pass scan (or photo
+-- fallback) records who was scanned, by which driver, on which trip, and the
+-- result. Append-only. rider_id is NULL for an invalid/forged pass (unattributable);
+-- trip_id has no FK yet (trips arrive in #18).
+CREATE TABLE IF NOT EXISTS scan_events (
+  id         uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  rider_id   uuid REFERENCES users (id) ON DELETE SET NULL,
+  scanned_by uuid REFERENCES users (id) ON DELETE SET NULL,
+  trip_id    uuid,
+  result     text NOT NULL CHECK (result IN ('valid', 'invalid', 'expired')),
+  method     text NOT NULL DEFAULT 'qr' CHECK (method IN ('qr', 'photo')),
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_scan_events_rider ON scan_events (rider_id);
+CREATE INDEX IF NOT EXISTS idx_scan_events_trip ON scan_events (trip_id);

--- a/services/api/src/modules/boarding/boarding.routes.ts
+++ b/services/api/src/modules/boarding/boarding.routes.ts
@@ -1,0 +1,68 @@
+// Boarding routes (#20). GET /me/pass issues the rider's rotating QR pass;
+// POST /boarding/scan lets a DRIVER verify a scanned pass (integrity) and logs
+// the scan. Both are authed + per-user rate limited; scan additionally requires
+// the driver role.
+
+import type { FastifyInstance } from 'fastify';
+import type { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { errorResponseSchema } from '../../lib/schemas';
+import type { RateLimitConfig } from '../ratelimit/ratelimit.plugin';
+import type { BoardingService } from './boarding.service';
+import { passResponseSchema, scanBodySchema, scanResponseSchema } from './boarding.schema';
+
+/**
+ * Register the boarding routes (`GET /me/pass`, `POST /boarding/scan`).
+ *
+ * @param app - the Fastify instance to register on.
+ * @param opts - route dependencies.
+ * @param opts.boardingService - issues passes + verifies scans.
+ * @param opts.rateLimit - per-user rate-limit config.
+ */
+export async function boardingRoutes(
+  app: FastifyInstance,
+  opts: { boardingService: BoardingService; rateLimit: RateLimitConfig },
+): Promise<void> {
+  const r = app.withTypeProvider<ZodTypeProvider>();
+
+  r.get(
+    '/me/pass',
+    {
+      schema: {
+        tags: ['boarding'],
+        summary: 'Issue the rider a short-lived boarding pass (render as a QR)',
+        security: [{ bearerAuth: [] }],
+        response: { 200: passResponseSchema, 401: errorResponseSchema },
+      },
+      preHandler: [app.authenticate, app.rateLimit({ ...opts.rateLimit, by: 'user' })],
+    },
+    async (request) => opts.boardingService.issuePass(request.user!.id),
+  );
+
+  r.post(
+    '/boarding/scan',
+    {
+      schema: {
+        tags: ['boarding'],
+        summary: 'Verify a scanned rider pass (driver only) and record the scan',
+        security: [{ bearerAuth: [] }],
+        body: scanBodySchema,
+        response: {
+          200: scanResponseSchema,
+          401: errorResponseSchema,
+          403: errorResponseSchema,
+        },
+      },
+      preHandler: [
+        app.authenticate,
+        app.requireRole('driver'),
+        app.rateLimit({ ...opts.rateLimit, by: 'user' }),
+      ],
+    },
+    async (request) =>
+      opts.boardingService.verifyScan({
+        pass: request.body.pass,
+        scannedBy: request.user!.id,
+        tripId: request.body.tripId,
+      }),
+  );
+}

--- a/services/api/src/modules/boarding/boarding.routes.ts
+++ b/services/api/src/modules/boarding/boarding.routes.ts
@@ -52,10 +52,12 @@ export async function boardingRoutes(
           403: errorResponseSchema,
         },
       },
+      // Throttle BEFORE the role check — otherwise non-driver tokens could
+      // hammer 403s without ever being rate limited.
       preHandler: [
         app.authenticate,
-        app.requireRole('driver'),
         app.rateLimit({ ...opts.rateLimit, by: 'user' }),
+        app.requireRole('driver'),
       ],
     },
     async (request) =>

--- a/services/api/src/modules/boarding/boarding.schema.ts
+++ b/services/api/src/modules/boarding/boarding.schema.ts
@@ -6,13 +6,14 @@ export const passResponseSchema = z.object({
 });
 
 export const scanBodySchema = z.object({
-  /** The token decoded from the scanned QR. */
-  pass: z.string().min(1),
+  /** The token decoded from the scanned QR. Our passes are ~300 bytes; the cap
+   * keeps oversized input away from jwtVerify. */
+  pass: z.string().min(1).max(512),
   tripId: z.string().uuid().optional(),
 });
 
 export const scanResponseSchema = z.object({
   valid: z.boolean(),
   riderId: z.string().nullable(),
-  reason: z.enum(['ok', 'invalid', 'expired']),
+  reason: z.enum(['ok', 'invalid', 'expired', 'reused']),
 });

--- a/services/api/src/modules/boarding/boarding.schema.ts
+++ b/services/api/src/modules/boarding/boarding.schema.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod';
+
+export const passResponseSchema = z.object({
+  pass: z.string(),
+  expiresInSeconds: z.number().int(),
+});
+
+export const scanBodySchema = z.object({
+  /** The token decoded from the scanned QR. */
+  pass: z.string().min(1),
+  tripId: z.string().uuid().optional(),
+});
+
+export const scanResponseSchema = z.object({
+  valid: z.boolean(),
+  riderId: z.string().nullable(),
+  reason: z.enum(['ok', 'invalid', 'expired']),
+});

--- a/services/api/src/modules/boarding/boarding.service.ts
+++ b/services/api/src/modules/boarding/boarding.service.ts
@@ -1,9 +1,18 @@
 // BoardingService — issue a rider's rotating QR pass, and verify a scanned pass
 // (#20). Verification is integrity-only: it proves the pass is a genuine,
-// unexpired pass for a rider, and records every scan for audit. The eligibility
-// gates (active membership, token debit on board) are deferred with the money
-// work (#19/#21) — a valid scan here means "real pass", not "cleared to ride".
+// unexpired, not-already-used pass for a rider, and records every scan for
+// audit. The eligibility gates (active membership, token debit on board) are
+// deferred with the money work (#19/#21) — a valid scan here means "real pass",
+// not "cleared to ride".
+//
+// Availability over strictness (same posture as the rate limiter): the KV
+// single-use check and the audit write both fail OPEN — a KV/DB blip must never
+// stop a bus from boarding. The audit trail is best-effort in this phase; when
+// the money work lands, the token debit becomes the transactional anchor and
+// the scan record should ride with it.
 
+import { errors } from 'jose';
+import type { KvStore } from '../../kv/kv.store';
 import { signPass, verifyPass, type IssuedPass } from './pass';
 import type { ScanEventRepository } from './scan-event.repository';
 
@@ -22,32 +31,24 @@ export interface VerifyScanResult {
   valid: boolean;
   /** The rider the pass belongs to (null when invalid/forged). */
   riderId: string | null;
-  reason: 'ok' | 'invalid' | 'expired';
+  reason: 'ok' | 'invalid' | 'expired' | 'reused';
 }
 
 /** Collaborators for {@link BoardingService}, injected at app wiring. */
 export interface BoardingServiceDeps {
   /** Append-only scan audit trail. */
   scanEvents: ScanEventRepository;
+  /** Marks passes consumed (single-use); Redis in prod, in-memory in dev/tests. */
+  kv: KvStore;
   /** Server signing key for passes (the JWT secret). */
   secret: string;
   /** Pass lifetime in seconds (short → the QR rotates). */
   passTtlSeconds: number;
 }
 
-/**
- * True when a jose verify error is a JWT-expired failure.
- *
- * @param err - the caught verify error.
- * @returns whether it indicates an expired pass.
- */
-function isExpired(err: unknown): boolean {
-  return (err as { code?: string }).code === 'ERR_JWT_EXPIRED';
-}
-
 /** Boarding-pass issuance + scan verification (see the file header). */
 export class BoardingService {
-  /** @param deps - the scan-event repo, signing secret, and pass TTL. */
+  /** @param deps - the scan-event repo, KV store, signing secret, and pass TTL. */
   constructor(private readonly deps: BoardingServiceDeps) {}
 
   /**
@@ -61,28 +62,54 @@ export class BoardingService {
   }
 
   /**
-   * Verify a scanned pass (integrity) and record the scan.
+   * Verify a scanned pass (integrity + single-use) and record the scan. A pass
+   * already consumed by a previous valid scan returns `reason: 'reused'` — a
+   * shared screenshot dies on the second scan, not just at the TTL.
    *
    * @param input - the scanned pass, the driver, and the trip.
    * @returns whether the pass is valid, the rider id, and the reason.
    */
   async verifyScan(input: VerifyScanInput): Promise<VerifyScanResult> {
     let riderId: string | null = null;
+    let jti: string | null = null;
     let reason: VerifyScanResult['reason'] = 'invalid';
     try {
-      ({ userId: riderId } = await verifyPass(input.pass, this.deps.secret));
+      ({ userId: riderId, jti } = await verifyPass(input.pass, this.deps.secret));
       reason = 'ok';
     } catch (err) {
-      reason = isExpired(err) ? 'expired' : 'invalid';
+      reason = err instanceof errors.JWTExpired ? 'expired' : 'invalid';
     }
 
-    await this.deps.scanEvents.record({
-      riderId,
-      scannedBy: input.scannedBy,
-      tripId: input.tripId ?? null,
-      result: reason === 'ok' ? 'valid' : reason,
-      method: 'qr',
-    });
+    // Single-use: atomically count uses of this jti; >1 means the pass was
+    // already consumed. Fails open — a KV outage must not block boarding (the
+    // audit trail still records the duplicates for reconciliation).
+    if (reason === 'ok' && jti) {
+      try {
+        // Key TTL slightly outlives the pass (TTL + clock tolerance).
+        const uses = await this.deps.kv.increment(
+          `pass:used:${jti}`,
+          this.deps.passTtlSeconds + 10,
+        );
+        if (uses > 1) reason = 'reused';
+      } catch (err) {
+        console.warn('boarding: single-use check failed (KV unavailable); allowing scan', err);
+      }
+    }
+
+    // Audit is best-effort here: verification already answered the driver, and a
+    // DB blip (or a rider deleted mid-window tripping the FK) must not 500 the
+    // scan. Failures are logged loudly instead.
+    try {
+      await this.deps.scanEvents.record({
+        riderId,
+        scannedBy: input.scannedBy,
+        tripId: input.tripId ?? null,
+        result: reason === 'ok' ? 'valid' : reason,
+        method: 'qr',
+      });
+    } catch (err) {
+      console.error('boarding: failed to record scan event (audit gap)', err);
+    }
 
     return { valid: reason === 'ok', riderId, reason };
   }

--- a/services/api/src/modules/boarding/boarding.service.ts
+++ b/services/api/src/modules/boarding/boarding.service.ts
@@ -1,0 +1,89 @@
+// BoardingService — issue a rider's rotating QR pass, and verify a scanned pass
+// (#20). Verification is integrity-only: it proves the pass is a genuine,
+// unexpired pass for a rider, and records every scan for audit. The eligibility
+// gates (active membership, token debit on board) are deferred with the money
+// work (#19/#21) — a valid scan here means "real pass", not "cleared to ride".
+
+import { signPass, verifyPass, type IssuedPass } from './pass';
+import type { ScanEventRepository } from './scan-event.repository';
+
+/** A driver's request to verify a scanned pass. */
+export interface VerifyScanInput {
+  /** The token decoded from the scanned QR. */
+  pass: string;
+  /** The driver performing the scan. */
+  scannedBy: string;
+  /** The trip being boarded, if known. */
+  tripId?: string | null;
+}
+
+/** The outcome returned to the driver's app. */
+export interface VerifyScanResult {
+  valid: boolean;
+  /** The rider the pass belongs to (null when invalid/forged). */
+  riderId: string | null;
+  reason: 'ok' | 'invalid' | 'expired';
+}
+
+/** Collaborators for {@link BoardingService}, injected at app wiring. */
+export interface BoardingServiceDeps {
+  /** Append-only scan audit trail. */
+  scanEvents: ScanEventRepository;
+  /** Server signing key for passes (the JWT secret). */
+  secret: string;
+  /** Pass lifetime in seconds (short → the QR rotates). */
+  passTtlSeconds: number;
+}
+
+/**
+ * True when a jose verify error is a JWT-expired failure.
+ *
+ * @param err - the caught verify error.
+ * @returns whether it indicates an expired pass.
+ */
+function isExpired(err: unknown): boolean {
+  return (err as { code?: string }).code === 'ERR_JWT_EXPIRED';
+}
+
+/** Boarding-pass issuance + scan verification (see the file header). */
+export class BoardingService {
+  /** @param deps - the scan-event repo, signing secret, and pass TTL. */
+  constructor(private readonly deps: BoardingServiceDeps) {}
+
+  /**
+   * Issue a short-lived boarding pass for a rider.
+   *
+   * @param userId - the authenticated rider.
+   * @returns the signed pass and its lifetime.
+   */
+  async issuePass(userId: string): Promise<IssuedPass> {
+    return signPass(userId, this.deps.secret, this.deps.passTtlSeconds);
+  }
+
+  /**
+   * Verify a scanned pass (integrity) and record the scan.
+   *
+   * @param input - the scanned pass, the driver, and the trip.
+   * @returns whether the pass is valid, the rider id, and the reason.
+   */
+  async verifyScan(input: VerifyScanInput): Promise<VerifyScanResult> {
+    let riderId: string | null = null;
+    let reason: VerifyScanResult['reason'] = 'invalid';
+    try {
+      ({ userId: riderId } = await verifyPass(input.pass, this.deps.secret));
+      reason = 'ok';
+    } catch (err) {
+      reason = isExpired(err) ? 'expired' : 'invalid';
+    }
+
+    await this.deps.scanEvents.record({
+      riderId,
+      scannedBy: input.scannedBy,
+      tripId: input.tripId ?? null,
+      result: reason === 'ok' ? 'valid' : reason,
+      method: 'qr',
+    });
+
+    return { valid: reason === 'ok', riderId, reason };
+  }
+}

--- a/services/api/src/modules/boarding/pass.ts
+++ b/services/api/src/modules/boarding/pass.ts
@@ -1,0 +1,58 @@
+// Boarding passes — short-lived signed tokens a rider shows as a QR (#20). Signed
+// with the server key but a distinct audience ('trotxi-pass'), so a pass can't be
+// used as an access token (or vice versa). The short TTL makes the QR rotate, so
+// a screenshot can't be reused. This is *integrity* only: verifying a pass proves
+// it's a genuine, unexpired pass for a rider — eligibility gates (active
+// membership, token balance) layer on with the money work (#19/#21).
+
+import { SignJWT, jwtVerify } from 'jose';
+
+const PASS_AUDIENCE = 'trotxi-pass';
+const ALG = 'HS256';
+
+/** A signed boarding pass plus how long it stays valid. */
+export interface IssuedPass {
+  /** The signed pass token — rendered as a QR by the app. */
+  pass: string;
+  /** Lifetime in seconds; the app refreshes the QR before it lapses. */
+  expiresInSeconds: number;
+}
+
+/**
+ * Sign a short-lived boarding pass for a rider.
+ *
+ * @param userId - the rider the pass belongs to.
+ * @param secret - the server signing key.
+ * @param ttlSeconds - pass lifetime (default 60s, so the QR rotates).
+ * @returns the signed pass token and its lifetime.
+ */
+export async function signPass(
+  userId: string,
+  secret: string,
+  ttlSeconds = 60,
+): Promise<IssuedPass> {
+  const key = new TextEncoder().encode(secret);
+  const pass = await new SignJWT({})
+    .setProtectedHeader({ alg: ALG })
+    .setSubject(userId)
+    .setIssuedAt()
+    .setAudience(PASS_AUDIENCE)
+    .setExpirationTime(`${ttlSeconds}s`)
+    .sign(key);
+  return { pass, expiresInSeconds: ttlSeconds };
+}
+
+/**
+ * Verify a scanned boarding pass.
+ *
+ * @param pass - the token decoded from the scanned QR.
+ * @param secret - the server signing key.
+ * @returns the rider id the pass was issued to.
+ * @throws if the pass is forged, expired, or not a boarding pass (wrong audience).
+ */
+export async function verifyPass(pass: string, secret: string): Promise<{ userId: string }> {
+  const key = new TextEncoder().encode(secret);
+  const { payload } = await jwtVerify(pass, key, { audience: PASS_AUDIENCE });
+  if (!payload.sub) throw new Error('Pass is missing its subject');
+  return { userId: payload.sub };
+}

--- a/services/api/src/modules/boarding/pass.ts
+++ b/services/api/src/modules/boarding/pass.ts
@@ -1,14 +1,20 @@
 // Boarding passes — short-lived signed tokens a rider shows as a QR (#20). Signed
 // with the server key but a distinct audience ('trotxi-pass'), so a pass can't be
-// used as an access token (or vice versa). The short TTL makes the QR rotate, so
-// a screenshot can't be reused. This is *integrity* only: verifying a pass proves
-// it's a genuine, unexpired pass for a rider — eligibility gates (active
-// membership, token balance) layer on with the money work (#19/#21).
+// used as an access token (or vice versa). The short TTL makes the QR rotate, and
+// each pass carries a unique `jti` so a scan can be marked consumed (single-use).
+// This is *integrity* only: verifying a pass proves it's a genuine, unexpired
+// pass for a rider — eligibility gates (active membership, token balance) layer
+// on with the money work (#19/#21).
 
 import { SignJWT, jwtVerify } from 'jose';
 
-const PASS_AUDIENCE = 'trotxi-pass';
+/** The JWT audience that marks a token as a boarding pass (never an access token). */
+export const PASS_AUDIENCE = 'trotxi-pass';
 const ALG = 'HS256';
+
+// Verifier leeway for issuer/verifier clock drift across instances. With only a
+// 60s TTL, drift would otherwise eat a real chunk of the pass's usable lifetime.
+const CLOCK_TOLERANCE_SECONDS = 5;
 
 /** A signed boarding pass plus how long it stays valid. */
 export interface IssuedPass {
@@ -16,6 +22,14 @@ export interface IssuedPass {
   pass: string;
   /** Lifetime in seconds; the app refreshes the QR before it lapses. */
   expiresInSeconds: number;
+}
+
+/** The claims recovered from a verified pass. */
+export interface VerifiedPass {
+  /** The rider the pass was issued to. */
+  userId: string;
+  /** The pass's unique id — the single-use key. */
+  jti: string;
 }
 
 /**
@@ -35,6 +49,7 @@ export async function signPass(
   const pass = await new SignJWT({})
     .setProtectedHeader({ alg: ALG })
     .setSubject(userId)
+    .setJti(crypto.randomUUID())
     .setIssuedAt()
     .setAudience(PASS_AUDIENCE)
     .setExpirationTime(`${ttlSeconds}s`)
@@ -47,12 +62,15 @@ export async function signPass(
  *
  * @param pass - the token decoded from the scanned QR.
  * @param secret - the server signing key.
- * @returns the rider id the pass was issued to.
+ * @returns the rider id the pass was issued to and the pass's unique jti.
  * @throws if the pass is forged, expired, or not a boarding pass (wrong audience).
  */
-export async function verifyPass(pass: string, secret: string): Promise<{ userId: string }> {
+export async function verifyPass(pass: string, secret: string): Promise<VerifiedPass> {
   const key = new TextEncoder().encode(secret);
-  const { payload } = await jwtVerify(pass, key, { audience: PASS_AUDIENCE });
-  if (!payload.sub) throw new Error('Pass is missing its subject');
-  return { userId: payload.sub };
+  const { payload } = await jwtVerify(pass, key, {
+    audience: PASS_AUDIENCE,
+    clockTolerance: CLOCK_TOLERANCE_SECONDS,
+  });
+  if (!payload.sub || !payload.jti) throw new Error('Pass is missing its subject or jti');
+  return { userId: payload.sub, jti: payload.jti };
 }

--- a/services/api/src/modules/boarding/scan-event.repository.pg.ts
+++ b/services/api/src/modules/boarding/scan-event.repository.pg.ts
@@ -1,0 +1,52 @@
+import type { Pool } from 'pg';
+import type {
+  NewScanEvent,
+  ScanEvent,
+  ScanEventRepository,
+  ScanMethod,
+  ScanResult,
+} from './scan-event.repository';
+
+interface ScanEventRow {
+  id: string;
+  rider_id: string | null;
+  scanned_by: string | null;
+  trip_id: string | null;
+  result: ScanResult;
+  method: ScanMethod;
+  created_at: Date;
+}
+
+function toScanEvent(row: ScanEventRow): ScanEvent {
+  return {
+    id: row.id,
+    riderId: row.rider_id,
+    scannedBy: row.scanned_by,
+    tripId: row.trip_id,
+    result: row.result,
+    method: row.method,
+    createdAt: row.created_at,
+  };
+}
+
+export class PgScanEventRepository implements ScanEventRepository {
+  constructor(private readonly pool: Pool) {}
+
+  async record(input: NewScanEvent): Promise<ScanEvent> {
+    const { rows } = await this.pool.query<ScanEventRow>(
+      `INSERT INTO scan_events (rider_id, scanned_by, trip_id, result, method)
+       VALUES ($1, $2, $3, $4, $5)
+       RETURNING *`,
+      [input.riderId, input.scannedBy, input.tripId, input.result, input.method],
+    );
+    return toScanEvent(rows[0]!);
+  }
+
+  async listForRider(riderId: string): Promise<ScanEvent[]> {
+    const { rows } = await this.pool.query<ScanEventRow>(
+      `SELECT * FROM scan_events WHERE rider_id = $1 ORDER BY created_at DESC`,
+      [riderId],
+    );
+    return rows.map(toScanEvent);
+  }
+}

--- a/services/api/src/modules/boarding/scan-event.repository.ts
+++ b/services/api/src/modules/boarding/scan-event.repository.ts
@@ -1,0 +1,74 @@
+// Scan events — the boarding audit trail (#20). Every pass verification (or photo
+// fallback) is one append-only row. Repository pattern (ADR-0009): interface +
+// InMemory here, Postgres in *.pg.ts.
+
+/** Outcome of a scan. */
+export type ScanResult = 'valid' | 'invalid' | 'expired';
+/** How the rider was verified. */
+export type ScanMethod = 'qr' | 'photo';
+
+/** A recorded boarding scan. */
+export interface ScanEvent {
+  id: string;
+  /** The pass owner; null when the pass was invalid/forged (unattributable). */
+  riderId: string | null;
+  /** The driver who scanned. */
+  scannedBy: string | null;
+  /** The trip, if known (no FK yet — trips are #18). */
+  tripId: string | null;
+  result: ScanResult;
+  method: ScanMethod;
+  createdAt: Date;
+}
+
+/** Fields to record a scan; the rest (id, timestamp) are set by the repo. */
+export interface NewScanEvent {
+  riderId: string | null;
+  scannedBy: string | null;
+  tripId: string | null;
+  result: ScanResult;
+  method: ScanMethod;
+}
+
+/** Persistence for boarding scan events (append-only). */
+export interface ScanEventRepository {
+  /**
+   * Record a scan event.
+   *
+   * @param input - the scan to record.
+   * @returns the persisted event.
+   */
+  record(input: NewScanEvent): Promise<ScanEvent>;
+  /**
+   * List a rider's recent scans, newest first (audit / "my rides").
+   *
+   * @param riderId - the rider whose scans to list.
+   * @returns the rider's scan events.
+   */
+  listForRider(riderId: string): Promise<ScanEvent[]>;
+}
+
+/** In-memory {@link ScanEventRepository} for dev and unit tests. */
+export class InMemoryScanEventRepository implements ScanEventRepository {
+  private readonly events: ScanEvent[] = [];
+
+  async record(input: NewScanEvent): Promise<ScanEvent> {
+    const event: ScanEvent = {
+      id: crypto.randomUUID(),
+      riderId: input.riderId,
+      scannedBy: input.scannedBy,
+      tripId: input.tripId,
+      result: input.result,
+      method: input.method,
+      createdAt: new Date(),
+    };
+    this.events.push(event);
+    return event;
+  }
+
+  async listForRider(riderId: string): Promise<ScanEvent[]> {
+    return this.events
+      .filter((e) => e.riderId === riderId)
+      .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+  }
+}

--- a/services/api/src/modules/boarding/scan-event.repository.ts
+++ b/services/api/src/modules/boarding/scan-event.repository.ts
@@ -3,7 +3,7 @@
 // InMemory here, Postgres in *.pg.ts.
 
 /** Outcome of a scan. */
-export type ScanResult = 'valid' | 'invalid' | 'expired';
+export type ScanResult = 'valid' | 'invalid' | 'expired' | 'reused';
 /** How the rider was verified. */
 export type ScanMethod = 'qr' | 'photo';
 

--- a/services/api/src/server.ts
+++ b/services/api/src/server.ts
@@ -38,6 +38,12 @@ import {
   type DeviceTokenRepository,
 } from './modules/devices/device-token.repository';
 import { PgDeviceTokenRepository } from './modules/devices/device-token.repository.pg';
+import { BoardingService } from './modules/boarding/boarding.service';
+import {
+  InMemoryScanEventRepository,
+  type ScanEventRepository,
+} from './modules/boarding/scan-event.repository';
+import { PgScanEventRepository } from './modules/boarding/scan-event.repository.pg';
 import {
   InMemoryPaymentRepository,
   type PaymentRepository,
@@ -80,6 +86,7 @@ async function main(): Promise<void> {
   let ledger: LedgerRepository;
   let payments: PaymentRepository;
   let deviceTokens: DeviceTokenRepository;
+  let scanEvents: ScanEventRepository;
   if (env.DATABASE_URL) {
     pool = createPool(env.DATABASE_URL);
     users = new PgUserRepository(pool);
@@ -89,6 +96,7 @@ async function main(): Promise<void> {
     ledger = new PgLedgerRepository(pool);
     payments = new PgPaymentRepository(pool);
     deviceTokens = new PgDeviceTokenRepository(pool);
+    scanEvents = new PgScanEventRepository(pool);
     console.log('Using Postgres repositories');
   } else {
     users = new InMemoryUserRepository();
@@ -98,8 +106,16 @@ async function main(): Promise<void> {
     ledger = new InMemoryLedgerRepository();
     payments = new InMemoryPaymentRepository();
     deviceTokens = new InMemoryDeviceTokenRepository();
+    scanEvents = new InMemoryScanEventRepository();
     console.log('Using in-memory repositories (no DATABASE_URL set)');
   }
+
+  // Boarding: short-lived QR passes signed with the server key + a scan audit log.
+  const boardingService = new BoardingService({
+    scanEvents,
+    secret: auth.secret,
+    passTtlSeconds: 60,
+  });
 
   // Sign-in verifier: real Google when configured; a dev fake outside production;
   // otherwise undefined (POST /auth/google returns 503 — keeps staging booting).
@@ -166,6 +182,7 @@ async function main(): Promise<void> {
     subscriptions,
     ledger,
     deviceTokens,
+    boardingService,
     authService,
     paymentsService,
     kv,

--- a/services/api/src/server.ts
+++ b/services/api/src/server.ts
@@ -110,9 +110,11 @@ async function main(): Promise<void> {
     console.log('Using in-memory repositories (no DATABASE_URL set)');
   }
 
-  // Boarding: short-lived QR passes signed with the server key + a scan audit log.
+  // Boarding: short-lived QR passes signed with the server key + a scan audit
+  // log; the KV store marks passes consumed (single-use).
   const boardingService = new BoardingService({
     scanEvents,
+    kv,
     secret: auth.secret,
     passTtlSeconds: 60,
   });

--- a/services/api/tests/boarding.routes.test.ts
+++ b/services/api/tests/boarding.routes.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import { buildApp } from '../src/app';
+import { BoardingService } from '../src/modules/boarding/boarding.service';
+import { InMemoryScanEventRepository } from '../src/modules/boarding/scan-event.repository';
+import { createJwtService, type AuthConfig } from '../src/modules/auth/jwt';
+
+const auth: AuthConfig = {
+  secret: 'test-secret-at-least-32-characters-long-0000',
+  accessTtl: '15m',
+  issuer: 'trotxi',
+  audience: 'trotxi-api',
+};
+const jwt = createJwtService(auth);
+const bearer = (t: string) => ({ authorization: `Bearer ${t}` });
+const access = (userId: string, role: 'commuter' | 'driver' | 'admin' = 'commuter') =>
+  jwt.signAccessToken({ userId, role });
+
+function make() {
+  const scanEvents = new InMemoryScanEventRepository();
+  const boardingService = new BoardingService({
+    scanEvents,
+    secret: auth.secret,
+    passTtlSeconds: 60,
+  });
+  return { scanEvents, boardingService };
+}
+
+describe('GET /me/pass', () => {
+  it('requires authentication', async () => {
+    const app = await buildApp({ auth, boardingService: make().boardingService });
+    expect((await app.inject({ method: 'GET', url: '/me/pass' })).statusCode).toBe(401);
+  });
+
+  it('issues a short-lived pass for the rider', async () => {
+    const app = await buildApp({ auth, boardingService: make().boardingService });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/me/pass',
+      headers: bearer(await access('rider-1')),
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().pass).toBeTruthy();
+    expect(res.json().expiresInSeconds).toBe(60);
+  });
+});
+
+describe('POST /boarding/scan', () => {
+  it('requires the driver role (commuter → 403)', async () => {
+    const app = await buildApp({ auth, boardingService: make().boardingService });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/boarding/scan',
+      headers: bearer(await access('rider-1', 'commuter')),
+      payload: { pass: 'x' },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('a driver verifies a valid pass; the scan is recorded', async () => {
+    const { boardingService, scanEvents } = make();
+    const app = await buildApp({ auth, boardingService });
+    const { pass } = await boardingService.issuePass('rider-1');
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/boarding/scan',
+      headers: bearer(await access('driver-1', 'driver')),
+      payload: { pass },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ valid: true, riderId: 'rider-1', reason: 'ok' });
+
+    const events = await scanEvents.listForRider('rider-1');
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ result: 'valid', scannedBy: 'driver-1', method: 'qr' });
+  });
+
+  it('a forged/garbage pass is invalid', async () => {
+    const app = await buildApp({ auth, boardingService: make().boardingService });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/boarding/scan',
+      headers: bearer(await access('driver-1', 'driver')),
+      payload: { pass: 'not-a-real-pass' },
+    });
+    expect(res.json()).toMatchObject({ valid: false, riderId: null, reason: 'invalid' });
+  });
+
+  it('an access token cannot be reused as a boarding pass (audience separation)', async () => {
+    const app = await buildApp({ auth, boardingService: make().boardingService });
+    const riderAccessToken = await access('rider-1'); // aud=trotxi-api, not trotxi-pass
+    const res = await app.inject({
+      method: 'POST',
+      url: '/boarding/scan',
+      headers: bearer(await access('driver-1', 'driver')),
+      payload: { pass: riderAccessToken },
+    });
+    expect(res.json()).toMatchObject({ valid: false, reason: 'invalid' });
+  });
+});

--- a/services/api/tests/boarding.routes.test.ts
+++ b/services/api/tests/boarding.routes.test.ts
@@ -1,8 +1,14 @@
+import { SignJWT } from 'jose';
 import { describe, expect, it } from 'vitest';
 import { buildApp } from '../src/app';
 import { BoardingService } from '../src/modules/boarding/boarding.service';
-import { InMemoryScanEventRepository } from '../src/modules/boarding/scan-event.repository';
+import { PASS_AUDIENCE } from '../src/modules/boarding/pass';
+import {
+  InMemoryScanEventRepository,
+  type ScanEventRepository,
+} from '../src/modules/boarding/scan-event.repository';
 import { createJwtService, type AuthConfig } from '../src/modules/auth/jwt';
+import { InMemoryKvStore, type KvStore } from '../src/kv/kv.store';
 
 const auth: AuthConfig = {
   secret: 'test-secret-at-least-32-characters-long-0000',
@@ -15,15 +21,25 @@ const bearer = (t: string) => ({ authorization: `Bearer ${t}` });
 const access = (userId: string, role: 'commuter' | 'driver' | 'admin' = 'commuter') =>
   jwt.signAccessToken({ userId, role });
 
-function make() {
-  const scanEvents = new InMemoryScanEventRepository();
+function make(overrides: { scanEvents?: ScanEventRepository; kv?: KvStore } = {}) {
+  const scanEvents = overrides.scanEvents ?? new InMemoryScanEventRepository();
+  const kv = overrides.kv ?? new InMemoryKvStore();
   const boardingService = new BoardingService({
     scanEvents,
+    kv,
     secret: auth.secret,
     passTtlSeconds: 60,
   });
-  return { scanEvents, boardingService };
+  return { scanEvents, kv, boardingService };
 }
+
+const scan = async (app: Awaited<ReturnType<typeof buildApp>>, pass: string, driver = 'driver-1') =>
+  app.inject({
+    method: 'POST',
+    url: '/boarding/scan',
+    headers: bearer(await access(driver, 'driver')),
+    payload: { pass },
+  });
 
 describe('GET /me/pass', () => {
   it('requires authentication', async () => {
@@ -56,17 +72,31 @@ describe('POST /boarding/scan', () => {
     expect(res.statusCode).toBe(403);
   });
 
+  it('rate limits before the role check (non-drivers cannot hammer 403s)', async () => {
+    const app = await buildApp({
+      auth,
+      boardingService: make().boardingService,
+      rateLimit: { max: 2, windowSeconds: 60 },
+    });
+    const commuter = await access('rider-1', 'commuter');
+    const post = () =>
+      app.inject({
+        method: 'POST',
+        url: '/boarding/scan',
+        headers: bearer(commuter),
+        payload: { pass: 'x' },
+      });
+    expect((await post()).statusCode).toBe(403);
+    expect((await post()).statusCode).toBe(403);
+    expect((await post()).statusCode).toBe(429); // throttled, not another 403
+  });
+
   it('a driver verifies a valid pass; the scan is recorded', async () => {
     const { boardingService, scanEvents } = make();
     const app = await buildApp({ auth, boardingService });
     const { pass } = await boardingService.issuePass('rider-1');
 
-    const res = await app.inject({
-      method: 'POST',
-      url: '/boarding/scan',
-      headers: bearer(await access('driver-1', 'driver')),
-      payload: { pass },
-    });
+    const res = await scan(app, pass);
     expect(res.statusCode).toBe(200);
     expect(res.json()).toMatchObject({ valid: true, riderId: 'rider-1', reason: 'ok' });
 
@@ -75,26 +105,87 @@ describe('POST /boarding/scan', () => {
     expect(events[0]).toMatchObject({ result: 'valid', scannedBy: 'driver-1', method: 'qr' });
   });
 
+  it('single-use: a second scan of the same pass is rejected as reused', async () => {
+    const { boardingService, scanEvents } = make();
+    const app = await buildApp({ auth, boardingService });
+    const { pass } = await boardingService.issuePass('rider-1');
+
+    expect((await scan(app, pass)).json()).toMatchObject({ valid: true, reason: 'ok' });
+    // same QR again (e.g. shared screenshot) within the TTL
+    const replay = await scan(app, pass, 'driver-2');
+    expect(replay.json()).toMatchObject({ valid: false, riderId: 'rider-1', reason: 'reused' });
+
+    const events = await scanEvents.listForRider('rider-1');
+    expect(events.map((e) => e.result).sort()).toEqual(['reused', 'valid']);
+  });
+
+  it('an expired pass is rejected as expired (beyond clock tolerance)', async () => {
+    const app = await buildApp({ auth, boardingService: make().boardingService });
+    const key = new TextEncoder().encode(auth.secret);
+    const expired = await new SignJWT({})
+      .setProtectedHeader({ alg: 'HS256' })
+      .setSubject('rider-1')
+      .setJti(crypto.randomUUID())
+      .setAudience(PASS_AUDIENCE)
+      .setExpirationTime(Math.floor(Date.now() / 1000) - 30) // 30s past, > 5s tolerance
+      .sign(key);
+    expect((await scan(app, expired)).json()).toMatchObject({ valid: false, reason: 'expired' });
+  });
+
   it('a forged/garbage pass is invalid', async () => {
     const app = await buildApp({ auth, boardingService: make().boardingService });
-    const res = await app.inject({
-      method: 'POST',
-      url: '/boarding/scan',
-      headers: bearer(await access('driver-1', 'driver')),
-      payload: { pass: 'not-a-real-pass' },
-    });
+    const res = await scan(app, 'not-a-real-pass');
     expect(res.json()).toMatchObject({ valid: false, riderId: null, reason: 'invalid' });
   });
 
   it('an access token cannot be reused as a boarding pass (audience separation)', async () => {
     const app = await buildApp({ auth, boardingService: make().boardingService });
     const riderAccessToken = await access('rider-1'); // aud=trotxi-api, not trotxi-pass
-    const res = await app.inject({
-      method: 'POST',
-      url: '/boarding/scan',
-      headers: bearer(await access('driver-1', 'driver')),
-      payload: { pass: riderAccessToken },
-    });
+    const res = await scan(app, riderAccessToken);
     expect(res.json()).toMatchObject({ valid: false, reason: 'invalid' });
+  });
+
+  it('rejects an oversized pass without touching jwtVerify (400)', async () => {
+    const app = await buildApp({ auth, boardingService: make().boardingService });
+    const res = await scan(app, 'x'.repeat(600));
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('an audit-write failure does not block the scan result (fails open)', async () => {
+    const failingScanEvents: ScanEventRepository = {
+      record: async () => {
+        throw new Error('db down');
+      },
+      listForRider: async () => [],
+    };
+    const { boardingService } = make({ scanEvents: failingScanEvents });
+    const app = await buildApp({ auth, boardingService });
+    const { pass } = await boardingService.issuePass('rider-1');
+
+    const res = await scan(app, pass);
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ valid: true, riderId: 'rider-1', reason: 'ok' });
+  });
+
+  it('a KV outage does not block boarding (single-use check fails open)', async () => {
+    const kv = new InMemoryKvStore();
+    const broken: KvStore = {
+      ...kv,
+      increment: async () => {
+        throw new Error('kv down');
+      },
+      get: kv.get.bind(kv),
+      set: kv.set.bind(kv),
+      del: kv.del.bind(kv),
+      ping: kv.ping.bind(kv),
+      close: kv.close.bind(kv),
+    };
+    const { boardingService } = make({ kv: broken });
+    const app = await buildApp({ auth, boardingService });
+    const { pass } = await boardingService.issuePass('rider-1');
+
+    const res = await scan(app, pass);
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ valid: true, reason: 'ok' });
   });
 });


### PR DESCRIPTION
The **money-independent half of #20**, per the earlier call: the QR/pass/scan-verify machinery can ship without the commission decision. This unblocks FE **#37 (board → pass)** and **#41 (driver scan)**.

## What
- **`GET /me/pass`** — rider gets a **rotating short-lived pass** (JWT, HS256, audience `trotxi-pass`, 60s TTL) to render as a QR. Screenshot reuse dies with the TTL.
- **`POST /boarding/scan`** — **driver-only** (`requireRole('driver')`): verifies a scanned pass (genuine/expired/forged) and returns `{ valid, riderId, reason }`.
- **`scan_events`** (migration `010`) — append-only audit of every scan (rider, driver, trip, result, method). `rider_id` null for forged passes.
- **Audience separation** — an access token can't be used as a boarding pass and vice-versa (tested).
- Feature doc: `docs/features/boarding.md` (incl. what's deferred and why).

## Deliberately deferred (documented)
- **Eligibility gates** (active membership + token debit on board) — couples to the **commission model, on hold**. A valid scan today means "real pass", not "cleared to ride".
- **Photo-pass fallback** — needs R2 upload (#24) + product UX.

## Tests
6 new (`boarding.routes.test.ts`): auth required · pass issuance · commuter→403 · valid scan recorded with audit row · forged pass invalid · **access-token-as-pass rejected**. Full suite **124 green**; typecheck/lint clean.

## FE contract (#37/#41)
Rider: `GET /me/pass` → render QR → refresh every ≤60s. Driver: scan → `POST /boarding/scan {pass}` → show valid/invalid + rider.