### PR TITLE
fix(grafana): NaN-proof error rate + absent() multi-replica caveat

### DIFF
--- a/ops/grafana/README.md
+++ b/ops/grafana/README.md
@@ -19,33 +19,46 @@ pick your Prometheus datasource when prompted.
 
 ## Panels (PromQL, if you'd rather build by hand)
 
-| Panel                     | Query                                                                                                                                            |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Request rate (req/s)      | `sum(rate(http_server_duration_milliseconds_count[5m]))`                                                                                         |
-| Error rate (%)            | `100 * sum(rate(http_server_duration_milliseconds_count{http_status_code=~"5.."}[5m])) / sum(rate(http_server_duration_milliseconds_count[5m]))` |
-| Latency p95 (ms)          | `histogram_quantile(0.95, sum by (le) (rate(http_server_duration_milliseconds_bucket[5m])))`                                                     |
-| Latency p99 (ms)          | `histogram_quantile(0.99, sum by (le) (rate(http_server_duration_milliseconds_bucket[5m])))`                                                     |
-| Latency p95 by route (ms) | `histogram_quantile(0.95, sum by (le, http_route) (rate(http_server_duration_milliseconds_bucket[5m])))`                                         |
-| Event-loop lag p99 (ms)   | `nodejs_eventloop_delay_p99_seconds * 1000`                                                                                                      |
-| Heap used vs limit (%)    | `100 * v8js_memory_heap_used_bytes / v8js_memory_heap_limit_bytes`                                                                               |
+| Panel                     | Query                                                                                                                                                                                         |
+| ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Request rate (req/s)      | `sum(rate(http_server_duration_milliseconds_count[5m]))`                                                                                                                                      |
+| Error rate (%)            | `100 * (sum(rate(http_server_duration_milliseconds_count{http_status_code=~"5.."}[5m])) or vector(0)) / clamp_min(sum(rate(http_server_duration_milliseconds_count[5m])) or vector(0), 1e-6)` |
+| Latency p95 (ms)          | `histogram_quantile(0.95, sum by (le) (rate(http_server_duration_milliseconds_bucket[5m])))`                                                                                                  |
+| Latency p99 (ms)          | `histogram_quantile(0.99, sum by (le) (rate(http_server_duration_milliseconds_bucket[5m])))`                                                                                                  |
+| Latency p95 by route (ms) | `histogram_quantile(0.95, sum by (le, http_route) (rate(http_server_duration_milliseconds_bucket[5m])))`                                                                                      |
+| Event-loop lag p99 (ms)   | `nodejs_eventloop_delay_p99_seconds * 1000`                                                                                                                                                   |
+| Heap used vs limit (%)    | `100 * v8js_memory_heap_used_bytes / v8js_memory_heap_limit_bytes`                                                                                                                            |
 
 ## Alert rules (create in Alerting → Alert rules)
 
 Thresholds come from `docs/design/observability.md §7`. Route **page** alerts to
 `#alerts`/on-call; **notify** to the same channel without paging.
 
