### PR TITLE
feat(api): ride entitlement + credit ledgers + allocation on subscription (#100, E1)

### DIFF
--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -16,15 +16,16 @@ repo (`system-design.md`, `security.md`). Each doc links to both.
 
 ## Index
 
-| Feature                                                                   | Doc                                              | Status                                 |
-| ------------------------------------------------------------------------- | ------------------------------------------------ | -------------------------------------- |
-| Authentication — access tokens, route guard, sign-in/refresh/logout       | [authentication.md](authentication.md)           | ✅ live                                |
-| Profile & avatars — `PATCH /me`, avatar upload → R2 (photo pass) (#24)    | [profile-avatars.md](profile-avatars.md)         | ✅ live                                |
-| Payments — Paystack subscribe + webhook (wallet/ledger removed, ADR-0014) | [payments-and-wallet.md](payments-and-wallet.md) | 🔄 model pivoted (Hybrid Subscription) |
-| Mobility — routes, stops, browse                                          | _(in review — #57)_                              | 🚧                                     |
-| Rate limiting (#23)                                                       | [rate-limiting.md](rate-limiting.md)             | ✅ live                                |
-| Boarding — QR passes + scan verification (#20)                            | [boarding.md](boarding.md)                       | 🟡 integrity slice                     |
-| Observability & performance (#28)                                         | [design](../design/observability.md)             | ✅ backend live (metrics/traces/logs)  |
+| Feature                                                                     | Doc                                              | Status                                 |
+| --------------------------------------------------------------------------- | ------------------------------------------------ | -------------------------------------- |
+| Authentication — access tokens, route guard, sign-in/refresh/logout         | [authentication.md](authentication.md)           | ✅ live                                |
+| Profile & avatars — `PATCH /me`, avatar upload → R2 (photo pass) (#24)      | [profile-avatars.md](profile-avatars.md)         | ✅ live                                |
+| Payments — Paystack subscribe + webhook (wallet/ledger removed, ADR-0014)   | [payments-and-wallet.md](payments-and-wallet.md) | 🔄 model pivoted (Hybrid Subscription) |
+| Ride entitlements & credits — `GET /me/rides`, allocation on payment (#100) | [entitlements.md](entitlements.md)               | ✅ E1 (ledgers + allocation)           |
+| Mobility — routes, stops, browse                                            | _(in review — #57)_                              | 🚧                                     |
+| Rate limiting (#23)                                                         | [rate-limiting.md](rate-limiting.md)             | ✅ live                                |
+| Boarding — QR passes + scan verification (#20)                              | [boarding.md](boarding.md)                       | 🟡 integrity slice                     |
+| Observability & performance (#28)                                           | [design](../design/observability.md)             | ✅ backend live (metrics/traces/logs)  |
 
 ## Conventions for a feature doc
 

--- a/docs/features/entitlements.md
+++ b/docs/features/entitlements.md
@@ -1,0 +1,95 @@
+# Ride entitlements & credits
+
+**Owner:** Godfred Awuku · **Last updated:** 2026-07-05 · **Issue:** #100 (epic E1)
+
+The money core of the **Hybrid Subscription Model** (ADR-0014). A subscription
+buys a **ride entitlement** (a count of rides for the period); unused rides
+become **Ride Credits** (pesewas) that reduce the next renewal. Both are modelled
+as **append-only, idempotent ledgers** — the same no-lost-update pattern the old
+token wallet used (system-design §4.1), reused twice.
+
+> **Scope (E1):** the two ledgers, allocation-on-subscription, and `GET /me/rides`.
+> Deferred: plan tiers/prices (E1b), boarding deduction + no-show (E4), month-end
+> credit conversion + credit-netted renewal (E5).
+
+---
+
+## Concepts
+
+- **Entitlement ledger — ride counts.** `remainingRides = SUM(delta_rides)`.
+  `+N` on allocation, `-1` on boarding/no-show, `+1` on operator-cancel return.
+- **Credit ledger — pesewas.** `balance = SUM(delta_pesewas)`. Credit is granted
+  (month-end conversion, compensation, loyalty) and spent against a renewal.
+- **Exactly-once.** Every append carries a unique `idempotency_key`; a retry is a
+  no-op. Allocation is keyed by the payment reference, so a re-delivered Paystack
+  webhook never double-allocates.
+- **Allocation happens on payment.** The Paystack `charge.success` webhook, on
+  activating a subscription, also allocates the period's rides — one flow, both
+  idempotent.
+
+---
+
+## API
+
+#### `GET /me/rides`
+
+The rider's balance (replaces the removed wallet `GET /me/balance`; FE #35).
+
+- **Auth:** `Bearer`. **Rate limit:** per user.
+- **200:** `{ "remainingRides": 44, "creditPesewas": 0 }`
+- **401** · **429** · **503** not configured
+
+---
+
+## Data
+
+```
+entitlement_ledger(id, user_id, delta_rides, reason, ref_type, ref_id,
+  idempotency_key unique, created_at)
+  -- reason ∈ allocation | boarding | no_show | returned | refund
+credit_ledger(id, user_id, delta_pesewas, reason, ref_type, ref_id,
+  idempotency_key unique, created_at)
+  -- reason ∈ month_end_conversion | compensation | loyalty | renewal_applied
+```
+
+`remainingRides(user) = SUM(delta_rides)` · `balancePesewas(user) = SUM(delta_pesewas)`.
+
+## How allocation works
+
+```
+POST /payments/subscribe → Paystack checkout → charge.success webhook:
+  activate subscription (idempotent, one-active-per-user index)
+  allocate rides       (idempotent, key = alloc:<payment reference>)
+  mark payment paid
+```
+
+The rides granted per period is a **placeholder constant**
+(`PLACEHOLDER_RIDES_PER_PERIOD = 44`) until the `plans` table lands (E1b) — the
+same posture as `SUBSCRIPTION_FEES_PESEWAS`.
+
+## Security / integrity notes
+
+- **Derived balances, never a mutable counter** — no lost updates under
+  concurrency; full audit trail.
+- **Server-authoritative** — allocation amount comes from the server, keyed to a
+  verified (signed) Paystack webhook.
+- **Idempotent everywhere** — safe to replay activation, allocation, and future
+  deductions.
+
+## Where the code lives
+
+```
+services/api/src/modules/entitlements/
+  entitlement-ledger.repository.ts(.pg)  # ride counts (append-only)
+  credit-ledger.repository.ts(.pg)       # Ride Credit pesewas (append-only)
+  entitlements.routes.ts                 # GET /me/rides
+  entitlements.schema.ts
+services/api/src/modules/payments/payments.service.ts  # allocation on webhook
+services/api/src/db/migrations/011_entitlement_ledger.sql · 012_credit_ledger.sql
+```
+
+## Related
+
+- [ADR-0014 — Hybrid Subscription Model](../adr/0014-hybrid-subscription-model.md)
+- [ADR-0011 — append-only ledger pattern](../adr/0011-token-ledger.md) (reused here)
+- `strategy/docs/hybrid-subscription-model.md` (epics E1–E7)

--- a/services/api/src/app.ts
+++ b/services/api/src/app.ts
@@ -20,6 +20,15 @@ import { BoardingService } from './modules/boarding/boarding.service';
 import { boardingRoutes } from './modules/boarding/boarding.routes';
 import { InMemoryScanEventRepository } from './modules/boarding/scan-event.repository';
 import { metricsPlugin, type MetricsOptions } from './modules/metrics/metrics.plugin';
+import { entitlementRoutes } from './modules/entitlements/entitlements.routes';
+import {
+  InMemoryEntitlementLedgerRepository,
+  type EntitlementLedgerRepository,
+} from './modules/entitlements/entitlement-ledger.repository';
+import {
+  InMemoryCreditLedgerRepository,
+  type CreditLedgerRepository,
+} from './modules/entitlements/credit-ledger.repository';
 import { paymentRoutes } from './modules/payments/payments.routes';
 import type { PaymentsService } from './modules/payments/payments.service';
 import { authPlugin } from './modules/auth/auth.plugin';
@@ -50,6 +59,10 @@ export interface AppDeps {
   deviceTokens?: DeviceTokenRepository;
   /** Boarding pass issuance + scan verification. Defaults to an in-memory scan store. */
   boardingService?: BoardingService;
+  /** Ride entitlement ledger (in-memory vs Postgres). Defaults to in-memory. */
+  entitlements?: EntitlementLedgerRepository;
+  /** Ride Credit ledger (in-memory vs Postgres). Defaults to in-memory. */
+  credits?: CreditLedgerRepository;
   /** Selected by REDIS_URL (in-memory vs Redis). For rate limits, idempotency, cache. */
   kv?: KvStore;
   /** Avatar/media storage (R2 in prod, in-memory Fake in dev/tests). */
@@ -100,6 +113,7 @@ export async function buildApp(deps: AppDeps = {}): Promise<FastifyInstance> {
         { name: 'system', description: 'Health, readiness, and service metadata' },
         { name: 'auth', description: 'Authentication and the current user' },
         { name: 'payments', description: 'Subscriptions checkout (Paystack) + webhook' },
+        { name: 'rides', description: 'Ride entitlement + Ride Credit balance' },
         { name: 'boarding', description: 'QR boarding passes + scan verification' },
       ],
       components: {
@@ -143,6 +157,11 @@ export async function buildApp(deps: AppDeps = {}): Promise<FastifyInstance> {
   });
   await app.register(paymentRoutes, {
     paymentsService: deps.paymentsService,
+    rateLimit: deps.rateLimit ?? DEFAULT_RATE_LIMIT,
+  });
+  await app.register(entitlementRoutes, {
+    entitlements: deps.entitlements ?? new InMemoryEntitlementLedgerRepository(),
+    credits: deps.credits ?? new InMemoryCreditLedgerRepository(),
     rateLimit: deps.rateLimit ?? DEFAULT_RATE_LIMIT,
   });
   await app.register(boardingRoutes, {

--- a/services/api/src/db/migrations/011_entitlement_ledger.sql
+++ b/services/api/src/db/migrations/011_entitlement_ledger.sql
@@ -1,0 +1,16 @@
+-- 011_entitlement_ledger: a rider's ride entitlement as an append-only ledger
+-- (ADR-0014, Hybrid Subscription Model). Remaining rides = SUM(delta_rides),
+-- never a mutable column. A subscription activation allocates rides (+); a
+-- boarding or confirmed no-show consumes one (-); an operator cancellation
+-- returns one (+). Every change is one immutable, idempotent row.
+CREATE TABLE IF NOT EXISTS entitlement_ledger (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id         uuid NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+  delta_rides     integer NOT NULL,        -- +44 allocation, -1 boarding/no_show
+  reason          text NOT NULL CHECK (reason IN ('allocation', 'boarding', 'no_show', 'returned', 'refund')),
+  ref_type        text,                    -- 'payment' | 'reservation' (no FK yet)
+  ref_id          text,
+  idempotency_key text NOT NULL UNIQUE,     -- exactly-once writes (retries are no-ops)
+  created_at      timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_entitlement_ledger_user ON entitlement_ledger (user_id);

--- a/services/api/src/db/migrations/012_credit_ledger.sql
+++ b/services/api/src/db/migrations/012_credit_ledger.sql
@@ -1,0 +1,16 @@
+-- 012_credit_ledger: a rider's Ride Credit balance (in PESEWAS) as an
+-- append-only ledger (ADR-0014). Credits arise from unused rides converted at
+-- month end, operator compensation, or loyalty rewards, and reduce a future
+-- renewal. Balance = SUM(delta_pesewas). The month-end conversion job that mints
+-- credits is E5; this migration is the store.
+CREATE TABLE IF NOT EXISTS credit_ledger (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id         uuid NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+  delta_pesewas   integer NOT NULL,        -- +4000 credit, -4000 applied to renewal
+  reason          text NOT NULL CHECK (reason IN ('month_end_conversion', 'compensation', 'loyalty', 'renewal_applied')),
+  ref_type        text,
+  ref_id          text,
+  idempotency_key text NOT NULL UNIQUE,     -- exactly-once writes (retries are no-ops)
+  created_at      timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_credit_ledger_user ON credit_ledger (user_id);

--- a/services/api/src/modules/entitlements/credit-ledger.repository.pg.ts
+++ b/services/api/src/modules/entitlements/credit-ledger.repository.pg.ts
@@ -1,0 +1,30 @@
+import type { Pool } from 'pg';
+import type { CreditEntry, CreditLedgerRepository } from './credit-ledger.repository';
+
+export class PgCreditLedgerRepository implements CreditLedgerRepository {
+  constructor(private readonly pool: Pool) {}
+
+  async record(entry: CreditEntry): Promise<void> {
+    await this.pool.query(
+      `INSERT INTO credit_ledger (user_id, delta_pesewas, reason, ref_type, ref_id, idempotency_key)
+       VALUES ($1, $2, $3, $4, $5, $6)
+       ON CONFLICT (idempotency_key) DO NOTHING`,
+      [
+        entry.userId,
+        entry.deltaPesewas,
+        entry.reason,
+        entry.refType ?? null,
+        entry.refId ?? null,
+        entry.idempotencyKey,
+      ],
+    );
+  }
+
+  async balancePesewas(userId: string): Promise<number> {
+    const { rows } = await this.pool.query<{ pesewas: number }>(
+      `SELECT COALESCE(SUM(delta_pesewas), 0)::int AS pesewas FROM credit_ledger WHERE user_id = $1`,
+      [userId],
+    );
+    return rows[0]!.pesewas;
+  }
+}

--- a/services/api/src/modules/entitlements/credit-ledger.repository.ts
+++ b/services/api/src/modules/entitlements/credit-ledger.repository.ts
@@ -1,0 +1,60 @@
+// Credit ledger — the rider's Ride Credit balance (in PESEWAS) as an append-only,
+// idempotent ledger (ADR-0014, epic E1). Balance = SUM(delta_pesewas). Credits
+// come from month-end conversion of unused rides (E5), operator compensation, or
+// loyalty, and are spent against a renewal. This is the store; the conversion
+// job lives in E5. Repository pattern (ADR-0009): interface + InMemory here,
+// Postgres in *.pg.ts.
+
+/** Why a credit row exists. */
+export type CreditReason = 'month_end_conversion' | 'compensation' | 'loyalty' | 'renewal_applied';
+
+/** A single append to the credit ledger. */
+export interface CreditEntry {
+  /** The rider the credit belongs to. */
+  userId: string;
+  /** Signed pesewas delta: +N when credit is granted, -N when applied to a renewal. */
+  deltaPesewas: number;
+  /** Why this row exists. */
+  reason: CreditReason;
+  /** What the row references (e.g. a subscription period or payment). */
+  refType?: string | null;
+  /** The referenced id. */
+  refId?: string | null;
+  /** Unique key making the write exactly-once — a retry with the same key is a no-op. */
+  idempotencyKey: string;
+}
+
+/** Append-only Ride Credit ledger (Postgres in prod, in-memory in dev/tests). */
+export interface CreditLedgerRepository {
+  /**
+   * Append an entry. A duplicate `idempotencyKey` is a no-op (exactly-once).
+   *
+   * @param entry - the credit delta to record.
+   */
+  record(entry: CreditEntry): Promise<void>;
+  /**
+   * The rider's credit balance in pesewas (the sum of their deltas).
+   *
+   * @param userId - the rider.
+   * @returns balance in pesewas (0 when the ledger is empty).
+   */
+  balancePesewas(userId: string): Promise<number>;
+}
+
+/** In-memory {@link CreditLedgerRepository} for dev and unit tests. */
+export class InMemoryCreditLedgerRepository implements CreditLedgerRepository {
+  private readonly entries: CreditEntry[] = [];
+  private readonly keys = new Set<string>();
+
+  async record(entry: CreditEntry): Promise<void> {
+    if (this.keys.has(entry.idempotencyKey)) return;
+    this.keys.add(entry.idempotencyKey);
+    this.entries.push(entry);
+  }
+
+  async balancePesewas(userId: string): Promise<number> {
+    return this.entries
+      .filter((e) => e.userId === userId)
+      .reduce((sum, e) => sum + e.deltaPesewas, 0);
+  }
+}

--- a/services/api/src/modules/entitlements/entitlement-ledger.repository.pg.ts
+++ b/services/api/src/modules/entitlements/entitlement-ledger.repository.pg.ts
@@ -1,0 +1,33 @@
+import type { Pool } from 'pg';
+import type {
+  EntitlementEntry,
+  EntitlementLedgerRepository,
+} from './entitlement-ledger.repository';
+
+export class PgEntitlementLedgerRepository implements EntitlementLedgerRepository {
+  constructor(private readonly pool: Pool) {}
+
+  async record(entry: EntitlementEntry): Promise<void> {
+    await this.pool.query(
+      `INSERT INTO entitlement_ledger (user_id, delta_rides, reason, ref_type, ref_id, idempotency_key)
+       VALUES ($1, $2, $3, $4, $5, $6)
+       ON CONFLICT (idempotency_key) DO NOTHING`,
+      [
+        entry.userId,
+        entry.deltaRides,
+        entry.reason,
+        entry.refType ?? null,
+        entry.refId ?? null,
+        entry.idempotencyKey,
+      ],
+    );
+  }
+
+  async remainingRides(userId: string): Promise<number> {
+    const { rows } = await this.pool.query<{ rides: number }>(
+      `SELECT COALESCE(SUM(delta_rides), 0)::int AS rides FROM entitlement_ledger WHERE user_id = $1`,
+      [userId],
+    );
+    return rows[0]!.rides;
+  }
+}

--- a/services/api/src/modules/entitlements/entitlement-ledger.repository.ts
+++ b/services/api/src/modules/entitlements/entitlement-ledger.repository.ts
@@ -1,0 +1,59 @@
+// Entitlement ledger — the rider's ride balance as an append-only, idempotent
+// ledger (ADR-0014, epic E1). Remaining rides = SUM(delta_rides); there is no
+// mutable count column (system-design §4.1 — the same no-lost-update reasoning
+// as the old token wallet). Repository pattern (ADR-0009): interface + InMemory
+// here, Postgres in *.pg.ts.
+
+/** Why an entitlement row exists. */
+export type EntitlementReason = 'allocation' | 'boarding' | 'no_show' | 'returned' | 'refund';
+
+/** A single append to the entitlement ledger. */
+export interface EntitlementEntry {
+  /** The rider the rides belong to. */
+  userId: string;
+  /** Signed ride delta: +N on allocation, -1 on boarding/no_show, +1 on return. */
+  deltaRides: number;
+  /** Why this row exists. */
+  reason: EntitlementReason;
+  /** What the row references, e.g. `payment` or `reservation` (no FK yet). */
+  refType?: string | null;
+  /** The referenced id (a payment reference, reservation id, …). */
+  refId?: string | null;
+  /** Unique key making the write exactly-once — a retry with the same key is a no-op. */
+  idempotencyKey: string;
+}
+
+/** Append-only ride-entitlement ledger (Postgres in prod, in-memory in dev/tests). */
+export interface EntitlementLedgerRepository {
+  /**
+   * Append an entry. A duplicate `idempotencyKey` is a no-op (exactly-once).
+   *
+   * @param entry - the ride delta to record.
+   */
+  record(entry: EntitlementEntry): Promise<void>;
+  /**
+   * The rider's remaining rides (the sum of their deltas).
+   *
+   * @param userId - the rider.
+   * @returns remaining rides (0 when the ledger is empty).
+   */
+  remainingRides(userId: string): Promise<number>;
+}
+
+/** In-memory {@link EntitlementLedgerRepository} for dev and unit tests. */
+export class InMemoryEntitlementLedgerRepository implements EntitlementLedgerRepository {
+  private readonly entries: EntitlementEntry[] = [];
+  private readonly keys = new Set<string>();
+
+  async record(entry: EntitlementEntry): Promise<void> {
+    if (this.keys.has(entry.idempotencyKey)) return;
+    this.keys.add(entry.idempotencyKey);
+    this.entries.push(entry);
+  }
+
+  async remainingRides(userId: string): Promise<number> {
+    return this.entries
+      .filter((e) => e.userId === userId)
+      .reduce((sum, e) => sum + e.deltaRides, 0);
+  }
+}

--- a/services/api/src/modules/entitlements/entitlements.routes.ts
+++ b/services/api/src/modules/entitlements/entitlements.routes.ts
@@ -1,0 +1,62 @@
+// Entitlement routes (#100, epic E1). `GET /me/rides` is the rider's balance
+// under the Hybrid Subscription Model — remaining rides + carried Ride Credit —
+// and replaces the removed wallet `GET /me/balance` (unblocks FE #35).
+
+import type { FastifyInstance } from 'fastify';
+import type { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { errorResponseSchema } from '../../lib/schemas';
+import type { RateLimitConfig } from '../ratelimit/ratelimit.plugin';
+import type { CreditLedgerRepository } from './credit-ledger.repository';
+import type { EntitlementLedgerRepository } from './entitlement-ledger.repository';
+import { ridesResponseSchema } from './entitlements.schema';
+
+/**
+ * Register the entitlement routes: `GET /me/rides`.
+ *
+ * @param app - the Fastify instance to register on.
+ * @param opts - route dependencies.
+ * @param opts.entitlements - the ride-entitlement ledger (503 when absent).
+ * @param opts.credits - the Ride Credit ledger (503 when absent).
+ * @param opts.rateLimit - rate-limit config (applied per user).
+ */
+export async function entitlementRoutes(
+  app: FastifyInstance,
+  opts: {
+    entitlements?: EntitlementLedgerRepository;
+    credits?: CreditLedgerRepository;
+    rateLimit: RateLimitConfig;
+  },
+): Promise<void> {
+  const r = app.withTypeProvider<ZodTypeProvider>();
+
+  r.get(
+    '/me/rides',
+    {
+      schema: {
+        tags: ['rides'],
+        summary: 'Remaining ride entitlement + Ride Credit balance',
+        security: [{ bearerAuth: [] }],
+        response: {
+          200: ridesResponseSchema,
+          401: errorResponseSchema,
+          429: errorResponseSchema,
+          503: errorResponseSchema,
+        },
+      },
+      preHandler: [app.authenticate, app.rateLimit({ ...opts.rateLimit, by: 'user' })],
+    },
+    async (request, reply) => {
+      if (!opts.entitlements || !opts.credits) {
+        return reply
+          .code(503)
+          .send({ error: 'unavailable', message: 'Entitlements are not configured' });
+      }
+      const userId = request.user!.id;
+      const [remainingRides, creditPesewas] = await Promise.all([
+        opts.entitlements.remainingRides(userId),
+        opts.credits.balancePesewas(userId),
+      ]);
+      return { remainingRides, creditPesewas };
+    },
+  );
+}

--- a/services/api/src/modules/entitlements/entitlements.schema.ts
+++ b/services/api/src/modules/entitlements/entitlements.schema.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+
+export const ridesResponseSchema = z.object({
+  /** Rides left in the current subscription period. */
+  remainingRides: z.number().int(),
+  /** Ride Credit balance in pesewas (carries toward the next renewal). */
+  creditPesewas: z.number().int(),
+});

--- a/services/api/src/modules/payments/payments.service.ts
+++ b/services/api/src/modules/payments/payments.service.ts
@@ -13,6 +13,7 @@
 // retried/partial webhook converges. Paystack retries; reconciliation (future)
 // backstops the rest.
 
+import type { EntitlementLedgerRepository } from '../entitlements/entitlement-ledger.repository';
 import type {
   SubscriptionPlan,
   SubscriptionRepository,
@@ -34,12 +35,19 @@ export class InvalidWebhookError extends Error {}
 
 /**
  * Membership fee in PESEWAS to be on the platform. Server-authoritative
- * (security.md §7). PLACEHOLDERS — replaced by the `plans` table in epic E1.
+ * (security.md §7). PLACEHOLDERS — replaced by the `plans` table in epic E1b.
  */
 export const SUBSCRIPTION_FEES_PESEWAS: Record<SubscriptionPlan, number> = {
   monthly: 2000, // GHS 20
   annual: 20000, // GHS 200
 };
+
+/**
+ * Rides granted when a subscription activates. PLACEHOLDER — the real formula
+ * (working-days × 2, per tier) lands with the `plans` table in epic E1b; this
+ * flat value keeps the allocation flow buildable now (ADR-0014).
+ */
+export const PLACEHOLDER_RIDES_PER_PERIOD = 44;
 
 /** Collaborators for {@link PaymentsService}, injected at app wiring (app.ts). */
 export interface PaymentsServiceDeps {
@@ -47,10 +55,14 @@ export interface PaymentsServiceDeps {
   payments: PaymentRepository;
   /** Platform memberships — activated on a successful subscription payment. */
   subscriptions: SubscriptionRepository;
+  /** Ride entitlement ledger — allocated on a successful subscription payment. */
+  entitlements: EntitlementLedgerRepository;
   /** Undefined when payments aren't configured (e.g. prod without a Paystack key). */
   paystack?: PaystackClient;
   /** Plan → membership fee in pesewas (server-authoritative). */
   subscriptionFees: Record<SubscriptionPlan, number>;
+  /** Rides allocated per activated period (placeholder until E1b tiers). */
+  ridesPerPeriod: number;
 }
 
 /**
@@ -158,12 +170,32 @@ export class PaymentsService {
     if (!payment) return; // unknown reference — not ours
 
     if (payment.purpose === 'subscription' && payment.plan) {
-      // Membership fee paid — activate the subscription.
+      // Membership fee paid — activate the subscription and allocate the
+      // period's rides. Both are idempotent, so a replayed webhook is a no-op.
       await this.activateSubscription(payment.userId, payment.plan);
+      await this.allocateEntitlement(payment.userId, reference);
     }
     // Legacy 'topup' payments (pre-ADR-0014 staging data) are ignored.
 
     await this.deps.payments.markPaid(reference);
+  }
+
+  /**
+   * Allocate the period's ride entitlement for a paid subscription. Keyed by the
+   * payment reference, so a re-delivered webhook never double-allocates.
+   *
+   * @param userId - the subscriber.
+   * @param reference - the payment reference (the allocation's idempotency key).
+   */
+  private async allocateEntitlement(userId: string, reference: string): Promise<void> {
+    await this.deps.entitlements.record({
+      userId,
+      deltaRides: this.deps.ridesPerPeriod,
+      reason: 'allocation',
+      refType: 'payment',
+      refId: reference,
+      idempotencyKey: `alloc:${reference}`,
+    });
   }
 
   /**

--- a/services/api/src/server.ts
+++ b/services/api/src/server.ts
@@ -48,7 +48,21 @@ import {
 import { PgPaymentRepository } from './modules/payments/payment.repository.pg';
 import { FakePaystackClient, type PaystackClient } from './modules/payments/paystack.client';
 import { PaystackHttpClient } from './modules/payments/paystack.client.live';
-import { PaymentsService, SUBSCRIPTION_FEES_PESEWAS } from './modules/payments/payments.service';
+import {
+  PaymentsService,
+  PLACEHOLDER_RIDES_PER_PERIOD,
+  SUBSCRIPTION_FEES_PESEWAS,
+} from './modules/payments/payments.service';
+import {
+  InMemoryEntitlementLedgerRepository,
+  type EntitlementLedgerRepository,
+} from './modules/entitlements/entitlement-ledger.repository';
+import { PgEntitlementLedgerRepository } from './modules/entitlements/entitlement-ledger.repository.pg';
+import {
+  InMemoryCreditLedgerRepository,
+  type CreditLedgerRepository,
+} from './modules/entitlements/credit-ledger.repository';
+import { PgCreditLedgerRepository } from './modules/entitlements/credit-ledger.repository.pg';
 import { InMemoryUserRepository, type UserRepository } from './modules/users/user.repository';
 import { PgUserRepository } from './modules/users/user.repository.pg';
 
@@ -98,6 +112,8 @@ async function main(): Promise<void> {
   let payments: PaymentRepository;
   let deviceTokens: DeviceTokenRepository;
   let scanEvents: ScanEventRepository;
+  let entitlements: EntitlementLedgerRepository;
+  let credits: CreditLedgerRepository;
   if (env.DATABASE_URL) {
     pool = createPool(env.DATABASE_URL);
     users = new PgUserRepository(pool);
@@ -107,6 +123,8 @@ async function main(): Promise<void> {
     payments = new PgPaymentRepository(pool);
     deviceTokens = new PgDeviceTokenRepository(pool);
     scanEvents = new PgScanEventRepository(pool);
+    entitlements = new PgEntitlementLedgerRepository(pool);
+    credits = new PgCreditLedgerRepository(pool);
     console.log('Using Postgres repositories');
   } else {
     users = new InMemoryUserRepository();
@@ -116,6 +134,8 @@ async function main(): Promise<void> {
     payments = new InMemoryPaymentRepository();
     deviceTokens = new InMemoryDeviceTokenRepository();
     scanEvents = new InMemoryScanEventRepository();
+    entitlements = new InMemoryEntitlementLedgerRepository();
+    credits = new InMemoryCreditLedgerRepository();
     console.log('Using in-memory repositories (no DATABASE_URL set)');
   }
 
@@ -166,8 +186,10 @@ async function main(): Promise<void> {
   const paymentsService = new PaymentsService({
     payments,
     subscriptions,
+    entitlements,
     paystack,
     subscriptionFees: SUBSCRIPTION_FEES_PESEWAS,
+    ridesPerPeriod: PLACEHOLDER_RIDES_PER_PERIOD,
   });
 
   // Readiness pings every configured backing service (DB + KV).
@@ -194,6 +216,8 @@ async function main(): Promise<void> {
     boardingService,
     authService,
     paymentsService,
+    entitlements,
+    credits,
     kv,
     objectStore,
     isReady,

--- a/services/api/tests/entitlements.test.ts
+++ b/services/api/tests/entitlements.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+import { buildApp } from '../src/app';
+import { InMemoryEntitlementLedgerRepository } from '../src/modules/entitlements/entitlement-ledger.repository';
+import { InMemoryCreditLedgerRepository } from '../src/modules/entitlements/credit-ledger.repository';
+import { createJwtService, type AuthConfig } from '../src/modules/auth/jwt';
+
+const auth: AuthConfig = {
+  secret: 'test-secret-at-least-32-characters-long-0000',
+  accessTtl: '15m',
+  issuer: 'trotxi',
+  audience: 'trotxi-api',
+};
+const jwt = createJwtService(auth);
+const bearer = (t: string) => ({ authorization: `Bearer ${t}` });
+
+describe('EntitlementLedger (ride counts)', () => {
+  it('remaining rides = sum of deltas', async () => {
+    const ledger = new InMemoryEntitlementLedgerRepository();
+    await ledger.record({
+      userId: 'u1',
+      deltaRides: 44,
+      reason: 'allocation',
+      idempotencyKey: 'a',
+    });
+    await ledger.record({ userId: 'u1', deltaRides: -1, reason: 'boarding', idempotencyKey: 'b' });
+    await ledger.record({
+      userId: 'u2',
+      deltaRides: 10,
+      reason: 'allocation',
+      idempotencyKey: 'c',
+    });
+    expect(await ledger.remainingRides('u1')).toBe(43);
+    expect(await ledger.remainingRides('u2')).toBe(10);
+    expect(await ledger.remainingRides('nobody')).toBe(0);
+  });
+
+  it('a duplicate idempotency key is a no-op', async () => {
+    const ledger = new InMemoryEntitlementLedgerRepository();
+    await ledger.record({
+      userId: 'u1',
+      deltaRides: 44,
+      reason: 'allocation',
+      idempotencyKey: 'k',
+    });
+    await ledger.record({
+      userId: 'u1',
+      deltaRides: 44,
+      reason: 'allocation',
+      idempotencyKey: 'k',
+    });
+    expect(await ledger.remainingRides('u1')).toBe(44);
+  });
+});
+
+describe('CreditLedger (pesewas)', () => {
+  it('balance = sum of deltas; duplicate key is a no-op', async () => {
+    const ledger = new InMemoryCreditLedgerRepository();
+    await ledger.record({
+      userId: 'u1',
+      deltaPesewas: 4000,
+      reason: 'month_end_conversion',
+      idempotencyKey: 'k',
+    });
+    await ledger.record({
+      userId: 'u1',
+      deltaPesewas: 4000,
+      reason: 'month_end_conversion',
+      idempotencyKey: 'k',
+    });
+    await ledger.record({
+      userId: 'u1',
+      deltaPesewas: -1000,
+      reason: 'renewal_applied',
+      idempotencyKey: 'r',
+    });
+    expect(await ledger.balancePesewas('u1')).toBe(3000);
+  });
+});
+
+describe('GET /me/rides', () => {
+  it('requires authentication', async () => {
+    const app = await buildApp({ auth });
+    expect((await app.inject({ method: 'GET', url: '/me/rides' })).statusCode).toBe(401);
+  });
+
+  it('returns remaining rides + credit balance for the caller', async () => {
+    const entitlements = new InMemoryEntitlementLedgerRepository();
+    const credits = new InMemoryCreditLedgerRepository();
+    await entitlements.record({
+      userId: 'rider-1',
+      deltaRides: 44,
+      reason: 'allocation',
+      idempotencyKey: 'a',
+    });
+    await credits.record({
+      userId: 'rider-1',
+      deltaPesewas: 4000,
+      reason: 'loyalty',
+      idempotencyKey: 'c',
+    });
+    const app = await buildApp({ auth, entitlements, credits });
+    const token = await jwt.signAccessToken({ userId: 'rider-1', role: 'commuter' });
+
+    const res = await app.inject({ method: 'GET', url: '/me/rides', headers: bearer(token) });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ remainingRides: 44, creditPesewas: 4000 });
+  });
+
+  it('defaults to zero for a rider with no ledger entries', async () => {
+    const app = await buildApp({ auth });
+    const token = await jwt.signAccessToken({ userId: 'newbie', role: 'commuter' });
+    const res = await app.inject({ method: 'GET', url: '/me/rides', headers: bearer(token) });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ remainingRides: 0, creditPesewas: 0 });
+  });
+});

--- a/services/api/tests/payments.routes.test.ts
+++ b/services/api/tests/payments.routes.test.ts
@@ -4,6 +4,7 @@ import { InMemoryPaymentRepository } from '../src/modules/payments/payment.repos
 import { FakePaystackClient, paystackSignature } from '../src/modules/payments/paystack.client';
 import { PaymentsService } from '../src/modules/payments/payments.service';
 import { InMemorySubscriptionRepository } from '../src/modules/subscriptions/subscription.repository';
+import { InMemoryEntitlementLedgerRepository } from '../src/modules/entitlements/entitlement-ledger.repository';
 import { createJwtService, type AuthConfig } from '../src/modules/auth/jwt';
 
 const auth: AuthConfig = {
@@ -18,13 +19,18 @@ const bearer = (t: string) => ({ authorization: `Bearer ${t}` });
 
 function appWithPayments() {
   const subscriptions = new InMemorySubscriptionRepository();
+  const entitlements = new InMemoryEntitlementLedgerRepository();
   const paymentsService = new PaymentsService({
     payments: new InMemoryPaymentRepository(),
     subscriptions,
+    entitlements,
     paystack: new FakePaystackClient(FAKE_SECRET),
     subscriptionFees: { monthly: 2000, annual: 20000 },
+    ridesPerPeriod: 44,
   });
-  return { subscriptions, build: buildApp({ auth, paymentsService }) };
+  // Share the entitlements instance with the app so GET /me/rides sees the
+  // rides the webhook allocates.
+  return { subscriptions, entitlements, build: buildApp({ auth, paymentsService, entitlements }) };
 }
 
 async function webhookFor(app: Awaited<ReturnType<typeof buildApp>>, reference: string) {
@@ -112,6 +118,15 @@ describe('POST /webhooks/paystack', () => {
 
     expect((await webhookFor(app, reference)).statusCode).toBe(200);
     expect(await subscriptions.findActiveByUser('rider-2')).not.toBeNull();
+
+    // …and the rider now has their allocated rides via GET /me/rides.
+    const rides = await app.inject({
+      method: 'GET',
+      url: '/me/rides',
+      headers: bearer(token),
+    });
+    expect(rides.statusCode).toBe(200);
+    expect(rides.json()).toMatchObject({ remainingRides: 44, creditPesewas: 0 });
   });
 
   it('rejects a bad signature with 401', async () => {

--- a/services/api/tests/payments.service.test.ts
+++ b/services/api/tests/payments.service.test.ts
@@ -10,19 +10,24 @@ import {
   InMemorySubscriptionRepository,
   type SubscriptionRepository,
 } from '../src/modules/subscriptions/subscription.repository';
+import { InMemoryEntitlementLedgerRepository } from '../src/modules/entitlements/entitlement-ledger.repository';
 
 const FAKE_SECRET = 'fake-paystack-secret';
 const subscriptionFees = { monthly: 2000, annual: 20000 }; // pesewas (GHS 20 / 200)
+const RIDES = 44;
 
 function make(subscriptions: SubscriptionRepository = new InMemorySubscriptionRepository()) {
   const payments = new InMemoryPaymentRepository();
+  const entitlements = new InMemoryEntitlementLedgerRepository();
   const service = new PaymentsService({
     payments,
     subscriptions,
+    entitlements,
     paystack: new FakePaystackClient(FAKE_SECRET),
     subscriptionFees,
+    ridesPerPeriod: RIDES,
   });
-  return { payments, subscriptions, service };
+  return { payments, subscriptions, entitlements, service };
 }
 
 function chargeSuccess(reference: string): { body: string; signature: string } {
@@ -47,7 +52,9 @@ describe('PaymentsService.initializeSubscription', () => {
     const service = new PaymentsService({
       payments: new InMemoryPaymentRepository(),
       subscriptions: new InMemorySubscriptionRepository(),
+      entitlements: new InMemoryEntitlementLedgerRepository(),
       subscriptionFees,
+      ridesPerPeriod: RIDES,
     });
     await expect(service.initializeSubscription('u1', 'monthly')).rejects.toBeInstanceOf(
       PaymentsNotConfiguredError,
@@ -61,25 +68,27 @@ describe('PaymentsService.handleWebhook', () => {
     await expect(service.handleWebhook('{}', 'bad')).rejects.toBeInstanceOf(InvalidWebhookError);
   });
 
-  it('subscription paid: activates the subscription and marks the payment paid', async () => {
-    const { service, subscriptions, payments } = make();
+  it('subscription paid: activates the subscription, allocates rides, marks paid', async () => {
+    const { service, subscriptions, payments, entitlements } = make();
     const { reference } = await service.initializeSubscription('u1', 'monthly');
     const { body, signature } = chargeSuccess(reference);
 
     await service.handleWebhook(body, signature);
 
     expect(await subscriptions.findActiveByUser('u1')).not.toBeNull();
+    expect(await entitlements.remainingRides('u1')).toBe(RIDES);
     expect((await payments.findByReference(reference))?.status).toBe('paid');
   });
 
-  it('is idempotent — a replayed webhook does not double-activate', async () => {
-    const { service, subscriptions } = make();
+  it('is idempotent — a replayed webhook does not double-activate or double-allocate', async () => {
+    const { service, subscriptions, entitlements } = make();
     const { reference } = await service.initializeSubscription('u1', 'monthly');
     const { body, signature } = chargeSuccess(reference);
 
     await service.handleWebhook(body, signature);
     await expect(service.handleWebhook(body, signature)).resolves.toBeUndefined();
     expect(await subscriptions.findActiveByUser('u1')).not.toBeNull();
+    expect(await entitlements.remainingRides('u1')).toBe(RIDES); // not 2×
   });
 
   it('ignores non charge.success events and unknown references', async () => {


### PR DESCRIPTION
Closes #100 (epic **E1**). The money foundation of the Hybrid Subscription Model (ADR-0014) — what the rest of the model deducts from. **This is the money/Paystack work for the new model** — no new plumbing, one added webhook step.

Built **in parallel with #108** (avatars) off `main`; the only overlap is a few wiring lines in `app.ts`/`server.ts` — I'll resolve whichever rebases second.

### What
- **Two append-only, idempotent ledgers** (repository pattern, ADR-0009) — the no-lost-update shape of the old token wallet, reused twice:
  - `entitlement_ledger` (ride counts): `remainingRides = SUM(delta_rides)`
  - `credit_ledger` (pesewas): `balance = SUM(delta_pesewas)`
- **Allocation on payment:** the Paystack `charge.success` webhook, on activating a subscription, also allocates the period's rides — **keyed by payment reference, so a replayed webhook never double-allocates** (activation + allocation both idempotent).
- **`GET /me/rides`** — remaining rides + Ride Credit balance (replaces the removed wallet `GET /me/balance`; unblocks FE #35).
- Rides/period is a **placeholder constant (44)** until the `plans` table (E1b) — same posture as `SUBSCRIPTION_FEES_PESEWAS`.

### Tests
6 new: ledger sums + idempotency (both ledgers), `GET /me/rides` (auth, values, zero-default), webhook allocation + **idempotent replay**, and a subscribe→webhook→`/me/rides` e2e. **127 green**, coverage gate passes, migrations 011/012.

### Deferred (separate issues)
Plan tiers/prices (E1b #103), boarding deduction + no-show (E4 #102), month-end conversion + netted renewal (E5 #104).