### PR TITLE
feat(api): daily ride confirmation — reservations + confirm/decline (#101, E3 core)

### DIFF
--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -22,6 +22,7 @@ repo (`system-design.md`, `security.md`). Each doc links to both.
 | Profile & avatars — `PATCH /me`, avatar upload → R2 (photo pass) (#24)      | [profile-avatars.md](profile-avatars.md)         | ✅ live                                |
 | Payments — Paystack subscribe + webhook (wallet/ledger removed, ADR-0014)   | [payments-and-wallet.md](payments-and-wallet.md) | 🔄 model pivoted (Hybrid Subscription) |
 | Ride entitlements & credits — `GET /me/rides`, allocation on payment (#100) | [entitlements.md](entitlements.md)               | ✅ E1 (ledgers + allocation)           |
+| Daily ride confirmation — `POST /me/reservations` (confirm/decline) (#101)  | [reservations.md](reservations.md)               | 🟡 E3 core (ask-dispatch deferred #18) |
 | Mobility — routes, stops, browse                                            | _(in review — #57)_                              | 🚧                                     |
 | Rate limiting (#23)                                                         | [rate-limiting.md](rate-limiting.md)             | ✅ live                                |
 | Boarding — QR passes + scan verification (#20)                              | [boarding.md](boarding.md)                       | 🟡 integrity slice                     |

--- a/docs/features/reservations.md
+++ b/docs/features/reservations.md
@@ -1,0 +1,85 @@
+# Daily ride confirmation (reservations)
+
+**Owner:** Godfred Awuku · **Last updated:** 2026-07-05 · **Issue:** #101 (epic E3)
+
+The **daily confirmation loop** of the Hybrid Subscription Model (ADR-0014). Each
+travel day the rider is asked "travelling tomorrow morning?" / "this evening?";
+they confirm or decline, and a **no-response defaults to travelling** at the
+cutoff. A reservation is what boarding (E4) verifies against and what the standby
+pool (E6) fills when declined.
+
+> **Scope shipped (E3-core):** the reservation lifecycle + the rider's
+> confirm/decline API + the default-yes operation. **Deferred to when trips (#18)
+> land:** the scheduled _ask-dispatch_ (which seeds `pending` rows for tomorrow's
+> trips and sends the FCM push) and seat **capacity / release** to standby. So
+> `trip_id` carries **no FK yet** (same as `scan_events`).
+
+---
+
+## Model
+
+One reservation per **rider × travel day × direction** (`morning` | `evening`).
+
+- **status:** `pending` (asked, awaiting reply) → `reserved` (travelling) |
+  `declined`; then `boarded` | `no_show` (E4), `released` (E6),
+  `operator_cancelled`.
+- **source:** `confirmation` (rider answered), `default` (no reply → defaulted),
+  `standby` (E6).
+
+**Confirmation windows** (from the master doc; drive the future cron):
+morning ask 18:00–20:45, **cutoff 21:00**; evening ask 12:00–13:45,
+**cutoff 14:00**. At each cutoff, `markDefaultTravelling(date, direction)` flips
+the still-`pending` rows to `reserved`/`default`.
+
+---
+
+## API
+
+#### `POST /me/reservations`
+
+Confirm or decline (an upsert per day+direction).
+
+- **Auth:** `Bearer`. **Rate limit:** per user.
+- **Body:** `{ "tripId?": "<uuid>", "travelDate": "YYYY-MM-DD", "direction": "morning"|"evening", "travelling": true|false }`
+- **200:** the reservation `{ id, tripId, travelDate, direction, status, source }`
+  (`reserved` when travelling, else `declined`) · **400** bad date · **401** · **429** · **503**
+
+#### `GET /me/reservations?from=YYYY-MM-DD`
+
+The rider's reservations, newest travel day first.
+
+- **200:** `{ "reservations": [ … ] }`
+
+---
+
+## Data
+
+`reservations(id, user_id, trip_id, travel_date, direction, status, source,
+confirmed_at, created_at, updated_at)`, unique `(user_id, travel_date,
+direction)`. `trip_id` has no FK yet (trips are #18).
+
+## Deferred (with #18)
+
+- **Ask-dispatch cron** — for each subscribed rider on tomorrow's trips, seed a
+  `pending` row (`createPending`) and send the FCM prompt; run
+  `markDefaultTravelling` at each cutoff. Needs trips + capacity.
+- **FCM push** — the notification sender (Firebase Admin) — needs the Firebase
+  service account (adomfosugit, #88–90).
+- **Deduction** — a confirmed no-show / a boarding consumes a ride (E4).
+
+## Where the code lives
+
+```
+services/api/src/modules/reservations/
+  reservation.repository.ts(.pg)   # lifecycle: respond, createPending,
+                                   # markDefaultTravelling, listForUser, find
+  reservations.routes.ts           # POST /me/reservations, GET /me/reservations
+  reservations.schema.ts
+services/api/src/db/migrations/013_reservations.sql
+```
+
+## Related
+
+- [ADR-0014 — Hybrid Subscription Model](../adr/0014-hybrid-subscription-model.md)
+- `strategy/docs/hybrid-subscription-model.md` (epics E1–E7)
+- [entitlements.md](entitlements.md) (E1) · [boarding.md](boarding.md) (E4 deducts against a reservation)

--- a/services/api/src/app.ts
+++ b/services/api/src/app.ts
@@ -29,6 +29,11 @@ import {
   InMemoryCreditLedgerRepository,
   type CreditLedgerRepository,
 } from './modules/entitlements/credit-ledger.repository';
+import { reservationRoutes } from './modules/reservations/reservations.routes';
+import {
+  InMemoryReservationRepository,
+  type ReservationRepository,
+} from './modules/reservations/reservation.repository';
 import { paymentRoutes } from './modules/payments/payments.routes';
 import type { PaymentsService } from './modules/payments/payments.service';
 import { authPlugin } from './modules/auth/auth.plugin';
@@ -63,6 +68,8 @@ export interface AppDeps {
   entitlements?: EntitlementLedgerRepository;
   /** Ride Credit ledger (in-memory vs Postgres). Defaults to in-memory. */
   credits?: CreditLedgerRepository;
+  /** Daily reservation store (in-memory vs Postgres). Defaults to in-memory. */
+  reservations?: ReservationRepository;
   /** Selected by REDIS_URL (in-memory vs Redis). For rate limits, idempotency, cache. */
   kv?: KvStore;
   /** Avatar/media storage (R2 in prod, in-memory Fake in dev/tests). */
@@ -114,6 +121,7 @@ export async function buildApp(deps: AppDeps = {}): Promise<FastifyInstance> {
         { name: 'auth', description: 'Authentication and the current user' },
         { name: 'payments', description: 'Subscriptions checkout (Paystack) + webhook' },
         { name: 'rides', description: 'Ride entitlement + Ride Credit balance' },
+        { name: 'reservations', description: 'Daily ride confirmation (confirm/decline)' },
         { name: 'boarding', description: 'QR boarding passes + scan verification' },
       ],
       components: {
@@ -162,6 +170,10 @@ export async function buildApp(deps: AppDeps = {}): Promise<FastifyInstance> {
   await app.register(entitlementRoutes, {
     entitlements: deps.entitlements ?? new InMemoryEntitlementLedgerRepository(),
     credits: deps.credits ?? new InMemoryCreditLedgerRepository(),
+    rateLimit: deps.rateLimit ?? DEFAULT_RATE_LIMIT,
+  });
+  await app.register(reservationRoutes, {
+    reservations: deps.reservations ?? new InMemoryReservationRepository(),
     rateLimit: deps.rateLimit ?? DEFAULT_RATE_LIMIT,
   });
   await app.register(boardingRoutes, {

--- a/services/api/src/db/migrations/013_reservations.sql
+++ b/services/api/src/db/migrations/013_reservations.sql
@@ -1,0 +1,22 @@
+-- 013_reservations: the daily ride confirmation (ADR-0014, epic E3). One row per
+-- rider per travel day per direction (morning/evening): the rider confirms or
+-- declines the trip, and at the cutoff any still-`pending` row defaults to
+-- travelling (source 'default'). A verified boarding / no-show / operator-cancel
+-- move it to a terminal state (E4/E6). trip_id has no FK yet — trips are #18.
+CREATE TABLE IF NOT EXISTS reservations (
+  id           uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id      uuid NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+  trip_id      uuid,                       -- no FK yet (trips are #18)
+  travel_date  date NOT NULL,
+  direction    text NOT NULL CHECK (direction IN ('morning', 'evening')),
+  status       text NOT NULL CHECK (status IN ('pending', 'reserved', 'declined', 'boarded', 'no_show', 'released', 'operator_cancelled')),
+  source       text NOT NULL CHECK (source IN ('confirmation', 'default', 'standby')),
+  confirmed_at timestamptz,
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  updated_at   timestamptz NOT NULL DEFAULT now(),
+  -- one reservation per rider per day per direction (the confirmation is a upsert)
+  UNIQUE (user_id, travel_date, direction)
+);
+CREATE INDEX IF NOT EXISTS idx_reservations_user ON reservations (user_id);
+CREATE INDEX IF NOT EXISTS idx_reservations_trip ON reservations (trip_id);
+CREATE INDEX IF NOT EXISTS idx_reservations_date_dir ON reservations (travel_date, direction);

--- a/services/api/src/modules/reservations/reservation.repository.pg.ts
+++ b/services/api/src/modules/reservations/reservation.repository.pg.ts
@@ -1,0 +1,105 @@
+import type { Pool } from 'pg';
+import type {
+  Reservation,
+  ReservationDirection,
+  ReservationRepository,
+  ReservationResponse,
+  ReservationStatus,
+  ReservationSource,
+  PendingReservation,
+} from './reservation.repository';
+
+interface ReservationRow {
+  id: string;
+  user_id: string;
+  trip_id: string | null;
+  travel_date: string; // pg returns DATE as 'YYYY-MM-DD'
+  direction: ReservationDirection;
+  status: ReservationStatus;
+  source: ReservationSource;
+  confirmed_at: Date | null;
+  created_at: Date;
+  updated_at: Date;
+}
+
+function toReservation(row: ReservationRow): Reservation {
+  return {
+    id: row.id,
+    userId: row.user_id,
+    tripId: row.trip_id,
+    travelDate: row.travel_date,
+    direction: row.direction,
+    status: row.status,
+    source: row.source,
+    confirmedAt: row.confirmed_at,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+export class PgReservationRepository implements ReservationRepository {
+  constructor(private readonly pool: Pool) {}
+
+  async respond(input: ReservationResponse): Promise<Reservation> {
+    const status: ReservationStatus = input.travelling ? 'reserved' : 'declined';
+    const { rows } = await this.pool.query<ReservationRow>(
+      `INSERT INTO reservations (user_id, trip_id, travel_date, direction, status, source, confirmed_at)
+       VALUES ($1, $2, $3, $4, $5, 'confirmation', now())
+       ON CONFLICT (user_id, travel_date, direction)
+       DO UPDATE SET trip_id = COALESCE(EXCLUDED.trip_id, reservations.trip_id),
+                     status = EXCLUDED.status,
+                     source = 'confirmation',
+                     confirmed_at = now(),
+                     updated_at = now()
+       RETURNING *`,
+      [input.userId, input.tripId ?? null, input.travelDate, input.direction, status],
+    );
+    return toReservation(rows[0]!);
+  }
+
+  async createPending(input: PendingReservation): Promise<Reservation> {
+    const { rows } = await this.pool.query<ReservationRow>(
+      `INSERT INTO reservations (user_id, trip_id, travel_date, direction, status, source)
+       VALUES ($1, $2, $3, $4, 'pending', 'confirmation')
+       ON CONFLICT (user_id, travel_date, direction) DO UPDATE SET updated_at = reservations.updated_at
+       RETURNING *`,
+      [input.userId, input.tripId ?? null, input.travelDate, input.direction],
+    );
+    return toReservation(rows[0]!);
+  }
+
+  async markDefaultTravelling(
+    travelDate: string,
+    direction: ReservationDirection,
+  ): Promise<number> {
+    const { rowCount } = await this.pool.query(
+      `UPDATE reservations
+         SET status = 'reserved', source = 'default', confirmed_at = now(), updated_at = now()
+       WHERE travel_date = $1 AND direction = $2 AND status = 'pending'`,
+      [travelDate, direction],
+    );
+    return rowCount ?? 0;
+  }
+
+  async listForUser(userId: string, opts?: { fromDate?: string }): Promise<Reservation[]> {
+    const { rows } = await this.pool.query<ReservationRow>(
+      `SELECT * FROM reservations
+       WHERE user_id = $1 AND ($2::date IS NULL OR travel_date >= $2::date)
+       ORDER BY travel_date DESC, direction`,
+      [userId, opts?.fromDate ?? null],
+    );
+    return rows.map(toReservation);
+  }
+
+  async find(
+    userId: string,
+    travelDate: string,
+    direction: ReservationDirection,
+  ): Promise<Reservation | null> {
+    const { rows } = await this.pool.query<ReservationRow>(
+      `SELECT * FROM reservations WHERE user_id = $1 AND travel_date = $2 AND direction = $3`,
+      [userId, travelDate, direction],
+    );
+    return rows[0] ? toReservation(rows[0]) : null;
+  }
+}

--- a/services/api/src/modules/reservations/reservation.repository.ts
+++ b/services/api/src/modules/reservations/reservation.repository.ts
@@ -1,0 +1,213 @@
+// Reservations — the daily ride confirmation (ADR-0014, epic E3). A rider
+// confirms or declines each travel day/direction; a still-`pending` row defaults
+// to travelling at the cutoff. Repository pattern (ADR-0009): interface +
+// InMemory here, Postgres in *.pg.ts.
+//
+// Scope of E3-core: the reservation lifecycle + the rider's confirm/decline API.
+// Deferred to when trips (#18) land: the scheduled ask-dispatch that seeds
+// `pending` rows for tomorrow's trips, the FCM push that asks, and capacity /
+// seat-release to the standby pool (E6).
+
+/** Which leg of the day a reservation is for. */
+export type ReservationDirection = 'morning' | 'evening';
+
+/** Lifecycle state of a reservation. */
+export type ReservationStatus =
+  | 'pending' // asked, awaiting the rider's response
+  | 'reserved' // travelling (confirmed, or defaulted at cutoff)
+  | 'declined' // rider said no; the seat is released
+  | 'boarded' // verified onto the vehicle (E4)
+  | 'no_show' // confirmed but didn't board — deducted (E4)
+  | 'released' // freed to the standby pool (E6)
+  | 'operator_cancelled'; // Trotxi couldn't run it — no deduction
+
+/** How a reservation reached its current state. */
+export type ReservationSource = 'confirmation' | 'default' | 'standby';
+
+/** A rider's reservation for one trip on one day. */
+export interface Reservation {
+  id: string;
+  userId: string;
+  /** The trip, when known (no FK yet — trips are #18). */
+  tripId: string | null;
+  /** The travel day as `YYYY-MM-DD`. */
+  travelDate: string;
+  direction: ReservationDirection;
+  status: ReservationStatus;
+  source: ReservationSource;
+  /** When the rider (or the default) settled the reservation. */
+  confirmedAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/** A rider's confirm/decline response to the daily prompt. */
+export interface ReservationResponse {
+  userId: string;
+  tripId?: string | null;
+  travelDate: string;
+  direction: ReservationDirection;
+  /** true → reserve the seat; false → decline it. */
+  travelling: boolean;
+}
+
+/** Seed of a `pending` reservation (the ask-dispatch creates these; #18). */
+export interface PendingReservation {
+  userId: string;
+  tripId?: string | null;
+  travelDate: string;
+  direction: ReservationDirection;
+}
+
+/** Persistence for daily reservations (Postgres in prod, in-memory in dev/tests). */
+export interface ReservationRepository {
+  /**
+   * Record a rider's confirm/decline for a day+direction (an upsert — the daily
+   * prompt is answered at most once, and a change of mind overwrites).
+   *
+   * @param input - who, which trip/day/direction, and whether they're travelling.
+   * @returns the resulting reservation.
+   */
+  respond(input: ReservationResponse): Promise<Reservation>;
+  /**
+   * Seed a `pending` reservation (the scheduled ask-dispatch; #18). A duplicate
+   * day+direction for the rider is left untouched.
+   *
+   * @param input - who, which trip, day, and direction.
+   * @returns the pending reservation (existing one if already present).
+   */
+  createPending(input: PendingReservation): Promise<Reservation>;
+  /**
+   * Default-yes at the cutoff: flip every still-`pending` reservation for a
+   * day+direction to `reserved` (source `default`). Declined/confirmed rows are
+   * untouched.
+   *
+   * @param travelDate - the travel day (`YYYY-MM-DD`).
+   * @param direction - morning or evening.
+   * @returns how many reservations were defaulted.
+   */
+  markDefaultTravelling(travelDate: string, direction: ReservationDirection): Promise<number>;
+  /**
+   * List a rider's reservations, newest travel day first.
+   *
+   * @param userId - the rider.
+   * @param opts - optional filters.
+   * @param opts.fromDate - lower bound (`YYYY-MM-DD`); omit for all.
+   * @returns the rider's reservations.
+   */
+  listForUser(userId: string, opts?: { fromDate?: string }): Promise<Reservation[]>;
+  /**
+   * Find a rider's reservation for a specific day+direction.
+   *
+   * @param userId - the rider.
+   * @param travelDate - the travel day (`YYYY-MM-DD`).
+   * @param direction - morning or evening.
+   * @returns the reservation, or null.
+   */
+  find(
+    userId: string,
+    travelDate: string,
+    direction: ReservationDirection,
+  ): Promise<Reservation | null>;
+}
+
+/** In-memory {@link ReservationRepository} for dev and unit tests. */
+export class InMemoryReservationRepository implements ReservationRepository {
+  private readonly rows: Reservation[] = [];
+
+  private key(userId: string, travelDate: string, direction: ReservationDirection): string {
+    return `${userId}|${travelDate}|${direction}`;
+  }
+
+  private index(userId: string, travelDate: string, direction: ReservationDirection): number {
+    return this.rows.findIndex(
+      (r) =>
+        this.key(r.userId, r.travelDate, r.direction) === this.key(userId, travelDate, direction),
+    );
+  }
+
+  async respond(input: ReservationResponse): Promise<Reservation> {
+    const now = new Date();
+    const status: ReservationStatus = input.travelling ? 'reserved' : 'declined';
+    const i = this.index(input.userId, input.travelDate, input.direction);
+    if (i >= 0) {
+      const updated: Reservation = {
+        ...this.rows[i]!,
+        tripId: input.tripId ?? this.rows[i]!.tripId,
+        status,
+        source: 'confirmation',
+        confirmedAt: now,
+        updatedAt: now,
+      };
+      this.rows[i] = updated;
+      return updated;
+    }
+    const created: Reservation = {
+      id: crypto.randomUUID(),
+      userId: input.userId,
+      tripId: input.tripId ?? null,
+      travelDate: input.travelDate,
+      direction: input.direction,
+      status,
+      source: 'confirmation',
+      confirmedAt: now,
+      createdAt: now,
+      updatedAt: now,
+    };
+    this.rows.push(created);
+    return created;
+  }
+
+  async createPending(input: PendingReservation): Promise<Reservation> {
+    const existing = this.index(input.userId, input.travelDate, input.direction);
+    if (existing >= 0) return this.rows[existing]!;
+    const now = new Date();
+    const created: Reservation = {
+      id: crypto.randomUUID(),
+      userId: input.userId,
+      tripId: input.tripId ?? null,
+      travelDate: input.travelDate,
+      direction: input.direction,
+      status: 'pending',
+      source: 'confirmation',
+      confirmedAt: null,
+      createdAt: now,
+      updatedAt: now,
+    };
+    this.rows.push(created);
+    return created;
+  }
+
+  async markDefaultTravelling(
+    travelDate: string,
+    direction: ReservationDirection,
+  ): Promise<number> {
+    let count = 0;
+    const now = new Date();
+    for (const r of this.rows) {
+      if (r.travelDate === travelDate && r.direction === direction && r.status === 'pending') {
+        r.status = 'reserved';
+        r.source = 'default';
+        r.confirmedAt = now;
+        r.updatedAt = now;
+        count++;
+      }
+    }
+    return count;
+  }
+
+  async listForUser(userId: string, opts?: { fromDate?: string }): Promise<Reservation[]> {
+    return this.rows
+      .filter((r) => r.userId === userId && (!opts?.fromDate || r.travelDate >= opts.fromDate))
+      .sort((a, b) => (a.travelDate < b.travelDate ? 1 : -1));
+  }
+
+  async find(
+    userId: string,
+    travelDate: string,
+    direction: ReservationDirection,
+  ): Promise<Reservation | null> {
+    const i = this.index(userId, travelDate, direction);
+    return i >= 0 ? this.rows[i]! : null;
+  }
+}

--- a/services/api/src/modules/reservations/reservations.routes.ts
+++ b/services/api/src/modules/reservations/reservations.routes.ts
@@ -1,0 +1,107 @@
+// Reservation routes (#101, epic E3). The rider answers the daily "travelling?"
+// prompt here (confirm/decline) and lists their upcoming reservations. The
+// scheduled ask-dispatch + default-yes cron and the FCM push are deferred until
+// trips (#18) land — see the module header.
+
+import type { FastifyInstance } from 'fastify';
+import type { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { errorResponseSchema } from '../../lib/schemas';
+import type { RateLimitConfig } from '../ratelimit/ratelimit.plugin';
+import type { Reservation, ReservationRepository } from './reservation.repository';
+import {
+  listReservationsQuerySchema,
+  reservationListResponseSchema,
+  reservationResponseSchema,
+  respondBodySchema,
+} from './reservations.schema';
+
+// Map a stored reservation to its public (client-facing) shape.
+function toResponse(r: Reservation): {
+  id: string;
+  tripId: string | null;
+  travelDate: string;
+  direction: Reservation['direction'];
+  status: Reservation['status'];
+  source: Reservation['source'];
+} {
+  return {
+    id: r.id,
+    tripId: r.tripId,
+    travelDate: r.travelDate,
+    direction: r.direction,
+    status: r.status,
+    source: r.source,
+  };
+}
+
+/**
+ * Register reservation routes: `POST /me/reservations` and `GET /me/reservations`.
+ *
+ * @param app - the Fastify instance to register on.
+ * @param opts - route dependencies.
+ * @param opts.reservations - the reservation repository (503 when absent).
+ * @param opts.rateLimit - rate-limit config (applied per user).
+ */
+export async function reservationRoutes(
+  app: FastifyInstance,
+  opts: { reservations?: ReservationRepository; rateLimit: RateLimitConfig },
+): Promise<void> {
+  const r = app.withTypeProvider<ZodTypeProvider>();
+  const UNAVAILABLE = { error: 'unavailable', message: 'Reservations are not configured' };
+
+  r.post(
+    '/me/reservations',
+    {
+      schema: {
+        tags: ['reservations'],
+        summary: 'Confirm or decline the daily ride (upsert per day + direction)',
+        security: [{ bearerAuth: [] }],
+        body: respondBodySchema,
+        response: {
+          200: reservationResponseSchema,
+          401: errorResponseSchema,
+          429: errorResponseSchema,
+          503: errorResponseSchema,
+        },
+      },
+      preHandler: [app.authenticate, app.rateLimit({ ...opts.rateLimit, by: 'user' })],
+    },
+    async (request, reply) => {
+      if (!opts.reservations) return reply.code(503).send(UNAVAILABLE);
+      const reservation = await opts.reservations.respond({
+        userId: request.user!.id,
+        tripId: request.body.tripId ?? null,
+        travelDate: request.body.travelDate,
+        direction: request.body.direction,
+        travelling: request.body.travelling,
+      });
+      return toResponse(reservation);
+    },
+  );
+
+  r.get(
+    '/me/reservations',
+    {
+      schema: {
+        tags: ['reservations'],
+        summary: "List the rider's reservations (newest travel day first)",
+        security: [{ bearerAuth: [] }],
+        querystring: listReservationsQuerySchema,
+        response: {
+          200: reservationListResponseSchema,
+          401: errorResponseSchema,
+          429: errorResponseSchema,
+          503: errorResponseSchema,
+        },
+      },
+      preHandler: [app.authenticate, app.rateLimit({ ...opts.rateLimit, by: 'user' })],
+    },
+    async (request, reply) => {
+      if (!opts.reservations) return reply.code(503).send(UNAVAILABLE);
+      const rows = await opts.reservations.listForUser(request.user!.id, {
+        fromDate: request.query.from,
+      });
+      return { reservations: rows.map(toResponse) };
+    },
+  );
+}

--- a/services/api/src/modules/reservations/reservations.schema.ts
+++ b/services/api/src/modules/reservations/reservations.schema.ts
@@ -1,0 +1,42 @@
+import { z } from 'zod';
+
+const directionSchema = z.enum(['morning', 'evening']);
+
+export const respondBodySchema = z.object({
+  /** The trip being confirmed (optional until trips land, #18). */
+  tripId: z.string().uuid().optional(),
+  /** Travel day as `YYYY-MM-DD`. */
+  travelDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'expected YYYY-MM-DD'),
+  direction: directionSchema,
+  /** true → reserve the seat; false → decline. */
+  travelling: z.boolean(),
+});
+
+export const listReservationsQuerySchema = z.object({
+  /** Optional lower bound (`YYYY-MM-DD`) — defaults to all. */
+  from: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, 'expected YYYY-MM-DD')
+    .optional(),
+});
+
+export const reservationResponseSchema = z.object({
+  id: z.string().uuid(),
+  tripId: z.string().nullable(),
+  travelDate: z.string(),
+  direction: directionSchema,
+  status: z.enum([
+    'pending',
+    'reserved',
+    'declined',
+    'boarded',
+    'no_show',
+    'released',
+    'operator_cancelled',
+  ]),
+  source: z.enum(['confirmation', 'default', 'standby']),
+});
+
+export const reservationListResponseSchema = z.object({
+  reservations: z.array(reservationResponseSchema),
+});

--- a/services/api/src/server.ts
+++ b/services/api/src/server.ts
@@ -63,6 +63,11 @@ import {
   type CreditLedgerRepository,
 } from './modules/entitlements/credit-ledger.repository';
 import { PgCreditLedgerRepository } from './modules/entitlements/credit-ledger.repository.pg';
+import {
+  InMemoryReservationRepository,
+  type ReservationRepository,
+} from './modules/reservations/reservation.repository';
+import { PgReservationRepository } from './modules/reservations/reservation.repository.pg';
 import { InMemoryUserRepository, type UserRepository } from './modules/users/user.repository';
 import { PgUserRepository } from './modules/users/user.repository.pg';
 
@@ -114,6 +119,7 @@ async function main(): Promise<void> {
   let scanEvents: ScanEventRepository;
   let entitlements: EntitlementLedgerRepository;
   let credits: CreditLedgerRepository;
+  let reservations: ReservationRepository;
   if (env.DATABASE_URL) {
     pool = createPool(env.DATABASE_URL);
     users = new PgUserRepository(pool);
@@ -125,6 +131,7 @@ async function main(): Promise<void> {
     scanEvents = new PgScanEventRepository(pool);
     entitlements = new PgEntitlementLedgerRepository(pool);
     credits = new PgCreditLedgerRepository(pool);
+    reservations = new PgReservationRepository(pool);
     console.log('Using Postgres repositories');
   } else {
     users = new InMemoryUserRepository();
@@ -136,6 +143,7 @@ async function main(): Promise<void> {
     scanEvents = new InMemoryScanEventRepository();
     entitlements = new InMemoryEntitlementLedgerRepository();
     credits = new InMemoryCreditLedgerRepository();
+    reservations = new InMemoryReservationRepository();
     console.log('Using in-memory repositories (no DATABASE_URL set)');
   }
 
@@ -218,6 +226,7 @@ async function main(): Promise<void> {
     paymentsService,
     entitlements,
     credits,
+    reservations,
     kv,
     objectStore,
     isReady,

--- a/services/api/tests/reservations.test.ts
+++ b/services/api/tests/reservations.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest';
+import { buildApp } from '../src/app';
+import { InMemoryReservationRepository } from '../src/modules/reservations/reservation.repository';
+import { createJwtService, type AuthConfig } from '../src/modules/auth/jwt';
+
+const auth: AuthConfig = {
+  secret: 'test-secret-at-least-32-characters-long-0000',
+  accessTtl: '15m',
+  issuer: 'trotxi',
+  audience: 'trotxi-api',
+};
+const jwt = createJwtService(auth);
+const bearer = (t: string) => ({ authorization: `Bearer ${t}` });
+const DATE = '2026-07-06';
+
+describe('ReservationRepository', () => {
+  it('respond upserts: confirm → reserved, decline → declined, re-answer overwrites', async () => {
+    const repo = new InMemoryReservationRepository();
+    const base = { userId: 'u1', travelDate: DATE, direction: 'morning' as const };
+
+    let res = await repo.respond({ ...base, travelling: true });
+    expect(res).toMatchObject({ status: 'reserved', source: 'confirmation' });
+
+    res = await repo.respond({ ...base, travelling: false }); // changed mind
+    expect(res.status).toBe('declined');
+
+    // still one row for that day+direction
+    expect(await repo.listForUser('u1')).toHaveLength(1);
+  });
+
+  it('default-yes: pending flips to reserved(default); declined/reserved untouched', async () => {
+    const repo = new InMemoryReservationRepository();
+    await repo.createPending({ userId: 'a', travelDate: DATE, direction: 'morning' });
+    await repo.respond({ userId: 'b', travelDate: DATE, direction: 'morning', travelling: false });
+    await repo.respond({ userId: 'c', travelDate: DATE, direction: 'morning', travelling: true });
+    // a different direction stays pending
+    await repo.createPending({ userId: 'a', travelDate: DATE, direction: 'evening' });
+
+    const count = await repo.markDefaultTravelling(DATE, 'morning');
+    expect(count).toBe(1); // only 'a' morning
+
+    expect(await repo.find('a', DATE, 'morning')).toMatchObject({
+      status: 'reserved',
+      source: 'default',
+    });
+    expect((await repo.find('b', DATE, 'morning'))?.status).toBe('declined');
+    expect((await repo.find('c', DATE, 'morning'))?.source).toBe('confirmation');
+    expect((await repo.find('a', DATE, 'evening'))?.status).toBe('pending'); // other direction
+  });
+
+  it('createPending is idempotent per day+direction', async () => {
+    const repo = new InMemoryReservationRepository();
+    await repo.createPending({ userId: 'a', travelDate: DATE, direction: 'morning' });
+    await repo.createPending({ userId: 'a', travelDate: DATE, direction: 'morning' });
+    expect(await repo.listForUser('a')).toHaveLength(1);
+  });
+
+  it('listForUser filters by fromDate and sorts newest first', async () => {
+    const repo = new InMemoryReservationRepository();
+    await repo.respond({
+      userId: 'u1',
+      travelDate: '2026-07-01',
+      direction: 'morning',
+      travelling: true,
+    });
+    await repo.respond({
+      userId: 'u1',
+      travelDate: '2026-07-10',
+      direction: 'morning',
+      travelling: true,
+    });
+    const list = await repo.listForUser('u1', { fromDate: '2026-07-05' });
+    expect(list).toHaveLength(1);
+    expect(list[0]!.travelDate).toBe('2026-07-10');
+  });
+});
+
+describe('POST /me/reservations', () => {
+  it('requires authentication', async () => {
+    const app = await buildApp({ auth });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/me/reservations',
+      payload: { travelDate: DATE, direction: 'morning', travelling: true },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('confirms a ride → reserved, and lists it', async () => {
+    const reservations = new InMemoryReservationRepository();
+    const app = await buildApp({ auth, reservations });
+    const token = await jwt.signAccessToken({ userId: 'rider-1', role: 'commuter' });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/me/reservations',
+      headers: bearer(token),
+      payload: { travelDate: DATE, direction: 'morning', travelling: true },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({
+      status: 'reserved',
+      source: 'confirmation',
+      direction: 'morning',
+    });
+
+    const list = await app.inject({
+      method: 'GET',
+      url: '/me/reservations',
+      headers: bearer(token),
+    });
+    expect(list.json().reservations).toHaveLength(1);
+  });
+
+  it('declining returns declined', async () => {
+    const app = await buildApp({ auth, reservations: new InMemoryReservationRepository() });
+    const token = await jwt.signAccessToken({ userId: 'rider-2', role: 'commuter' });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/me/reservations',
+      headers: bearer(token),
+      payload: { travelDate: DATE, direction: 'evening', travelling: false },
+    });
+    expect(res.json().status).toBe('declined');
+  });
+
+  it('rejects a malformed travelDate (400)', async () => {
+    const app = await buildApp({ auth, reservations: new InMemoryReservationRepository() });
+    const token = await jwt.signAccessToken({ userId: 'rider-3', role: 'commuter' });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/me/reservations',
+      headers: bearer(token),
+      payload: { travelDate: '06-07-2026', direction: 'morning', travelling: true },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+});


### PR DESCRIPTION
Part of #101 (epic **E3**). The daily confirmation loop of the Hybrid Subscription Model (ADR-0014).

### Scope — E3 core (rider lifecycle), built now
- **`reservations` table (013):** one row per rider × travel day × direction; full status lifecycle (`pending`/`reserved`/`declined`/`boarded`/`no_show`/`released`/`operator_cancelled`) + `source`. `trip_id` has **no FK yet** — trips are #18 (same pattern as `scan_events`).
- **`ReservationRepository`** (interface + InMemory + Pg): `respond` (confirm/decline upsert), `createPending` (ask-dispatch seed), **`markDefaultTravelling`** (no-response → `reserved`/`default` at cutoff), `listForUser`, `find`.
- **`POST /me/reservations`** (confirm/decline), **`GET /me/reservations`** — guarded, per-user rate limited. **Unblocks the FE confirmation UI (E3.3).**

### Deliberately deferred (needs trips #18 / Firebase)
- **Ask-dispatch cron** — seed `pending` for tomorrow's trips, send the FCM prompt, run `markDefaultTravelling` at the cutoffs (21:00 / 14:00). Needs trips + capacity.
- **FCM push** — the notification sender (Firebase Admin) needs the service account (#88–90, adomfosugit).
- **Deduction** on boarding / confirmed no-show → **E4**.

### Tests
8 new: upsert (confirm/decline/re-answer), default-yes leaving declined+confirmed untouched, `createPending` idempotency, list filter/sort, and route auth/confirm/decline/400. **145 green**, coverage gate passes, migration 013 applies.

Branches off `main` (post-#109). No overlap with other open work beyond the usual `app.ts`/`server.ts` wiring lines.