### PR TITLE
feat(api): user profile + avatar upload to Cloudflare R2 (#24)

### DIFF
--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -19,6 +19,7 @@ repo (`system-design.md`, `security.md`). Each doc links to both.
 | Feature                                                                   | Doc                                              | Status                                 |
 | ------------------------------------------------------------------------- | ------------------------------------------------ | -------------------------------------- |
 | Authentication — access tokens, route guard, sign-in/refresh/logout       | [authentication.md](authentication.md)           | ✅ live                                |
+| Profile & avatars — `PATCH /me`, avatar upload → R2 (photo pass) (#24)    | [profile-avatars.md](profile-avatars.md)         | ✅ live                                |
 | Payments — Paystack subscribe + webhook (wallet/ledger removed, ADR-0014) | [payments-and-wallet.md](payments-and-wallet.md) | 🔄 model pivoted (Hybrid Subscription) |
 | Mobility — routes, stops, browse                                          | _(in review — #57)_                              | 🚧                                     |
 | Rate limiting (#23)                                                       | [rate-limiting.md](rate-limiting.md)             | ✅ live                                |

--- a/docs/features/profile-avatars.md
+++ b/docs/features/profile-avatars.md
@@ -1,0 +1,99 @@
+# User profile & avatars
+
+**Owner:** Godfred Awuku · **Last updated:** 2026-07-05 · **Issue:** #24
+
+Profile edits and the avatar upload that feeds the **photo pass** (the driver
+sees the rider's name + photo at boarding — E4 manifest, `security.md §7`).
+Avatars live in **Cloudflare R2** (S3-compatible, zero egress); the bucket is
+**private** and images are served only through **short-lived signed URLs**.
+
+---
+
+## Concepts
+
+- **Server-side processing is mandatory.** Every upload is **resized to 256×256
+  and re-encoded to JPEG** on the server (`sharp`). The re-encode **strips EXIF**
+  — phone photos embed GPS/PII in metadata, which must never reach storage. A
+  client cannot bypass this by pre-sizing: we always re-encode.
+- **Key, not URL, in the DB.** `users.avatar_url` stores the R2 **object key**
+  (`avatars/<userId>`), never a public URL. Responses swap it for a **signed GET
+  URL** (default TTL 300s) at serialization time.
+- **Proxy upload, not presigned PUT.** The image flows through the API so the
+  server controls resize/validation; R2 ingress is free and avatars are tiny.
+- **Selected by env.** All four `R2_*` vars set → real R2; any unset → an
+  in-memory Fake (zero-infra dev/tests). Same pattern as Redis/Paystack.
+
+---
+
+## API
+
+#### `GET /me` _(in auth.routes)_
+
+Returns the user; `avatarUrl` is a **signed URL** when an avatar is set, else null.
+
+#### `PATCH /me`
+
+Update editable profile fields.
+
+- **Auth:** `Bearer`. **Rate limit:** per user.
+- **Body:** `{ "displayName": "Ama Mensah" }` (1–80 chars, trimmed)
+- **200:** the updated user · **400** invalid · **401** · **404** · **503**
+
+#### `POST /me/avatar`
+
+Upload an avatar (**multipart/form-data**, field `file`).
+
+- **Auth:** `Bearer`. **Rate limit:** per user.
+- **Accepts:** JPEG/PNG/WebP, ≤ 5 MB — resized to 256px JPEG, EXIF stripped.
+- **200:** `{ "avatarUrl": "<signed URL>" }`
+- **400** not an image / unsupported type · **401** · **404** · **413** too large · **503**
+
+#### `GET /me/avatar`
+
+- **200:** `{ "avatarUrl": "<signed URL>" }` · **404** no avatar set · **401** · **503**
+
+---
+
+## Data
+
+`users.avatar_url` (existing column) holds the R2 object key `avatars/<userId>`.
+No migration needed.
+
+## Configuration
+
+| Env var                | Notes                                                                    |
+| ---------------------- | ------------------------------------------------------------------------ |
+| `R2_ACCOUNT_ID`        | Cloudflare account id → endpoint `https://<id>.r2.cloudflarestorage.com` |
+| `R2_ACCESS_KEY_ID`     | R2 **S3 API** token — Access Key ID (secret; dashboard only)             |
+| `R2_SECRET_ACCESS_KEY` | R2 **S3 API** token — Secret Access Key (secret; dashboard only)         |
+| `R2_BUCKET`            | bucket name, e.g. `trotxi-avatars` (keep it **private**)                 |
+
+All four unset (or partial) → in-memory Fake object store. Cloudflare's native
+**API "Token value" is not used** — we authenticate via the S3 keys.
+
+## Security notes
+
+- **EXIF/PII stripped** on every upload (re-encode) — no location leaks.
+- **Private bucket + short-lived signed URLs** — no public avatar URLs; a leaked
+  link expires in ~5 min.
+- **Raw object key never exposed** — responses always sign it.
+- **Server-authoritative size/type** — client-declared MIME is checked _and_ the
+  bytes must decode as an image, or it's a 400.
+
+## Where the code lives
+
+```
+services/api/src/storage/
+  object-store.ts        # ObjectStore interface + FakeObjectStore + avatarKey
+  object-store.r2.ts     # Cloudflare R2 impl (S3 SDK; excluded from unit coverage)
+services/api/src/modules/users/
+  avatar.ts              # sharp resize + EXIF-strip (processAvatar)
+  users.routes.ts        # PATCH /me, POST /me/avatar, GET /me/avatar
+  user.presenter.ts      # toUserResponse — signs the avatar key
+  user.repository.ts(.pg)# updateProfile + setAvatarKey
+```
+
+## Related
+
+- `strategy/system-design.md §4.3` (photo pass) · `security.md §7` (object storage, PII)
+- Feeds **E4** (boarding manifest) — ADR-0014

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,15 @@ importers:
 
   services/api:
     dependencies:
+      '@aws-sdk/client-s3':
+        specifier: ^3.1079.0
+        version: 3.1079.0
+      '@aws-sdk/s3-request-presigner':
+        specifier: ^3.1079.0
+        version: 3.1079.0
+      '@fastify/multipart':
+        specifier: ^10.0.0
+        version: 10.0.0
       '@fastify/swagger':
         specifier: ^9.7.0
         version: 9.7.0
@@ -113,6 +122,9 @@ importers:
       prom-client:
         specifier: ^15.1.3
         version: 15.1.3
+      sharp:
+        specifier: ^0.35.3
+        version: 0.35.3(@types/node@26.0.1)
       zod:
         specifier: ^3.24.1
         version: 3.25.76
@@ -157,6 +169,82 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
+  '@aws-sdk/checksums@3.1000.12':
+    resolution: {integrity: sha512-RgNDWfhNRIlNEzePIRrYTNi/6q+wwRMMapojn8YVzw4ZcJRa/gxVMtUbeZARR1gmopuv6oIhMbY7J66qIQ0ynw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-s3@3.1079.0':
+    resolution: {integrity: sha512-di9U/7Po7qlVYb2dq58ULsbBAE1pBIk53rux+50LQCvH1X+/l1Ys+BIk/QLBtdaK1nADk0xRNEBbA1QWVnMccw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.974.27':
+    resolution: {integrity: sha512-WRWEgIq6vx+NU6ot3VrRu4Jovj9MIObitSi6of/GV5THDDPccBhivCRNkWJutMM+m3GvdeI3l/UbGNcoOobxOA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.53':
+    resolution: {integrity: sha512-+KDA3uc/HZ1vIneGu5QMQb0gAXDYrm2vOE60+BJ7lS0YinMQ5i2oV4PR1A16XkF6K1IbSwjEHd1hQIIgMsK48w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.55':
+    resolution: {integrity: sha512-1gBfkWY3RWeBlCoB9lIJjXMx45/54wxcgfzv6BY9otTmMrZPcNPi1v+MwZxxaCUg441NV3jsr1efnFNCXiW70g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.972.60':
+    resolution: {integrity: sha512-CV2md+PXvABwRjApWGhQ0wACy9WSFIhnUGrovLcjnjBCd/46TbuivLADtkF8IWNjtCQmQ+2IagSaxqBYqXBNAQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.59':
+    resolution: {integrity: sha512-JG4S9yyA1GFzJdJXqLKrUzZbyK+VDp2QIsJD7YOicJHAhqymfHpDJIok2dLnhOdVB0I37RjdC53uOwCMVS00gw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.62':
+    resolution: {integrity: sha512-S6Slq3Tx7bvFk5yc34XNADyZYTX2HUXvaFAnowGRQnhjBO8J/mP62Fn7lxvJwjaDyYm/7gh9h6HEHaltRyMFXw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.53':
+    resolution: {integrity: sha512-EhfH+MQlqOMCkXIVa8MMObPzAQqwTTtxA7KhEJiyPeuNVA8PLOOUpgK7nBrgaDaGiIDLN/9LpGdaHuDjomeRTw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.972.59':
+    resolution: {integrity: sha512-h8793pOjcImx0SB+VcLONcaQQ57VAvKVuqyewQMRKqqH+CSXsG2dwOeLMUJPMxLdNvL7dXOM0ueTukyNUnu5mA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.59':
+    resolution: {integrity: sha512-VoyO9+vl3XVmpZwn4obskrWIkrA/Jf3lSe1E3ZERlaN9u0D4YZ6+HywC3+L98QOXqZesEfedk67gRER8tK8+8w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-sdk-s3@3.972.58':
+    resolution: {integrity: sha512-6uaWRRYJGhOqc9EoTSbLDf9nI/doSAb5vAwGshs5/Hlv5Ce25b246lBkbRd/77fLAi+uMI1a70mJzVyLyCEufQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.27':
+    resolution: {integrity: sha512-A8PIePF9NIIOJ/4Lg1rl9xm/+QaKkHGetq+Z9wb5B+3Da31YYXRo8n7IDMh5C+HQI5eyEmjrwkGWVdYtnLtbXQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/s3-request-presigner@3.1079.0':
+    resolution: {integrity: sha512-NfHUaND7WyLUPkO7HCF3MFg4bdscY34A4tm4dPWa31qYzhGNZarRPr/CcRgllxzPoOSD/EHfZ4fQtZnMl2xWFg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.38':
+    resolution: {integrity: sha512-C379Sk+MiFZCfWZphKlMyLHKxV22OjoGM5KJjj5IJNJcOCWL4IGIpnEGzv1FQiRwhYXfq55SJMfxlqPE08JJ9g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1079.0':
+    resolution: {integrity: sha512-cbietrLlHPhhmbnMPTuDS4Zj/KNGhY+3vVhn6dwjO6Dqzrwothzg2srtcY34T9mlICsTXn34avDoWLHSntP54A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.973.15':
+    resolution: {integrity: sha512-IULn8uBV/SMtmOIANsm4WHXIOtVPBWfOWs3WGL0j/sI+KhaYehvOw0ET+9urnn8MBpiijuU/0JOpuwKOE451PQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.33':
+    resolution: {integrity: sha512-ezbwz9WpuLctm6o7P2t2naDhVVPI5jFGrVefVybhcKGjU57VIyT46pQVO0RI2RYkUdhdj2Z9uSIlAzGZE9NW9A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.3.0':
+    resolution: {integrity: sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==}
+    engines: {node: '>=18.0.0'}
+
   '@babel/helper-string-parser@7.29.7':
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
     engines: {node: '>=6.9.0'}
@@ -179,6 +267,9 @@ packages:
 
   '@borewit/text-codec@0.2.2':
     resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
+
+  '@emnapi/runtime@1.11.2':
+    resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
 
   '@es-joy/jsdoccomment@0.87.0':
     resolution: {integrity: sha512-mFXZloZMzuJZXSHUmAFu/pXTk0ZJTJBluuAkrvbzidpTN8W6F2bpRFuedSH+85kbdlRLJqc+gfN+kD3JOLJK5g==}
@@ -682,6 +773,12 @@ packages:
   '@fastify/ajv-compiler@4.0.5':
     resolution: {integrity: sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==}
 
+  '@fastify/busboy@3.2.0':
+    resolution: {integrity: sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==}
+
+  '@fastify/deepmerge@3.2.1':
+    resolution: {integrity: sha512-N5Oqvltoa2r9z1tbx4xjky0oRR60v+T47Ic4J1ukoVQcptLOrIdRnCSdTGmOmajZuHVKlTnfcmrjyqsGEW1ztA==}
+
   '@fastify/error@4.2.0':
     resolution: {integrity: sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ==}
 
@@ -693,6 +790,9 @@ packages:
 
   '@fastify/merge-json-schemas@0.2.1':
     resolution: {integrity: sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A==}
+
+  '@fastify/multipart@10.0.0':
+    resolution: {integrity: sha512-pUx3Z1QStY7E7kwvDTIvB6P+rF5lzP+iqPgZyJyG3yBJVPvQaZxzDHYbQD89rbY0ciXrMOyGi8ezHDVexLvJDA==}
 
   '@fastify/proxy-addr@5.1.0':
     resolution: {integrity: sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==}
@@ -737,6 +837,168 @@ packages:
   '@humanwhocodes/retry@0.4.3':
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
+
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.35.3':
+    resolution: {integrity: sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.35.3':
+    resolution: {integrity: sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-freebsd-wasm32@0.35.3':
+    resolution: {integrity: sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==}
+    engines: {node: '>=20.9.0'}
+    os: [freebsd]
+
+  '@img/sharp-libvips-darwin-arm64@1.3.2':
+    resolution: {integrity: sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.3.2':
+    resolution: {integrity: sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.3.2':
+    resolution: {integrity: sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-arm@1.3.2':
+    resolution: {integrity: sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-ppc64@1.3.2':
+    resolution: {integrity: sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-riscv64@1.3.2':
+    resolution: {integrity: sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-s390x@1.3.2':
+    resolution: {integrity: sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-x64@1.3.2':
+    resolution: {integrity: sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.2':
+    resolution: {integrity: sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.3.2':
+    resolution: {integrity: sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linux-arm64@0.35.3':
+    resolution: {integrity: sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-arm@0.35.3':
+    resolution: {integrity: sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-ppc64@0.35.3':
+    resolution: {integrity: sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-riscv64@0.35.3':
+    resolution: {integrity: sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==}
+    engines: {node: '>=20.9.0'}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-s390x@0.35.3':
+    resolution: {integrity: sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==}
+    engines: {node: '>=20.9.0'}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-x64@0.35.3':
+    resolution: {integrity: sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linuxmusl-arm64@0.35.3':
+    resolution: {integrity: sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linuxmusl-x64@0.35.3':
+    resolution: {integrity: sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-wasm32@0.35.3':
+    resolution: {integrity: sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==}
+    engines: {node: '>=20.9.0'}
+
+  '@img/sharp-webcontainers-wasm32@0.35.3':
+    resolution: {integrity: sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==}
+    engines: {node: '>=20.9.0'}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.35.3':
+    resolution: {integrity: sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.35.3':
+    resolution: {integrity: sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==}
+    engines: {node: ^20.9.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.35.3':
+    resolution: {integrity: sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [win32]
 
   '@inquirer/core@6.0.0':
     resolution: {integrity: sha512-fKi63Khkisgda3ohnskNf5uZJj+zXOaBvOllHsOkdsXRA/ubQLJQrZchFFi57NKbZzkTunXiBMdvWOv71alonw==}
@@ -1239,6 +1501,30 @@ packages:
     resolution: {integrity: sha512-TeheYy0ILzBEI/CO55CP6zJCSdSWeRtGnHy8U8dWSUH4I68iqTsy7HkMktR4xakThc9jotkPQUXT4ITdbV7cHA==}
     engines: {node: '>=18'}
 
+  '@smithy/core@3.29.1':
+    resolution: {integrity: sha512-qoiY4nrk5OCu1+eIR1VB8l5DmON/oKiqrd5zZFAhXJXjJlLWQusKEW/SkBDAtGDcPaz86m9kfcE1lngU0GlM6A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.4.6':
+    resolution: {integrity: sha512-B2WQ/PV/H6Jeg3lrIq6bKUfa6Hy01mtK7CGs6lhjzHA6k4aagldH6T6eEjnzKl4HI0cJnAsxfJ19pgb5PV+CVQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.6.3':
+    resolution: {integrity: sha512-CwCc/7SMTj45y97MUnDTbTaxvtAsiNNRm81z3abROIuMbMsC2Iy5EKfkkVdsKrz8WExQAAMx1EJapq+9j4fFTQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.9.3':
+    resolution: {integrity: sha512-qZTa4gQFUo8RM02rk6q5UVTDLNrQ1oS20LsepBzqq1QBVc/EHJ03OOUADcqMZiXHArW+Y7+OGY0BpdTwZRq/Yg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.6.2':
+    resolution: {integrity: sha512-QgHflghMoPxCJ9axiCVh8KZfbC9fuP6vkXXyK//E3cq7nLaSSyyLj0GAoqVWezYeDQmXIZhmlRvLE16jsqDK6g==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.15.1':
+    resolution: {integrity: sha512-x3L0XSACF6UYzKpa9biqiRMgvH5+wnFFew9Tm/grFYqgaupPwx/+ojDPpPJM8dZON3S9tjz5U+PQYsCBd1Mw5Q==}
+    engines: {node: '>=18.0.0'}
+
   '@tokenizer/inflate@0.4.1':
     resolution: {integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==}
     engines: {node: '>=18'}
@@ -1479,6 +1765,9 @@ packages:
   bintrees@1.0.2:
     resolution: {integrity: sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==}
 
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
+
   brace-expansion@1.1.15:
     resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
 
@@ -1670,6 +1959,10 @@ packages:
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -2644,6 +2937,15 @@ packages:
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
+  sharp@0.35.3:
+    resolution: {integrity: sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==}
+    engines: {node: '>=20.9.0'}
+    peerDependencies:
+      '@types/node': '*'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -3076,6 +3378,180 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
+  '@aws-sdk/checksums@3.1000.12':
+    dependencies:
+      '@aws-sdk/core': 3.974.27
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/client-s3@3.1079.0':
+    dependencies:
+      '@aws-sdk/checksums': 3.1000.12
+      '@aws-sdk/core': 3.974.27
+      '@aws-sdk/credential-provider-node': 3.972.62
+      '@aws-sdk/middleware-sdk-s3': 3.972.58
+      '@aws-sdk/signature-v4-multi-region': 3.996.38
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/fetch-http-handler': 5.6.3
+      '@smithy/node-http-handler': 4.9.3
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/core@3.974.27':
+    dependencies:
+      '@aws-sdk/types': 3.973.15
+      '@aws-sdk/xml-builder': 3.972.33
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.29.1
+      '@smithy/signature-v4': 5.6.2
+      '@smithy/types': 4.15.1
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.53':
+    dependencies:
+      '@aws-sdk/core': 3.974.27
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.55':
+    dependencies:
+      '@aws-sdk/core': 3.974.27
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/fetch-http-handler': 5.6.3
+      '@smithy/node-http-handler': 4.9.3
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.972.60':
+    dependencies:
+      '@aws-sdk/core': 3.974.27
+      '@aws-sdk/credential-provider-env': 3.972.53
+      '@aws-sdk/credential-provider-http': 3.972.55
+      '@aws-sdk/credential-provider-login': 3.972.59
+      '@aws-sdk/credential-provider-process': 3.972.53
+      '@aws-sdk/credential-provider-sso': 3.972.59
+      '@aws-sdk/credential-provider-web-identity': 3.972.59
+      '@aws-sdk/nested-clients': 3.997.27
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/credential-provider-imds': 4.4.6
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.59':
+    dependencies:
+      '@aws-sdk/core': 3.974.27
+      '@aws-sdk/nested-clients': 3.997.27
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-node@3.972.62':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.53
+      '@aws-sdk/credential-provider-http': 3.972.55
+      '@aws-sdk/credential-provider-ini': 3.972.60
+      '@aws-sdk/credential-provider-process': 3.972.53
+      '@aws-sdk/credential-provider-sso': 3.972.59
+      '@aws-sdk/credential-provider-web-identity': 3.972.59
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/credential-provider-imds': 4.4.6
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.53':
+    dependencies:
+      '@aws-sdk/core': 3.974.27
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.972.59':
+    dependencies:
+      '@aws-sdk/core': 3.974.27
+      '@aws-sdk/nested-clients': 3.997.27
+      '@aws-sdk/token-providers': 3.1079.0
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.59':
+    dependencies:
+      '@aws-sdk/core': 3.974.27
+      '@aws-sdk/nested-clients': 3.997.27
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-sdk-s3@3.972.58':
+    dependencies:
+      '@aws-sdk/core': 3.974.27
+      '@aws-sdk/signature-v4-multi-region': 3.996.38
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.27':
+    dependencies:
+      '@aws-sdk/core': 3.974.27
+      '@aws-sdk/signature-v4-multi-region': 3.996.38
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/fetch-http-handler': 5.6.3
+      '@smithy/node-http-handler': 4.9.3
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/s3-request-presigner@3.1079.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.27
+      '@aws-sdk/signature-v4-multi-region': 3.996.38
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.38':
+    dependencies:
+      '@aws-sdk/types': 3.973.15
+      '@smithy/signature-v4': 5.6.2
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1079.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.27
+      '@aws-sdk/nested-clients': 3.997.27
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.973.15':
+    dependencies:
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.33':
+    dependencies:
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.3.0': {}
+
   '@babel/helper-string-parser@7.29.7': {}
 
   '@babel/helper-validator-identifier@7.29.7': {}
@@ -3092,6 +3568,11 @@ snapshots:
   '@bcoe/v8-coverage@0.2.3': {}
 
   '@borewit/text-codec@0.2.2': {}
+
+  '@emnapi/runtime@1.11.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@es-joy/jsdoccomment@0.87.0':
     dependencies:
@@ -3382,6 +3863,10 @@ snapshots:
       ajv-formats: 3.0.1(ajv@8.20.0)
       fast-uri: 3.1.2
 
+  '@fastify/busboy@3.2.0': {}
+
+  '@fastify/deepmerge@3.2.1': {}
+
   '@fastify/error@4.2.0': {}
 
   '@fastify/fast-json-stringify-compiler@5.0.3':
@@ -3393,6 +3878,14 @@ snapshots:
   '@fastify/merge-json-schemas@0.2.1':
     dependencies:
       dequal: 2.0.3
+
+  '@fastify/multipart@10.0.0':
+    dependencies:
+      '@fastify/busboy': 3.2.0
+      '@fastify/deepmerge': 3.2.1
+      '@fastify/error': 4.2.0
+      fastify-plugin: 5.1.0
+      secure-json-parse: 4.1.0
 
   '@fastify/proxy-addr@5.1.0':
     dependencies:
@@ -3461,6 +3954,112 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/retry@0.4.3': {}
+
+  '@img/colour@1.1.0': {}
+
+  '@img/sharp-darwin-arm64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.3.2
+    optional: true
+
+  '@img/sharp-darwin-x64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.3.2
+    optional: true
+
+  '@img/sharp-freebsd-wasm32@0.35.3':
+    dependencies:
+      '@img/sharp-wasm32': 0.35.3
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.3.2':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.3.2
+    optional: true
+
+  '@img/sharp-linux-arm@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.3.2
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.3.2
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.3.2
+    optional: true
+
+  '@img/sharp-linux-s390x@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.3.2
+    optional: true
+
+  '@img/sharp-linux-x64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.3.2
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.2
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.2
+    optional: true
+
+  '@img/sharp-wasm32@0.35.3':
+    dependencies:
+      '@emnapi/runtime': 1.11.2
+    optional: true
+
+  '@img/sharp-webcontainers-wasm32@0.35.3':
+    dependencies:
+      '@img/sharp-wasm32': 0.35.3
+    optional: true
+
+  '@img/sharp-win32-arm64@0.35.3':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.35.3':
+    optional: true
+
+  '@img/sharp-win32-x64@0.35.3':
+    optional: true
 
   '@inquirer/core@6.0.0':
     dependencies:
@@ -4013,6 +4612,39 @@ snapshots:
 
   '@sindresorhus/base62@1.0.0': {}
 
+  '@smithy/core@3.29.1':
+    dependencies:
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.4.6':
+    dependencies:
+      '@smithy/core': 3.29.1
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.6.3':
+    dependencies:
+      '@smithy/core': 3.29.1
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.9.3':
+    dependencies:
+      '@smithy/core': 3.29.1
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.6.2':
+    dependencies:
+      '@smithy/core': 3.29.1
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@smithy/types@4.15.1':
+    dependencies:
+      tslib: 2.8.1
+
   '@tokenizer/inflate@0.4.1':
     dependencies:
       debug: 4.4.3
@@ -4300,6 +4932,8 @@ snapshots:
 
   bintrees@1.0.2: {}
 
+  bowser@2.14.1: {}
+
   brace-expansion@1.1.15:
     dependencies:
       balanced-match: 1.0.2
@@ -4460,6 +5094,8 @@ snapshots:
   depd@2.0.0: {}
 
   dequal@2.0.3: {}
+
+  detect-libc@2.1.2: {}
 
   dunder-proto@1.0.1:
     dependencies:
@@ -5542,6 +6178,39 @@ snapshots:
   set-cookie-parser@2.7.2: {}
 
   setprototypeof@1.2.0: {}
+
+  sharp@0.35.3(@types/node@26.0.1):
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.8.5
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.35.3
+      '@img/sharp-darwin-x64': 0.35.3
+      '@img/sharp-freebsd-wasm32': 0.35.3
+      '@img/sharp-libvips-darwin-arm64': 1.3.2
+      '@img/sharp-libvips-darwin-x64': 1.3.2
+      '@img/sharp-libvips-linux-arm': 1.3.2
+      '@img/sharp-libvips-linux-arm64': 1.3.2
+      '@img/sharp-libvips-linux-ppc64': 1.3.2
+      '@img/sharp-libvips-linux-riscv64': 1.3.2
+      '@img/sharp-libvips-linux-s390x': 1.3.2
+      '@img/sharp-libvips-linux-x64': 1.3.2
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.2
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.2
+      '@img/sharp-linux-arm': 0.35.3
+      '@img/sharp-linux-arm64': 0.35.3
+      '@img/sharp-linux-ppc64': 0.35.3
+      '@img/sharp-linux-riscv64': 0.35.3
+      '@img/sharp-linux-s390x': 0.35.3
+      '@img/sharp-linux-x64': 0.35.3
+      '@img/sharp-linuxmusl-arm64': 0.35.3
+      '@img/sharp-linuxmusl-x64': 0.35.3
+      '@img/sharp-webcontainers-wasm32': 0.35.3
+      '@img/sharp-win32-arm64': 0.35.3
+      '@img/sharp-win32-ia32': 0.35.3
+      '@img/sharp-win32-x64': 0.35.3
+      '@types/node': 26.0.1
 
   shebang-command@2.0.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,3 +10,6 @@ allowBuilds:
   # protobufjs (via the OTLP protobuf exporter) works at runtime from its
   # prebuilt dist; its postinstall build script is not needed.
   protobufjs: false
+  # sharp (avatar resize/EXIF-strip, #24) needs its postinstall to install the
+  # platform's prebuilt libvips binary.
+  sharp: true

--- a/render.yaml
+++ b/render.yaml
@@ -55,6 +55,17 @@ services:
         sync: false
       - key: OTEL_SERVICE_NAME
         value: trotxi-api
+      # Cloudflare R2 (avatars, #24) — S3-compatible object storage. The access
+      # keys are secrets → set in the dashboard, never commit. All four unset ->
+      # in-memory object store (no avatars persisted).
+      - key: R2_ACCOUNT_ID
+        sync: false
+      - key: R2_ACCESS_KEY_ID
+        sync: false
+      - key: R2_SECRET_ACCESS_KEY
+        sync: false
+      - key: R2_BUCKET
+        sync: false
 
   # ---- Production (uncomment when going live) ----
   # Needs a paid Postgres plan so data doesn't expire. After applying, set the

--- a/services/api/.env.example
+++ b/services/api/.env.example
@@ -29,6 +29,14 @@ NODE_ENV=development
 # dashboard, never commit. Unset -> dev fake client (non-prod) / 503 (prod).
 # PAYSTACK_SECRET_KEY=sk_test_xxxxxxxx
 
+# Cloudflare R2 (avatars, #24) — S3-compatible object storage. Set ALL FOUR to
+# use R2; leave any unset -> in-memory object store (zero infra, not persisted).
+# The access keys are secrets: set in the dashboard, never commit.
+# R2_ACCOUNT_ID=xxxxxxxx
+# R2_ACCESS_KEY_ID=xxxxxxxx
+# R2_SECRET_ACCESS_KEY=xxxxxxxx
+# R2_BUCKET=trotxi-avatars
+
 # Rate limiting (fixed window) — defaults shown.
 # RATE_LIMIT_MAX=100
 # RATE_LIMIT_WINDOW_SECONDS=60

--- a/services/api/eslint.config.js
+++ b/services/api/eslint.config.js
@@ -26,6 +26,7 @@ export default tseslint.config(
       'src/**/*.redis.ts',
       'src/**/*.live.ts',
       'src/**/*.google.ts',
+      'src/**/*.r2.ts',
       'src/**/*.schema.ts',
       'src/server.ts',
       'src/db/**',

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -19,6 +19,9 @@
     "migrate": "tsx src/db/migrate.ts"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.1079.0",
+    "@aws-sdk/s3-request-presigner": "^3.1079.0",
+    "@fastify/multipart": "^10.0.0",
     "@fastify/swagger": "^9.7.0",
     "@fastify/swagger-ui": "^6.0.0",
     "@opentelemetry/exporter-logs-otlp-proto": "^0.219.0",
@@ -43,6 +46,7 @@
     "jose": "^6.2.3",
     "pg": "^8.13.1",
     "prom-client": "^15.1.3",
+    "sharp": "^0.35.3",
     "zod": "^3.24.1"
   },
   "devDependencies": {

--- a/services/api/src/app.ts
+++ b/services/api/src/app.ts
@@ -9,6 +9,8 @@ import {
 } from 'fastify-type-provider-zod';
 import { z } from 'zod';
 import { InMemoryKvStore, type KvStore } from './kv/kv.store';
+import { FakeObjectStore, type ObjectStore } from './storage/object-store';
+import { userRoutes } from './modules/users/users.routes';
 import {
   InMemoryDeviceTokenRepository,
   type DeviceTokenRepository,
@@ -50,6 +52,8 @@ export interface AppDeps {
   boardingService?: BoardingService;
   /** Selected by REDIS_URL (in-memory vs Redis). For rate limits, idempotency, cache. */
   kv?: KvStore;
+  /** Avatar/media storage (R2 in prod, in-memory Fake in dev/tests). */
+  objectStore?: ObjectStore;
   /** JWT/auth settings. Defaults to a dev-only config when unset (tests, local). */
   auth?: AuthConfig;
   /** Sign-in/refresh/logout orchestrator. Routes return 503 when absent. */
@@ -118,12 +122,19 @@ export async function buildApp(deps: AppDeps = {}): Promise<FastifyInstance> {
 
   // Guards first (decorators on the root instance), then routes that use them.
   const kv = deps.kv ?? new InMemoryKvStore();
+  const objectStore = deps.objectStore ?? new FakeObjectStore();
   const authConfig = deps.auth ?? DEV_AUTH_CONFIG;
   await app.register(authPlugin, { config: authConfig });
   await app.register(rateLimitPlugin, { kv });
   await app.register(authRoutes, {
     users: deps.users,
+    objectStore,
     authService: deps.authService,
+    rateLimit: deps.rateLimit ?? DEFAULT_RATE_LIMIT,
+  });
+  await app.register(userRoutes, {
+    users: deps.users,
+    objectStore,
     rateLimit: deps.rateLimit ?? DEFAULT_RATE_LIMIT,
   });
   await app.register(deviceRoutes, {

--- a/services/api/src/config/env.ts
+++ b/services/api/src/config/env.ts
@@ -22,6 +22,12 @@ const envSchema = z
     // Paystack SECRET key (sk_...). Used for the API + webhook signature check.
     // Set -> real payments; unset -> dev fake client (non-prod) / 503 (prod).
     PAYSTACK_SECRET_KEY: z.string().optional(),
+    // Cloudflare R2 (avatars, #24). All four set -> real R2; any unset ->
+    // in-memory Fake object store (dev/tests). Secrets -> Render dashboard only.
+    R2_ACCOUNT_ID: z.string().optional(),
+    R2_ACCESS_KEY_ID: z.string().optional(),
+    R2_SECRET_ACCESS_KEY: z.string().optional(),
+    R2_BUCKET: z.string().optional(),
     // Rate limiting (fixed window). Tunable without a code change.
     RATE_LIMIT_MAX: z.coerce.number().int().positive().default(100),
     RATE_LIMIT_WINDOW_SECONDS: z.coerce.number().int().positive().default(60),

--- a/services/api/src/modules/auth/auth.routes.ts
+++ b/services/api/src/modules/auth/auth.routes.ts
@@ -7,7 +7,9 @@ import type { ZodTypeProvider } from 'fastify-type-provider-zod';
 import { errorResponseSchema } from '../../lib/schemas';
 import type { RateLimitConfig } from '../ratelimit/ratelimit.plugin';
 import { userResponseSchema } from '../users/user.schema';
+import { toUserResponse } from '../users/user.presenter';
 import type { UserRepository } from '../users/user.repository';
+import type { ObjectStore } from '../../storage/object-store';
 import {
   authResultSchema,
   googleSignInBodySchema,
@@ -34,12 +36,18 @@ const AUTH_RATE_LIMIT = { max: 10, windowSeconds: 60 } as const;
  * @param app - the Fastify instance to register on.
  * @param opts - route dependencies.
  * @param opts.users - the user repository (for `GET /me`).
+ * @param opts.objectStore - avatar storage, to sign the avatar URL on `GET /me`.
  * @param opts.authService - the AuthService (routes 503 when absent).
  * @param opts.rateLimit - rate-limit config for the credential endpoints.
  */
 export async function authRoutes(
   app: FastifyInstance,
-  opts: { users?: UserRepository; authService?: AuthService; rateLimit: RateLimitConfig },
+  opts: {
+    users?: UserRepository;
+    objectStore: ObjectStore;
+    authService?: AuthService;
+    rateLimit: RateLimitConfig;
+  },
 ): Promise<void> {
   const r = app.withTypeProvider<ZodTypeProvider>();
 
@@ -65,7 +73,7 @@ export async function authRoutes(
       if (!user) {
         return reply.code(404).send({ error: 'not_found', message: 'User not found' });
       }
-      return user;
+      return toUserResponse(user, opts.objectStore);
     },
   );
 

--- a/services/api/src/modules/users/avatar.ts
+++ b/services/api/src/modules/users/avatar.ts
@@ -1,0 +1,41 @@
+// Avatar image processing (#24). Every uploaded photo is re-encoded server-side
+// before it ever reaches storage — this both bounds size and, crucially, STRIPS
+// EXIF (phone photos embed GPS/PII in metadata; security.md §7). The client
+// can't bypass this by sending a pre-sized image: we always re-encode.
+
+import sharp from 'sharp';
+
+/** Longest edge of a stored avatar, in pixels (a square thumbnail). */
+export const AVATAR_SIZE_PX = 256;
+/** JPEG quality for the re-encoded avatar (visually fine at 256px, small bytes). */
+const AVATAR_JPEG_QUALITY = 80;
+/** Max accepted upload size before processing — a guard on the raw bytes. */
+export const MAX_UPLOAD_BYTES = 5 * 1024 * 1024; // 5 MB
+/** Content types we accept for upload (all re-encoded to JPEG regardless). */
+export const ACCEPTED_MIME = new Set(['image/jpeg', 'image/png', 'image/webp']);
+
+/** The MIME type every processed avatar is stored as. */
+export const PROCESSED_MIME = 'image/jpeg';
+
+/** Thrown when an upload isn't a decodable image of an accepted type. */
+export class InvalidImageError extends Error {}
+
+/**
+ * Resize an uploaded image to a square avatar and re-encode to JPEG (dropping
+ * EXIF and any other metadata).
+ *
+ * @param input - the raw uploaded bytes.
+ * @returns the processed JPEG bytes ready for storage.
+ * @throws InvalidImageError if the bytes aren't a decodable image.
+ */
+export async function processAvatar(input: Buffer): Promise<Buffer> {
+  try {
+    return await sharp(input)
+      .rotate() // apply EXIF orientation, then the re-encode drops the metadata
+      .resize(AVATAR_SIZE_PX, AVATAR_SIZE_PX, { fit: 'cover' })
+      .jpeg({ quality: AVATAR_JPEG_QUALITY })
+      .toBuffer();
+  } catch {
+    throw new InvalidImageError('Uploaded file is not a valid image');
+  }
+}

--- a/services/api/src/modules/users/user.presenter.ts
+++ b/services/api/src/modules/users/user.presenter.ts
@@ -1,0 +1,35 @@
+// Serialize a User for API responses. The DB stores the avatar as a private
+// object KEY; clients must never see it — we swap it for a short-lived signed
+// URL here, so every route that returns a user does so consistently (#24).
+
+import type { ObjectStore } from '../../storage/object-store';
+import type { User } from './user.repository';
+
+/** A user as returned by the API (see `userResponseSchema`). */
+export interface UserResponse {
+  id: string;
+  displayName: string;
+  phone: string | null;
+  avatarUrl: string | null;
+  role: User['role'];
+  createdAt: Date;
+}
+
+/**
+ * Build the public response for a user, signing the stored avatar key into a
+ * short-lived URL (null when the user has no avatar).
+ *
+ * @param user - the persisted user.
+ * @param objectStore - used to sign the avatar object key.
+ * @returns the client-safe user representation.
+ */
+export async function toUserResponse(user: User, objectStore: ObjectStore): Promise<UserResponse> {
+  return {
+    id: user.id,
+    displayName: user.displayName,
+    phone: user.phone,
+    avatarUrl: user.avatarUrl ? await objectStore.signedUrl(user.avatarUrl) : null,
+    role: user.role,
+    createdAt: user.createdAt,
+  };
+}

--- a/services/api/src/modules/users/user.repository.pg.ts
+++ b/services/api/src/modules/users/user.repository.pg.ts
@@ -38,4 +38,20 @@ export class PgUserRepository implements UserRepository {
     const { rows } = await this.pool.query<UserRow>('SELECT * FROM users WHERE id = $1', [id]);
     return rows[0] ? toUser(rows[0]) : null;
   }
+
+  async updateProfile(id: string, patch: { displayName: string }): Promise<User | null> {
+    const { rows } = await this.pool.query<UserRow>(
+      `UPDATE users SET display_name = $2, updated_at = now() WHERE id = $1 RETURNING *`,
+      [id, patch.displayName],
+    );
+    return rows[0] ? toUser(rows[0]) : null;
+  }
+
+  async setAvatarKey(id: string, key: string | null): Promise<User | null> {
+    const { rows } = await this.pool.query<UserRow>(
+      `UPDATE users SET avatar_url = $2, updated_at = now() WHERE id = $1 RETURNING *`,
+      [id, key],
+    );
+    return rows[0] ? toUser(rows[0]) : null;
+  }
 }

--- a/services/api/src/modules/users/user.repository.ts
+++ b/services/api/src/modules/users/user.repository.ts
@@ -39,6 +39,23 @@ export interface UserRepository {
    * @returns the user, or null if not found.
    */
   findById(id: string): Promise<User | null>;
+  /**
+   * Update a user's editable profile fields.
+   *
+   * @param id - the user id.
+   * @param patch - the fields to change.
+   * @param patch.displayName - the new display name.
+   * @returns the updated user, or null if not found.
+   */
+  updateProfile(id: string, patch: { displayName: string }): Promise<User | null>;
+  /**
+   * Set (or clear) a user's stored avatar object key.
+   *
+   * @param id - the user id.
+   * @param key - the object-store key, or null to remove the avatar.
+   * @returns the updated user, or null if not found.
+   */
+  setAvatarKey(id: string, key: string | null): Promise<User | null>;
 }
 
 /** In-memory {@link UserRepository} for dev and unit tests. */
@@ -60,5 +77,21 @@ export class InMemoryUserRepository implements UserRepository {
 
   async findById(id: string): Promise<User | null> {
     return this.users.get(id) ?? null;
+  }
+
+  async updateProfile(id: string, patch: { displayName: string }): Promise<User | null> {
+    const user = this.users.get(id);
+    if (!user) return null;
+    const updated = { ...user, displayName: patch.displayName };
+    this.users.set(id, updated);
+    return updated;
+  }
+
+  async setAvatarKey(id: string, key: string | null): Promise<User | null> {
+    const user = this.users.get(id);
+    if (!user) return null;
+    const updated = { ...user, avatarUrl: key };
+    this.users.set(id, updated);
+    return updated;
   }
 }

--- a/services/api/src/modules/users/user.schema.ts
+++ b/services/api/src/modules/users/user.schema.ts
@@ -8,7 +8,17 @@ export const userResponseSchema = z.object({
   id: z.string().uuid(),
   displayName: z.string(),
   phone: z.string().nullable(),
+  // A short-lived signed URL when the user has an avatar (the raw object key is
+  // never exposed); null otherwise.
   avatarUrl: z.string().nullable(),
   role: z.enum(USER_ROLES),
   createdAt: z.date(),
+});
+
+export const updateProfileBodySchema = z.object({
+  displayName: z.string().trim().min(1).max(80),
+});
+
+export const avatarResponseSchema = z.object({
+  avatarUrl: z.string(),
 });

--- a/services/api/src/modules/users/users.routes.ts
+++ b/services/api/src/modules/users/users.routes.ts
@@ -1,0 +1,158 @@
+// User profile + avatar routes (#24). Profile edits and the avatar upload live
+// here; the canonical `GET /me` stays in auth.routes.ts. Uploads are proxied
+// through the API (not presigned direct-to-R2) so the server always resizes and
+// re-encodes — stripping EXIF/PII — before anything is stored (security.md §7).
+
+import type { FastifyInstance } from 'fastify';
+import fastifyMultipart from '@fastify/multipart';
+import type { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { errorResponseSchema } from '../../lib/schemas';
+import type { ObjectStore } from '../../storage/object-store';
+import type { RateLimitConfig } from '../ratelimit/ratelimit.plugin';
+import {
+  ACCEPTED_MIME,
+  InvalidImageError,
+  MAX_UPLOAD_BYTES,
+  processAvatar,
+  PROCESSED_MIME,
+} from './avatar';
+import { toUserResponse } from './user.presenter';
+import type { UserRepository } from './user.repository';
+import { avatarResponseSchema, updateProfileBodySchema, userResponseSchema } from './user.schema';
+
+/**
+ * Register user profile + avatar routes: `PATCH /me`, `POST /me/avatar`,
+ * `GET /me/avatar`.
+ *
+ * @param app - the Fastify instance to register on.
+ * @param opts - route dependencies.
+ * @param opts.users - the user repository.
+ * @param opts.objectStore - avatar storage (R2 in prod, in-memory in dev/tests).
+ * @param opts.rateLimit - rate-limit config (applied per user).
+ */
+export async function userRoutes(
+  app: FastifyInstance,
+  opts: { users?: UserRepository; objectStore: ObjectStore; rateLimit: RateLimitConfig },
+): Promise<void> {
+  await app.register(fastifyMultipart, { limits: { fileSize: MAX_UPLOAD_BYTES, files: 1 } });
+  const r = app.withTypeProvider<ZodTypeProvider>();
+  const UNAVAILABLE = { error: 'unavailable', message: 'User store is not configured' };
+  const NOT_FOUND = { error: 'not_found', message: 'User not found' };
+
+  r.patch(
+    '/me',
+    {
+      schema: {
+        tags: ['auth'],
+        summary: "Update the authenticated user's profile",
+        security: [{ bearerAuth: [] }],
+        body: updateProfileBodySchema,
+        response: {
+          200: userResponseSchema,
+          401: errorResponseSchema,
+          404: errorResponseSchema,
+          429: errorResponseSchema,
+          503: errorResponseSchema,
+        },
+      },
+      preHandler: [app.authenticate, app.rateLimit({ ...opts.rateLimit, by: 'user' })],
+    },
+    async (request, reply) => {
+      if (!opts.users) return reply.code(503).send(UNAVAILABLE);
+      const user = await opts.users.updateProfile(request.user!.id, {
+        displayName: request.body.displayName,
+      });
+      if (!user) return reply.code(404).send(NOT_FOUND);
+      return toUserResponse(user, opts.objectStore);
+    },
+  );
+
+  r.post(
+    '/me/avatar',
+    {
+      schema: {
+        tags: ['auth'],
+        summary: 'Upload the authenticated user avatar (resized + EXIF-stripped server-side)',
+        consumes: ['multipart/form-data'],
+        security: [{ bearerAuth: [] }],
+        response: {
+          200: avatarResponseSchema,
+          400: errorResponseSchema,
+          401: errorResponseSchema,
+          404: errorResponseSchema,
+          413: errorResponseSchema,
+          429: errorResponseSchema,
+          503: errorResponseSchema,
+        },
+      },
+      preHandler: [app.authenticate, app.rateLimit({ ...opts.rateLimit, by: 'user' })],
+    },
+    async (request, reply) => {
+      if (!opts.users) return reply.code(503).send(UNAVAILABLE);
+
+      const part = await request.file();
+      if (!part) return reply.code(400).send({ error: 'bad_request', message: 'No file uploaded' });
+      if (!ACCEPTED_MIME.has(part.mimetype)) {
+        return reply
+          .code(400)
+          .send({ error: 'bad_request', message: 'Unsupported image type (use JPEG/PNG/WebP)' });
+      }
+
+      let raw: Buffer;
+      try {
+        raw = await part.toBuffer();
+      } catch (err) {
+        if ((err as { code?: string }).code === 'FST_REQ_FILE_TOO_LARGE') {
+          return reply
+            .code(413)
+            .send({ error: 'payload_too_large', message: 'Image exceeds 5 MB' });
+        }
+        throw err;
+      }
+
+      let processed: Buffer;
+      try {
+        processed = await processAvatar(raw);
+      } catch (err) {
+        if (err instanceof InvalidImageError) {
+          return reply.code(400).send({ error: 'bad_request', message: err.message });
+        }
+        throw err;
+      }
+
+      const userId = request.user!.id;
+      const key = await opts.objectStore.putAvatar(userId, processed, PROCESSED_MIME);
+      const user = await opts.users.setAvatarKey(userId, key);
+      if (!user) return reply.code(404).send(NOT_FOUND);
+      return { avatarUrl: await opts.objectStore.signedUrl(key) };
+    },
+  );
+
+  r.get(
+    '/me/avatar',
+    {
+      schema: {
+        tags: ['auth'],
+        summary: 'Get a short-lived signed URL for the authenticated user avatar',
+        security: [{ bearerAuth: [] }],
+        response: {
+          200: avatarResponseSchema,
+          401: errorResponseSchema,
+          404: errorResponseSchema,
+          429: errorResponseSchema,
+          503: errorResponseSchema,
+        },
+      },
+      preHandler: [app.authenticate, app.rateLimit({ ...opts.rateLimit, by: 'user' })],
+    },
+    async (request, reply) => {
+      if (!opts.users) return reply.code(503).send(UNAVAILABLE);
+      const user = await opts.users.findById(request.user!.id);
+      if (!user) return reply.code(404).send(NOT_FOUND);
+      if (!user.avatarUrl) {
+        return reply.code(404).send({ error: 'not_found', message: 'No avatar set' });
+      }
+      return { avatarUrl: await opts.objectStore.signedUrl(user.avatarUrl) };
+    },
+  );
+}

--- a/services/api/src/server.ts
+++ b/services/api/src/server.ts
@@ -8,6 +8,8 @@ import { loadEnv } from './config/env';
 import { createPool } from './db/pool';
 import { InMemoryKvStore, type KvStore } from './kv/kv.store';
 import { RedisKvStore } from './kv/kv.store.redis';
+import { FakeObjectStore, type ObjectStore } from './storage/object-store';
+import { R2ObjectStore } from './storage/object-store.r2';
 import {
   InMemoryAuthIdentityRepository,
   type AuthIdentityRepository,
@@ -71,6 +73,21 @@ async function main(): Promise<void> {
   console.log(
     env.REDIS_URL ? 'Using Redis KV store' : 'Using in-memory KV store (no REDIS_URL set)',
   );
+
+  // Object store: Cloudflare R2 when all four R2_* vars are set, else in-memory.
+  let objectStore: ObjectStore;
+  if (env.R2_ACCOUNT_ID && env.R2_ACCESS_KEY_ID && env.R2_SECRET_ACCESS_KEY && env.R2_BUCKET) {
+    objectStore = new R2ObjectStore({
+      accountId: env.R2_ACCOUNT_ID,
+      accessKeyId: env.R2_ACCESS_KEY_ID,
+      secretAccessKey: env.R2_SECRET_ACCESS_KEY,
+      bucket: env.R2_BUCKET,
+    });
+    console.log('Using Cloudflare R2 object store');
+  } else {
+    objectStore = new FakeObjectStore();
+    console.log('Using in-memory object store (R2_* not fully set)');
+  }
 
   // Repositories: Postgres when DATABASE_URL is set, else in-memory (zero infra).
   let pool: Pool | undefined;
@@ -178,6 +195,7 @@ async function main(): Promise<void> {
     authService,
     paymentsService,
     kv,
+    objectStore,
     isReady,
     auth,
     rateLimit,

--- a/services/api/src/storage/object-store.r2.ts
+++ b/services/api/src/storage/object-store.r2.ts
@@ -1,0 +1,52 @@
+// Cloudflare R2 ObjectStore (the real impl behind object-store.ts). R2 speaks
+// the S3 API, so we use the AWS S3 SDK pointed at the account's R2 endpoint.
+// The bucket is private; reads go through presigned GET URLs (zero egress on R2).
+// Excluded from unit coverage (needs a live bucket) — exercised via staging.
+
+import { GetObjectCommand, PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { avatarKey, SIGNED_URL_TTL_SECONDS, type ObjectStore } from './object-store';
+
+/** Credentials + bucket for an R2-backed {@link ObjectStore}. */
+export interface R2Config {
+  accountId: string;
+  accessKeyId: string;
+  secretAccessKey: string;
+  bucket: string;
+}
+
+export class R2ObjectStore implements ObjectStore {
+  private readonly client: S3Client;
+
+  constructor(private readonly config: R2Config) {
+    this.client = new S3Client({
+      region: 'auto',
+      endpoint: `https://${config.accountId}.r2.cloudflarestorage.com`,
+      credentials: {
+        accessKeyId: config.accessKeyId,
+        secretAccessKey: config.secretAccessKey,
+      },
+    });
+  }
+
+  async putAvatar(userId: string, bytes: Buffer, contentType: string): Promise<string> {
+    const key = avatarKey(userId);
+    await this.client.send(
+      new PutObjectCommand({
+        Bucket: this.config.bucket,
+        Key: key,
+        Body: bytes,
+        ContentType: contentType,
+      }),
+    );
+    return key;
+  }
+
+  async signedUrl(key: string, ttlSeconds = SIGNED_URL_TTL_SECONDS): Promise<string> {
+    return getSignedUrl(
+      this.client,
+      new GetObjectCommand({ Bucket: this.config.bucket, Key: key }),
+      { expiresIn: ttlSeconds },
+    );
+  }
+}

--- a/services/api/src/storage/object-store.ts
+++ b/services/api/src/storage/object-store.ts
@@ -1,0 +1,65 @@
+// Object storage for user media (avatars, #24). Repository-style seam (ADR-0009):
+// an interface with an in-memory Fake (dev/tests) and a Cloudflare R2 impl
+// (object-store.r2.ts), selected by env. Buckets are PRIVATE — objects are read
+// only through short-lived signed URLs, never a public URL (security.md §7: the
+// avatar is PII, served transiently to the verifying driver).
+
+/**
+ * The object key where a user's avatar lives (stored in `users.avatar_url`).
+ *
+ * @param userId - the avatar owner.
+ * @returns the deterministic object key for that user's avatar.
+ */
+export function avatarKey(userId: string): string {
+  return `avatars/${userId}`;
+}
+
+/** Default lifetime of a signed avatar URL — long enough to render, short
+ * enough that a leaked link dies quickly. */
+export const SIGNED_URL_TTL_SECONDS = 300;
+
+/** Storage for user media. R2 in prod, in-memory Fake in dev/tests. */
+export interface ObjectStore {
+  /**
+   * Store a user's avatar bytes (already resized/re-encoded by the caller).
+   *
+   * @param userId - the avatar owner; determines the object key.
+   * @param bytes - the processed image bytes.
+   * @param contentType - the stored object's MIME type (e.g. `image/jpeg`).
+   * @returns the object key to persist on the user record.
+   */
+  putAvatar(userId: string, bytes: Buffer, contentType: string): Promise<string>;
+  /**
+   * Mint a short-lived signed GET URL for an object key.
+   *
+   * @param key - the object key (from {@link ObjectStore.putAvatar}).
+   * @param ttlSeconds - link lifetime (defaults to {@link SIGNED_URL_TTL_SECONDS}).
+   * @returns a time-limited URL the client can GET directly.
+   */
+  signedUrl(key: string, ttlSeconds?: number): Promise<string>;
+}
+
+/** In-memory {@link ObjectStore} for dev and unit tests (no network). */
+export class FakeObjectStore implements ObjectStore {
+  private readonly objects = new Map<string, { bytes: Buffer; contentType: string }>();
+
+  async putAvatar(userId: string, bytes: Buffer, contentType: string): Promise<string> {
+    const key = avatarKey(userId);
+    this.objects.set(key, { bytes, contentType });
+    return key;
+  }
+
+  async signedUrl(key: string, ttlSeconds = SIGNED_URL_TTL_SECONDS): Promise<string> {
+    return `https://fake-object-store.local/${key}?expires=${ttlSeconds}`;
+  }
+
+  /**
+   * Test/dev helper: read back stored bytes for a key.
+   *
+   * @param key - the object key.
+   * @returns the stored object, or undefined if absent.
+   */
+  peek(key: string): { bytes: Buffer; contentType: string } | undefined {
+    return this.objects.get(key);
+  }
+}

--- a/services/api/tests/users.routes.test.ts
+++ b/services/api/tests/users.routes.test.ts
@@ -1,0 +1,159 @@
+import sharp from 'sharp';
+import { describe, expect, it } from 'vitest';
+import { buildApp } from '../src/app';
+import { InMemoryUserRepository } from '../src/modules/users/user.repository';
+import { FakeObjectStore, avatarKey } from '../src/storage/object-store';
+import { createJwtService, type AuthConfig } from '../src/modules/auth/jwt';
+
+const auth: AuthConfig = {
+  secret: 'test-secret-at-least-32-characters-long-0000',
+  accessTtl: '15m',
+  issuer: 'trotxi',
+  audience: 'trotxi-api',
+};
+const jwt = createJwtService(auth);
+const bearer = (t: string) => ({ authorization: `Bearer ${t}` });
+
+async function setup() {
+  const users = new InMemoryUserRepository();
+  const objectStore = new FakeObjectStore();
+  const user = await users.create({ displayName: 'Ama', role: 'commuter' });
+  const app = await buildApp({ auth, users, objectStore });
+  const token = await jwt.signAccessToken({ userId: user.id, role: 'commuter' });
+  return { users, objectStore, user, app, token };
+}
+
+/** Build a multipart/form-data body with a single file part (no extra deps). */
+function multipart(bytes: Buffer, filename: string, contentType: string) {
+  const boundary = '----trotxitestboundary';
+  const head = Buffer.from(
+    `--${boundary}\r\nContent-Disposition: form-data; name="file"; filename="${filename}"\r\n` +
+      `Content-Type: ${contentType}\r\n\r\n`,
+  );
+  const tail = Buffer.from(`\r\n--${boundary}--\r\n`);
+  return {
+    contentType: `multipart/form-data; boundary=${boundary}`,
+    payload: Buffer.concat([head, bytes, tail]),
+  };
+}
+
+/** POST an avatar upload, merging the bearer header with the multipart type. */
+function uploadAvatar(
+  app: Awaited<ReturnType<typeof buildApp>>,
+  token: string | null,
+  bytes: Buffer,
+  filename: string,
+  contentType: string,
+) {
+  const mp = multipart(bytes, filename, contentType);
+  const headers: Record<string, string> = { 'content-type': mp.contentType };
+  if (token) headers.authorization = `Bearer ${token}`;
+  return app.inject({ method: 'POST', url: '/me/avatar', headers, payload: mp.payload });
+}
+
+const samplePng = () =>
+  sharp({ create: { width: 400, height: 400, channels: 3, background: { r: 10, g: 150, b: 90 } } })
+    .png()
+    .toBuffer();
+
+describe('PATCH /me', () => {
+  it('requires authentication', async () => {
+    const { app } = await setup();
+    const res = await app.inject({ method: 'PATCH', url: '/me', payload: { displayName: 'X' } });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('updates the display name', async () => {
+    const { app, token, users, user } = await setup();
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/me',
+      headers: bearer(token),
+      payload: { displayName: 'Ama Mensah' },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().displayName).toBe('Ama Mensah');
+    expect((await users.findById(user.id))?.displayName).toBe('Ama Mensah');
+  });
+
+  it('rejects an empty display name (400)', async () => {
+    const { app, token } = await setup();
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/me',
+      headers: bearer(token),
+      payload: { displayName: '   ' },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+describe('POST /me/avatar', () => {
+  it('requires authentication', async () => {
+    const { app } = await setup();
+    const res = await uploadAvatar(app, null, await samplePng(), 'a.png', 'image/png');
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('resizes + re-encodes to a 256px JPEG and stores it', async () => {
+    const { app, token, objectStore, user } = await setup();
+    const res = await uploadAvatar(app, token, await samplePng(), 'a.png', 'image/png');
+    expect(res.statusCode).toBe(200);
+    expect(res.json().avatarUrl).toContain(avatarKey(user.id));
+
+    const stored = objectStore.peek(avatarKey(user.id));
+    expect(stored?.contentType).toBe('image/jpeg');
+    // re-encoded to JPEG (magic bytes FF D8) — EXIF stripped
+    expect(stored!.bytes.subarray(0, 2)).toEqual(Buffer.from([0xff, 0xd8]));
+    const meta = await sharp(stored!.bytes).metadata();
+    expect(meta.format).toBe('jpeg');
+    expect(meta.width).toBe(256);
+    expect(meta.height).toBe(256);
+  });
+
+  it('rejects an unsupported content type (400)', async () => {
+    const { app, token } = await setup();
+    const res = await uploadAvatar(app, token, Buffer.from('%PDF-1.4'), 'a.pdf', 'application/pdf');
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('rejects bytes that are not a decodable image (400)', async () => {
+    const { app, token } = await setup();
+    const res = await uploadAvatar(
+      app,
+      token,
+      Buffer.from('not really a png'),
+      'a.png',
+      'image/png',
+    );
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+describe('GET /me/avatar', () => {
+  it('404s when no avatar is set', async () => {
+    const { app, token } = await setup();
+    const res = await app.inject({ method: 'GET', url: '/me/avatar', headers: bearer(token) });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('returns a signed URL after an upload', async () => {
+    const { app, token } = await setup();
+    await uploadAvatar(app, token, await samplePng(), 'a.png', 'image/png');
+    const res = await app.inject({ method: 'GET', url: '/me/avatar', headers: bearer(token) });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().avatarUrl).toContain('https://');
+  });
+});
+
+describe('GET /me avatar signing', () => {
+  it('returns a signed URL (not the raw key) after an upload', async () => {
+    const { app, token, user } = await setup();
+    await uploadAvatar(app, token, await samplePng(), 'a.png', 'image/png');
+    const me = await app.inject({ method: 'GET', url: '/me', headers: bearer(token) });
+    expect(me.statusCode).toBe(200);
+    const url = me.json().avatarUrl as string;
+    expect(url).toContain('https://');
+    expect(url).toContain(avatarKey(user.id));
+  });
+});

--- a/services/api/vitest.config.ts
+++ b/services/api/vitest.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
         'src/**/*.redis.ts',
         'src/**/*.google.ts',
         'src/**/*.live.ts',
+        'src/**/*.r2.ts',
       ],
       thresholds: {
         lines: 80,


### PR DESCRIPTION
Closes #24. Unblocks the **E4 photo-pass manifest** (driver sees rider name + photo at boarding).

### What
- **`ObjectStore` seam** (ADR-0009): interface + `FakeObjectStore` (dev/tests) + `R2ObjectStore` (S3 SDK, `*.r2.ts`, excluded from unit coverage). Selected by env — all four `R2_*` set → R2, else Fake. Same pattern as Redis/Paystack.
- **Server-side image processing** (`sharp`): every upload is resized to 256×256 and **re-encoded to JPEG, stripping EXIF/GPS** before storage (security.md §7). Proxy upload (not presigned PUT) so the server always controls it.
- **Private bucket:** store the object **key** in `users.avatar_url`; serve via **short-lived signed URLs**. `toUserResponse()` signs it wherever a user is returned — `GET /me` no longer leaks the raw key.
- **Routes:** `PATCH /me`, `POST /me/avatar` (multipart, ≤5 MB, JPEG/PNG/WebP), `GET /me/avatar`. Repo gains `updateProfile` + `setAvatarKey` (InMemory + Pg).

### Config
`render.yaml` + `.env.example` document the four `R2_*` keys (access keys are secrets → dashboard only). Already set in Render. `sharp` added to the pnpm build-script allowlist.

### Tests
10 new (resize/EXIF re-encode asserted via `sharp` metadata, guards, unsupported-type + non-image 400s); **131 total green**, coverage gate passes, build clean (native deps stay external).

### Note
No schema change — `avatar_url` already existed on `users`.