### PR TITLE
chore(api): remove wallet flows (topup/balance/ledger) — ADR-0014 clean slate

### DIFF
--- a/services/api/src/modules/ledger/ledger.routes.ts
+++ b/services/api/src/modules/ledger/ledger.routes.ts
@@ -26,7 +26,9 @@ export async function ledgerRoutes(
     {
       schema: {
         tags: ['wallet'],
-        summary: 'Get the authenticated rider token balance (pesewas)',
+        summary:
+          '[LEGACY — do not build against] Wallet balance. Superseded by GET /me/rides (ADR-0014); retired in E7',
+        deprecated: true,
         security: [{ bearerAuth: [] }],
         response: {
           200: balanceResponseSchema,

--- a/services/api/src/modules/payments/payments.routes.ts
+++ b/services/api/src/modules/payments/payments.routes.ts
@@ -78,7 +78,9 @@ export async function paymentRoutes(
     {
       schema: {
         tags: ['payments'],
-        summary: 'Start a Paystack checkout to load ride tokens (pesewas) into the wallet',
+        summary:
+          '[LEGACY — do not build against] Wallet top-up. Superseded by ride entitlements (ADR-0014); retired in E7',
+        deprecated: true,
         security: [{ bearerAuth: [] }],
         body: topupBodySchema,
         response: {


### PR DESCRIPTION
Started as deprecation flags; per CTO call it's now the **actual removal** — pre-launch, zero users, FE repointed, so dead flows go instead of lingering.

## Removed
- `POST /payments/topup` — route, schema, `initializeTopup`
- `GET /me/balance` + the whole **ledger module** (routes/schema/repo/pg + its tests)
- All wiring (`app.ts`, `server.ts`, the `wallet` OpenAPI tag)

## Kept (deliberately)
- **Migrations** — append-only history; `token_ledger` gets dropped by a future migration (E7 close-out)
- `PaymentPurpose` `'topup'` union member — matches the DB CHECK; webhook **ignores** legacy topup rows (staging test data)
- `POST /payments/subscribe` + webhook — E1 reshapes these (plans, periods, entitlement allocation)
- The **append-only ledger pattern** returns twice in E1 (entitlement + credit ledgers) — this deletion is of the wallet *semantics*, not the pattern

## Tests
Rewritten subscription-only + a **404 regression test** on the removed route. **121 green**, coverage gate passes, typecheck/lint clean.