### PR TITLE
docs: ADR-0014 — Hybrid Subscription Model (money hold lifted)

### DIFF
--- a/docs/adr/0011-token-ledger.md
+++ b/docs/adr/0011-token-ledger.md
@@ -69,3 +69,13 @@ Boarding requires **both** an active subscription and sufficient balance
   the boarding debit (#20) are blocked on that decision because it shapes the
   ledger and payout design. Full status:
   `docs/features/payments-and-wallet.md` → "Status & roadmap (ON HOLD)".
+
+## Update — 2026-07-04 (superseded in part by ADR-0014)
+
+The hold is lifted: product adopted the **Hybrid Subscription Model**
+([ADR-0014](0014-hybrid-subscription-model.md)). The **wallet/top-up semantics**
+of this ADR are superseded — subscriptions now carry a **ride entitlement**, and
+unused value becomes **Ride Credits** against the next renewal; there is no
+prepaid wallet. The **append-only ledger pattern this ADR established stands**
+and is reused twice (entitlement ledger in ride counts; credit ledger in
+pesewas). `token_ledger`/top-ups are legacy pending retirement (E7).

--- a/docs/adr/0014-hybrid-subscription-model.md
+++ b/docs/adr/0014-hybrid-subscription-model.md
@@ -1,0 +1,53 @@
+# ADR-0014 — Hybrid Subscription Model supersedes the wallet/top-up money model
+
+**Status:** accepted · **Date:** 2026-07-04 · **Supersedes the money semantics of** ADR-0011 (the ledger _pattern_ stands)
+
+## Context
+
+The money system was built as: subscription = platform membership fee (no rides
+included) + a separate prepaid GHS wallet funded by top-ups, with boarding
+debiting the route's fare in pesewas (#66, #68). Further money work was then put
+**on hold** pending the product team's commercial model.
+
+That decision has landed: the **Trotxi Hybrid Subscription Model** ("Mobility
+Membership" master doc, June 2026; engineering plan in
+`strategy/docs/hybrid-subscription-model.md`). Target market per the investor
+strategy: **corporate commuters** on scheduled, reserved-seat shuttles —
+asset-light, demand-aggregated.
+
+## Decision
+
+Adopt the Hybrid Subscription Model as the commercial/money model:
+
+- **Subscription = the product.** Monthly plans (standard/premium/corporate/
+  student) buy a **ride entitlement** (working days × 2 trips). No prepaid
+  wallet; "tokens" are retired as a user-facing concept.
+- **Deduct one ride only when it commits:** on successful boarding verification
+  (any of driver-manifest / daily 4-digit PIN / QR scan), or on a confirmed-yes
+  **no-show**. Operator failure never deducts (optional compensation credit).
+- **Daily ride confirmation** (push, evening + midday windows; no response =
+  travelling by default) drives seat reservation and the driver manifest.
+- **Ride Credits:** unused rides convert at month end to a GHS value (stored in
+  pesewas) that discounts the next renewal. Loyalty may also issue credits.
+- **Standby pool** (KYC'd non-subscribers) takes released seats and pays per
+  single journey instantly — the only pay-per-ride path.
+
+Two append-only ledgers replace the wallet: an **entitlement ledger** (ride
+counts) and a **credit ledger** (pesewas) — the same exactly-once,
+derived-balance pattern as ADR-0011.
+
+## Consequences
+
+- **Foundations stand:** boarding QR core (#93) becomes the verification layer
+  (plus PIN + manifest/photo); FCM device tokens (#84) power the confirmation
+  notifications; Paystack module extends (variable renewals, `standby_fare`);
+  pesewas storage and idempotency discipline are unchanged.
+- **To retire (E7):** `POST /payments/topup` and the wallet balance semantics of
+  `GET /me/balance` — after entitlements land. Staging-only data; no migration
+  of real funds needed.
+- **Build phases** E1–E7 and the data-model sketch live in
+  `strategy/docs/hybrid-subscription-model.md`; critical path is
+  trips/capacity (#18) → daily confirmation → boarding v2.
+- **Still open (product):** operator/fleet-partner revenue share %, tier
+  pricing, per-ride credit value, corporate billing, standby KYC scope — none
+  block E1–E4.

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -16,14 +16,14 @@ repo (`system-design.md`, `security.md`). Each doc links to both.
 
 ## Index
 
-| Feature                                                                       | Doc                                              | Status                                |
-| ----------------------------------------------------------------------------- | ------------------------------------------------ | ------------------------------------- |
-| Authentication — access tokens, route guard, sign-in/refresh/logout           | [authentication.md](authentication.md)           | ✅ live                               |
-| Wallet & payments — token ledger, balance, subscriptions & top-ups (Paystack) | [payments-and-wallet.md](payments-and-wallet.md) | ✅ live                               |
-| Mobility — routes, stops, browse                                              | _(in review — #57)_                              | 🚧                                    |
-| Rate limiting (#23)                                                           | [rate-limiting.md](rate-limiting.md)             | ✅ live                               |
-| Boarding — QR passes + scan verification (#20)                                | [boarding.md](boarding.md)                       | 🟡 integrity slice                    |
-| Observability & performance (#28)                                             | [design](../design/observability.md)             | ✅ backend live (metrics/traces/logs) |
+| Feature                                                                         | Doc                                              | Status                                 |
+| ------------------------------------------------------------------------------- | ------------------------------------------------ | -------------------------------------- |
+| Authentication — access tokens, route guard, sign-in/refresh/logout             | [authentication.md](authentication.md)           | ✅ live                                |
+| Wallet & payments — Paystack + ledgers; wallet semantics superseded by ADR-0014 | [payments-and-wallet.md](payments-and-wallet.md) | 🔄 model pivoted (Hybrid Subscription) |
+| Mobility — routes, stops, browse                                                | _(in review — #57)_                              | 🚧                                     |
+| Rate limiting (#23)                                                             | [rate-limiting.md](rate-limiting.md)             | ✅ live                                |
+| Boarding — QR passes + scan verification (#20)                                  | [boarding.md](boarding.md)                       | 🟡 integrity slice                     |
+| Observability & performance (#28)                                               | [design](../design/observability.md)             | ✅ backend live (metrics/traces/logs)  |
 
 ## Conventions for a feature doc
 

--- a/docs/features/boarding.md
+++ b/docs/features/boarding.md
@@ -72,13 +72,21 @@ no FK yet (trips are #18).
   `jwtVerify`; the scan route throttles **before** the role check so non-driver
   tokens can't hammer unthrottled 403s.
 
-## Deferred (with the money work / product)
+## Next (Hybrid Subscription Model — ADR-0014, boarding v2 / epic E4)
 
-- **Eligibility gates** — a valid scan should also require an **active
-  subscription** and (later) **debit a token** for the fare. Couples to the
-  commission model (on hold), so not built here.
-- **Photo-pass fallback** — driver-confirmed boarding when QR fails; needs image
-  upload (Cloudflare R2, #24) + product UX for how the driver identifies the rider.
+The commercial model is decided
+([ADR-0014](../adr/0014-hybrid-subscription-model.md)): this QR core becomes
+**one of three verification layers**, and boarding consumes **1 ride from the
+subscription entitlement** (not a fare debit from a wallet). Coming in E4:
+
+- **Driver manifest layer** — name + **photo** (server-side, R2 #24) + pickup
+  point for the day's reservations. The photo pass is now required product.
+- **Daily 4-digit PIN layer** — offline-friendly fallback; any layer completes
+  verification.
+- **Ride deduction on verify** (idempotency key = reservation id) + the
+  confirmed-yes **no-show** deduction job; operator cancellation never deducts.
+- Eligibility: active subscription + a **confirmed reservation** for the trip
+  (from the daily-confirmation flow), replacing the old wallet-balance gate.
 
 ## Where the code lives
 

--- a/docs/features/payments-and-wallet.md
+++ b/docs/features/payments-and-wallet.md
@@ -1,16 +1,21 @@
 # Wallet & Payments (the money system)
 
-**Owner:** Godfred Awuku · **Last updated:** 2026-06-28
+**Owner:** Godfred Awuku · **Last updated:** 2026-07-04
 
-**Status:** ⏸️ **ON HOLD** (as of 2026-06-28). The rider-side money system below
-is built and working; **further money work is paused** until the product team
-defines the **commission model** (how Trotxi charges its cut). See
-[Status & roadmap](#status--roadmap-on-hold).
+**Status:** 🔄 **MODEL PIVOTED** (2026-07-04). The hold is lifted — product
+adopted the **Hybrid Subscription Model**
+([ADR-0014](../adr/0014-hybrid-subscription-model.md); engineering plan in
+`strategy/docs/hybrid-subscription-model.md`): subscriptions carry a **ride
+entitlement**, unused rides become **Ride Credits** against the next renewal,
+and there is **no prepaid wallet**. The wallet/top-up flows documented below are
+**live on staging but LEGACY** — kept accurate for what's deployed, retired once
+the entitlement flow lands (epic E7).
 
-> ⏸️ **Paused.** Do not start new money features (boarding debit, driver payouts,
-> fee splits) until the commission model is decided — it changes the ledger and
-> payout design. The current build is a safe stopping point: rider-side only,
-> with no real funds processed.
+> 🔄 **Build to the new model, not this doc's wallet semantics.** Still valid
+> and carried forward: the Paystack integration (checkout + signed webhook),
+> pesewas storage, the append-only-ledger pattern, and all the idempotency/
+> security controls below. Superseded: `POST /payments/topup` and the wallet
+> meaning of `GET /me/balance`.
 
 The money system has two **separate** flows — keep them straight:
 


### PR DESCRIPTION
The product team decided the commercial model — the **Hybrid Subscription Model** ("Mobility Membership" master doc, June 2026). This PR records it and re-points our docs; the full engineering plan (domain model, flows, epics E1–E7) lives in `strategy/docs/hybrid-subscription-model.md`.

## What it decides
- **Subscription = ride entitlement** (plans × working days × 2 trips). No prepaid wallet; "tokens" retired as a user concept.
- **Deduct 1 ride only when it commits** — verified boarding (manifest / daily PIN / QR) or a confirmed-yes no-show; operator failure never deducts.
- **Ride Credits**: unused rides → GHS value (pesewas) discounting the next renewal.
- **Standby pool** pays per single journey — the only pay-per-ride path.

## Changes here
- **ADR-0014** (the decision) + **ADR-0011** superseded-in-part note (ledger *pattern* stands, wallet *semantics* don't).
- `payments-and-wallet.md`: **ON HOLD → MODEL PIVOTED** — the documented endpoints stay accurate for what's deployed, marked **legacy** pending E7 retirement.
- `boarding.md`: "deferred with money" → **boarding v2 (E4)** next steps: manifest + photo (needs #24), daily PIN, ride deduction, reservation-based eligibility.
- Features index updated.

## What stays open (product, non-blocking for E1–E4)
Operator revenue share %, tier pricing, per-ride credit value, corporate billing, standby KYC scope.

Docs only — no code. Next: epic/issue breakdown for E1–E7.