-| Alert                   | Expression                                                                                                                                       | Fires when                                                         | For | Tier      |
-| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------ | --- | --------- |
-| **API not reporting**   | `absent(http_server_duration_milliseconds_count)`                                                                                                | metric absent (no OTLP arriving — service down or exporter broken) | 5m  | 🔴 page   |
-| **High 5xx error rate** | `100 * sum(rate(http_server_duration_milliseconds_count{http_status_code=~"5.."}[5m])) / sum(rate(http_server_duration_milliseconds_count[5m]))` | `> 0.5`                                                            | 5m  | 🔴 page   |
-| **High latency (p95)**  | `histogram_quantile(0.95, sum by (le) (rate(http_server_duration_milliseconds_bucket[5m])))`                                                     | `> 300` (ms)                                                       | 10m | 🟠 notify |
-| **Event-loop lag**      | `nodejs_eventloop_delay_p99_seconds`                                                                                                             | `> 0.07` (70 ms)                                                   | 10m | 🟠 notify |
-| **Memory near limit**   | `100 * v8js_memory_heap_used_bytes / v8js_memory_heap_limit_bytes`                                                                               | `> 80`                                                             | 10m | 🟠 notify |
+| Alert                   | Expression                                                                                                                                                                                    | Fires when                                                         | For | Tier      |
+| ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ | --- | --------- |
+| **API not reporting**   | `absent(http_server_duration_milliseconds_count)`                                                                                                                                             | metric absent (no OTLP arriving — service down or exporter broken) | 5m  | 🔴 page   |
+| **High 5xx error rate** | `100 * (sum(rate(http_server_duration_milliseconds_count{http_status_code=~"5.."}[5m])) or vector(0)) / clamp_min(sum(rate(http_server_duration_milliseconds_count[5m])) or vector(0), 1e-6)` | `> 0.5`                                                            | 5m  | 🔴 page   |
+| **High latency (p95)**  | `histogram_quantile(0.95, sum by (le) (rate(http_server_duration_milliseconds_bucket[5m])))`                                                                                                  | `> 300` (ms)                                                       | 10m | 🟠 notify |
+| **Event-loop lag**      | `nodejs_eventloop_delay_p99_seconds`                                                                                                                                                          | `> 0.07` (70 ms)                                                   | 10m | 🟠 notify |
+| **Memory near limit**   | `100 * v8js_memory_heap_used_bytes / v8js_memory_heap_limit_bytes`                                                                                                                            | `> 80`                                                             | 10m | 🟠 notify |
 
 Notes:
 
 - **Absence, not `up`:** we **push** OTLP (no Prometheus scrape target), so there's
   no `up` metric — `absent(...)` is the down-detector.
+- **`absent()` detects total silence only.** Adequate while we run **one
+  instance** (current). With >1 replica, a single crash-looping instance won't
+  trip it (the healthy replicas keep reporting). Before scaling out: set
+  `OTEL_RESOURCE_ATTRIBUTES=service.instance.id=$RENDER_INSTANCE_ID` on the
+  service so metrics carry a per-instance label, then alert per instance (e.g.
+  `count by (service_instance_id) (rate(http_server_duration_milliseconds_count[5m]))`
+  dropping below the replica count).
+- **Division is NaN/No-Data-proof:** the error-rate query uses
+  `or vector(0)` + `clamp_min(..., 1e-6)`, so a zero-traffic window (3am) reads
+  **0%**, never `0/0 = NaN` or an empty result. Belt-and-braces: still set the
+  alert rule's **"No data" state to OK** (Alerting → rule → "Configure no data
+  and error handling") so a datasource hiccup can't page either — the
+  **API-not-reporting** rule is the one that owns "nothing is arriving".
 - Add an external **uptime monitor** on `/healthz` (UptimeRobot/Better Stack free)
   as a second, independent down-signal (design §6).
 - These are starting SLOs — calibrate the thresholds after a week of real traffic.

--- a/ops/grafana/dashboards/trotxi-api-overview.json
+++ b/ops/grafana/dashboards/trotxi-api-overview.json
@@ -59,7 +59,7 @@
         {
           "refId": "A",
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "100 * sum(rate(http_server_duration_milliseconds_count{http_status_code=~\"5..\"}[5m])) / sum(rate(http_server_duration_milliseconds_count[5m]))",
+          "expr": "100 * (sum(rate(http_server_duration_milliseconds_count{http_status_code=~\"5..\"}[5m])) or vector(0)) / clamp_min(sum(rate(http_server_duration_milliseconds_count[5m])) or vector(0), 1e-6)",
           "legendFormat": "5xx %"
         }
       ]


### PR DESCRIPTION
Addresses the two review points on the #92 dashboard/alerts:

1. **0/0 → NaN at low traffic:** error-rate query (dashboard panel + alert) now uses `or vector(0)` + `clamp_min(denominator, 1e-6)` — a zero-traffic window evaluates to **0%**, never NaN/No-Data. README additionally says to set the rule's **No-Data state to OK**, so a datasource hiccup can't page at 3am either; the **API-not-reporting** (`absent()`) rule is the single owner of "nothing is arriving".
2. **`absent()` and partial outages:** documented that it detects **total silence only** — correct for our current **single instance**, blind to one crash-looping replica among several. README now carries the scale-out prerequisite: set `service.instance.id` via `OTEL_RESOURCE_ATTRIBUTES` (Render's `$RENDER_INSTANCE_ID`) and alert on per-instance reporter count. External `/healthz` uptime probe remains the independent second signal.

Docs/JSON only.