### PR TITLE
feat(api): mobility — trips, vehicles, drivers & driver↔trip assignment (#18)

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -8,17 +8,17 @@ areas land; it is not authoritative once the code moves.
 `services/api` — Fastify 5 + TypeScript (Node 24), single process, layered
 `server.ts → buildApp (app.ts) → plugins/routes → repositories`.
 
-| Layer        | Modules                                                                                                                                                     |
-| ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Config       | `config/env.ts` (zod-validated env), `config/dotenv.ts`                                                                                                     |
-| Data         | `db/migrate.ts` (runner), `db/pool.ts`; migrations `001_init` (users, auth_identity, sessions), `002`/`003` (subscriptions + constraints), `004` (mobility) |
-| KV           | `kv/kv.store.ts` (interface + in-memory), `kv.store.redis.ts` (ADR-0010)                                                                                    |
-| Auth         | `auth/jwt.ts`, `auth/auth.plugin.ts` (`authenticate`/`requireRole`), `auth/auth.routes.ts` (`/me`) (ADR-0007)                                               |
-| Rate limit   | `ratelimit/ratelimit.plugin.ts` (#23)                                                                                                                       |
-| Domain repos | `users/*`, `subscriptions/*` — **repos only, no routes**; `mobility/*` — repos + browse routes (#17)                                                        |
-| Contract     | `lib/schemas.ts`, `user.schema.ts`, `mobility.schema.ts`, OpenAPI via zod type-provider (ADR-0008)                                                          |
+| Layer        | Modules                                                                                                                                                                                                  |
+| ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Config       | `config/env.ts` (zod-validated env), `config/dotenv.ts`                                                                                                                                                  |
+| Data         | `db/migrate.ts` (runner), `db/pool.ts`; migrations `001_init` (users, auth_identity, sessions), `002`/`003` (subscriptions + constraints), `014` (mobility routes/stops), `015` (trips/vehicles/drivers) |
+| KV           | `kv/kv.store.ts` (interface + in-memory), `kv.store.redis.ts` (ADR-0010)                                                                                                                                 |
+| Auth         | `auth/jwt.ts`, `auth/auth.plugin.ts` (`authenticate`/`requireRole`), `auth/auth.routes.ts` (`/me`) (ADR-0007)                                                                                            |
+| Rate limit   | `ratelimit/ratelimit.plugin.ts` (#23)                                                                                                                                                                    |
+| Domain repos | `users/*`, `subscriptions/*` — **repos only, no routes**; `mobility/*` — repos + browse routes (#17)                                                                                                     |
+| Contract     | `lib/schemas.ts`, `user.schema.ts`, `mobility.schema.ts`, OpenAPI via zod type-provider (ADR-0008)                                                                                                       |
 
-**Live HTTP surface:** `/`, `/version`, `/healthz`, `/readyz`, `/me`, `/docs`, `/routes`, `/routes/:id`.
+**Live HTTP surface:** `/`, `/version`, `/healthz`, `/readyz`, `/me`, `/docs`, `/routes`, `/routes/:id`, `/trips`, `/trips/:id`.
 
 **Cross-cutting (in place):** repository pattern (ADR-0009), KV fallback
 (ADR-0010), readiness pings DB+KV, rate limiting, typed OpenAPI, ~100% unit
@@ -42,8 +42,8 @@ staging auto / prod gated), CODEOWNERS + code-owner reviews.
 
 ### 🟡 Mobility — browse layer only (closes #17, PR #57)
 
-Data model and read endpoints are in place; the operational layer (trips,
-boarding, live positions) is not yet started.
+Data model and read endpoints are in place; trips landed (#18), so the
+operational layer now has schedules — boarding and live positions are next.
 
 **What landed (migration `004_mobility_routes.sql`):**
 
@@ -72,12 +72,12 @@ boarding, live positions) is not yet started.
 
 **Still missing (mobility):**
 
-| Area                               | Issue | Notes                                           |
-| ---------------------------------- | ----- | ----------------------------------------------- |
-| Trips & schedules                  | #18   | no tables or endpoints                          |
-| QR boarding / passes / scan_events | #20   | none                                            |
-| Live vehicle positions (polling)   | #25   | no positions table; ADR-0002 telemetry deferred |
-| Nearest-stop spatial query         | —     | GiST index is in place; no endpoint yet         |
+| Area                               | Issue | Notes                                                                                                               |
+| ---------------------------------- | ----- | ------------------------------------------------------------------------------------------------------------------- |
+| Trips & schedules                  | #18   | ✅ landed — trips/vehicles/drivers + `assigned_driver_id`; `GET /trips` (`?routeId`), `GET /trips/:id` (auth-gated) |
+| QR boarding / passes / scan_events | #20   | none                                                                                                                |
+| Live vehicle positions (polling)   | #25   | no positions table; ADR-0002 telemetry deferred                                                                     |
+| Nearest-stop spatial query         | —     | GiST index is in place; no endpoint yet                                                                             |
 
 ### ❌ Not started (mapped to issues)
 

--- a/services/api/src/app.ts
+++ b/services/api/src/app.ts
@@ -47,8 +47,10 @@ import {
 } from './modules/ratelimit/ratelimit.plugin';
 import type { RouteStopRepository } from './modules/mobility/route-stop.repository';
 import { mobilityRoutes } from './modules/mobility/mobility.routes';
+import { tripRoutes } from './modules/mobility/trips.routes';
 import type { RouteRepository } from './modules/mobility/route.repository';
 import type { StopRepository } from './modules/mobility/stop.repository';
+import type { TripRepository } from './modules/mobility/trip.repository';
 import type { SubscriptionRepository } from './modules/subscriptions/subscription.repository';
 import type { UserRepository } from './modules/users/user.repository';
 
@@ -68,6 +70,8 @@ export interface AppDeps {
   routes?: RouteRepository;
   stops?: StopRepository;
   routeStops?: RouteStopRepository;
+  /** Trips (scheduled route runs). Reads require auth; routes return 503 when absent. */
+  trips?: TripRepository;
   /** Device push-token registry (in-memory vs Postgres). Defaults to in-memory. */
   deviceTokens?: DeviceTokenRepository;
   /** Boarding pass issuance + scan verification. Defaults to an in-memory scan store. */
@@ -200,6 +204,10 @@ export async function buildApp(deps: AppDeps = {}): Promise<FastifyInstance> {
     routes: deps.routes,
     stops: deps.stops,
     routeStops: deps.routeStops,
+  });
+  await app.register(tripRoutes, {
+    trips: deps.trips,
+    rateLimit: deps.rateLimit ?? DEFAULT_RATE_LIMIT,
   });
 
   r.get(

--- a/services/api/src/db/migrations/015_mobility_trips.sql
+++ b/services/api/src/db/migrations/015_mobility_trips.sql
@@ -1,0 +1,43 @@
+-- 015_mobility_trips: the operational layer over routes (#18). A trip is one
+-- scheduled run of a route by a vehicle and a driver. `assigned_driver_id` is
+-- modelled now because it later authorizes GPS position reporting — only the
+-- assigned driver may report a trip's live position (system-design §7, #25).
+--
+-- vehicle_id / assigned_driver_id are nullable: a trip can be scheduled before
+-- ops assigns a bus and driver (#26). They ON DELETE SET NULL rather than
+-- cascade so retiring a vehicle/driver never deletes historical trips; route_id
+-- cascades to mirror route_stops (a route and its runs live and die together).
+
+CREATE TABLE IF NOT EXISTS vehicles (
+  id           uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  registration text NOT NULL UNIQUE,          -- plate number (e.g. "GR-1234-24")
+  label        text,                          -- human name (e.g. "Yutong #7")
+  capacity     integer NOT NULL DEFAULT 0 CHECK (capacity >= 0),
+  created_at   timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS drivers (
+  id             uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  full_name      text NOT NULL,
+  phone          text,
+  license_number text,
+  -- optional link to an auth principal; GPS authz (#25) resolves the signed-in
+  -- user to a driver through this. Nullable until driver sign-in lands.
+  user_id        uuid REFERENCES users (id) ON DELETE SET NULL,
+  created_at     timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS trips (
+  id                 uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  route_id           uuid NOT NULL REFERENCES routes (id) ON DELETE CASCADE,
+  vehicle_id         uuid REFERENCES vehicles (id) ON DELETE SET NULL,
+  assigned_driver_id uuid REFERENCES drivers (id) ON DELETE SET NULL,
+  status             text NOT NULL DEFAULT 'scheduled'
+                       CHECK (status IN ('scheduled', 'active', 'completed', 'cancelled')),
+  scheduled_at       timestamptz NOT NULL,
+  created_at         timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_trips_route ON trips (route_id);
+-- driver index backs the GPS-authz lookup (#25): "trips assigned to this driver".
+CREATE INDEX IF NOT EXISTS idx_trips_driver ON trips (assigned_driver_id);
+CREATE INDEX IF NOT EXISTS idx_trips_scheduled ON trips (scheduled_at);

--- a/services/api/src/modules/mobility/driver.repository.pg.ts
+++ b/services/api/src/modules/mobility/driver.repository.pg.ts
@@ -1,0 +1,40 @@
+import type { Pool } from 'pg';
+import type { Driver, DriverRepository, NewDriver } from './driver.repository';
+
+interface DriverRow {
+  id: string;
+  full_name: string;
+  phone: string | null;
+  license_number: string | null;
+  user_id: string | null;
+  created_at: Date;
+}
+
+function toDriver(row: DriverRow): Driver {
+  return {
+    id: row.id,
+    fullName: row.full_name,
+    phone: row.phone,
+    licenseNumber: row.license_number,
+    userId: row.user_id,
+    createdAt: row.created_at,
+  };
+}
+
+export class PgDriverRepository implements DriverRepository {
+  constructor(private readonly pool: Pool) {}
+
+  async create(input: NewDriver): Promise<Driver> {
+    const { rows } = await this.pool.query<DriverRow>(
+      `INSERT INTO drivers (full_name, phone, license_number, user_id)
+       VALUES ($1, $2, $3, $4) RETURNING *`,
+      [input.fullName, input.phone ?? null, input.licenseNumber ?? null, input.userId ?? null],
+    );
+    return toDriver(rows[0]!);
+  }
+
+  async findById(id: string): Promise<Driver | null> {
+    const { rows } = await this.pool.query<DriverRow>('SELECT * FROM drivers WHERE id = $1', [id]);
+    return rows[0] ? toDriver(rows[0]) : null;
+  }
+}

--- a/services/api/src/modules/mobility/driver.repository.ts
+++ b/services/api/src/modules/mobility/driver.repository.ts
@@ -1,0 +1,65 @@
+// Driver repository — a driver operates a vehicle on a trip. Modelled as its own
+// entity (not just a user) because drivers are onboarded/managed by ops before
+// any app sign-in exists; the optional userId links a driver to an auth
+// principal once driver sign-in lands, which is how GPS reporting is later
+// authorized (only the assigned driver — system-design §7, #25). Two
+// implementations: InMemory for dev/tests, Postgres (driver.repository.pg.ts).
+
+/** A driver who operates a vehicle on a trip. */
+export interface Driver {
+  id: string;
+  fullName: string;
+  phone: string | null;
+  licenseNumber: string | null;
+  /** Links to an auth principal once driver sign-in lands (GPS authz, #25). */
+  userId: string | null;
+  createdAt: Date;
+}
+
+/** Fields needed to create a {@link Driver}. */
+export interface NewDriver {
+  fullName: string;
+  phone?: string | null;
+  licenseNumber?: string | null;
+  userId?: string | null;
+}
+
+/** Persistence for drivers (Postgres in prod, in-memory in dev/tests). */
+export interface DriverRepository {
+  /**
+   * Create a driver.
+   *
+   * @param input - the driver's name and optional contact/license details.
+   * @returns the created driver.
+   */
+  create(input: NewDriver): Promise<Driver>;
+  /**
+   * Look up a driver by id.
+   *
+   * @param id - the driver id.
+   * @returns the driver, or null if it doesn't exist.
+   */
+  findById(id: string): Promise<Driver | null>;
+}
+
+/** In-memory {@link DriverRepository} for dev and unit tests. */
+export class InMemoryDriverRepository implements DriverRepository {
+  private readonly drivers = new Map<string, Driver>();
+
+  async create(input: NewDriver): Promise<Driver> {
+    const driver: Driver = {
+      id: crypto.randomUUID(),
+      fullName: input.fullName,
+      phone: input.phone ?? null,
+      licenseNumber: input.licenseNumber ?? null,
+      userId: input.userId ?? null,
+      createdAt: new Date(),
+    };
+    this.drivers.set(driver.id, driver);
+    return driver;
+  }
+
+  async findById(id: string): Promise<Driver | null> {
+    return this.drivers.get(id) ?? null;
+  }
+}

--- a/services/api/src/modules/mobility/mobility.schema.ts
+++ b/services/api/src/modules/mobility/mobility.schema.ts
@@ -4,6 +4,7 @@
 // rather than a PostGIS geometry — the Pg adapter handles the conversion.
 
 import { z } from 'zod';
+import { TRIP_STATUSES } from './trip.repository';
 
 export const stopResponseSchema = z.object({
   id: z.string().uuid(),
@@ -29,4 +30,28 @@ export const routeWithStopsResponseSchema = routeResponseSchema.extend({
       seq: z.number().int(),
     }),
   ),
+});
+
+// A trip is one scheduled run of a route. vehicleId/assignedDriverId are exposed
+// as plain FK ids (nullable until ops assigns them, #26) rather than expanded
+// objects — clients resolve the route via GET /routes/:id. status is the shared
+// lifecycle enum (source of truth: trip.repository.ts + the migration CHECK).
+export const tripResponseSchema = z.object({
+  id: z.string().uuid(),
+  routeId: z.string().uuid(),
+  vehicleId: z.string().uuid().nullable(),
+  assignedDriverId: z.string().uuid().nullable(),
+  status: z.enum(TRIP_STATUSES),
+  scheduledAt: z.date(),
+  createdAt: z.date(),
+});
+
+// GET /trips filters: routeId narrows to one route's runs (optional — omit to
+// list all).
+export const listTripsQuerySchema = z.object({
+  routeId: z.string().uuid().optional(),
+});
+
+export const tripListResponseSchema = z.object({
+  trips: z.array(tripResponseSchema),
 });

--- a/services/api/src/modules/mobility/trip.repository.pg.ts
+++ b/services/api/src/modules/mobility/trip.repository.pg.ts
@@ -1,0 +1,60 @@
+import type { Pool } from 'pg';
+import type { NewTrip, Trip, TripFilter, TripRepository, TripStatus } from './trip.repository';
+
+interface TripRow {
+  id: string;
+  route_id: string;
+  vehicle_id: string | null;
+  assigned_driver_id: string | null;
+  status: TripStatus;
+  scheduled_at: Date;
+  created_at: Date;
+}
+
+function toTrip(row: TripRow): Trip {
+  return {
+    id: row.id,
+    routeId: row.route_id,
+    vehicleId: row.vehicle_id,
+    assignedDriverId: row.assigned_driver_id,
+    status: row.status,
+    scheduledAt: row.scheduled_at,
+    createdAt: row.created_at,
+  };
+}
+
+export class PgTripRepository implements TripRepository {
+  constructor(private readonly pool: Pool) {}
+
+  async create(input: NewTrip): Promise<Trip> {
+    const { rows } = await this.pool.query<TripRow>(
+      `INSERT INTO trips (route_id, vehicle_id, assigned_driver_id, status, scheduled_at)
+       VALUES ($1, $2, $3, COALESCE($4, 'scheduled'), $5) RETURNING *`,
+      [
+        input.routeId,
+        input.vehicleId ?? null,
+        input.assignedDriverId ?? null,
+        input.status ?? null,
+        input.scheduledAt,
+      ],
+    );
+    return toTrip(rows[0]!);
+  }
+
+  async findById(id: string): Promise<Trip | null> {
+    const { rows } = await this.pool.query<TripRow>('SELECT * FROM trips WHERE id = $1', [id]);
+    return rows[0] ? toTrip(rows[0]) : null;
+  }
+
+  async findAll(filter?: TripFilter): Promise<Trip[]> {
+    // routeId is the only filter today (GET /trips?routeId); build the WHERE
+    // clause conditionally so the unfiltered list stays a plain scan + sort.
+    const { rows } = filter?.routeId
+      ? await this.pool.query<TripRow>(
+          'SELECT * FROM trips WHERE route_id = $1 ORDER BY scheduled_at',
+          [filter.routeId],
+        )
+      : await this.pool.query<TripRow>('SELECT * FROM trips ORDER BY scheduled_at');
+    return rows.map(toTrip);
+  }
+}

--- a/services/api/src/modules/mobility/trip.repository.ts
+++ b/services/api/src/modules/mobility/trip.repository.ts
@@ -1,0 +1,90 @@
+// Trip repository — a trip is one scheduled run of a route by a vehicle and a
+// driver. vehicleId/assignedDriverId are nullable: a trip can be scheduled
+// before ops assigns a bus and driver (#26). assignedDriverId is the field that
+// later authorizes GPS position reporting — only the assigned driver may report
+// a trip's live position (system-design §7, #25). Two implementations: InMemory
+// for dev/tests, Postgres (trip.repository.pg.ts) for real runs.
+
+/** Valid trip lifecycle states — the source of truth for the DB CHECK, the
+ * domain type, and the response enum (imported by mobility.schema.ts). */
+export const TRIP_STATUSES = ['scheduled', 'active', 'completed', 'cancelled'] as const;
+export type TripStatus = (typeof TRIP_STATUSES)[number];
+
+/** One scheduled run of a route by a vehicle and a driver. */
+export interface Trip {
+  id: string;
+  routeId: string;
+  vehicleId: string | null;
+  assignedDriverId: string | null;
+  status: TripStatus;
+  scheduledAt: Date;
+  createdAt: Date;
+}
+
+/** Fields needed to create a {@link Trip}. status defaults to 'scheduled'. */
+export interface NewTrip {
+  routeId: string;
+  vehicleId?: string | null;
+  assignedDriverId?: string | null;
+  status?: TripStatus;
+  scheduledAt: Date;
+}
+
+/** Optional filters for {@link TripRepository.findAll}. */
+export interface TripFilter {
+  routeId?: string;
+}
+
+/** Persistence for trips (Postgres in prod, in-memory in dev/tests). */
+export interface TripRepository {
+  /**
+   * Create a trip.
+   *
+   * @param input - the route, optional vehicle/driver, status, and schedule.
+   * @returns the created trip.
+   */
+  create(input: NewTrip): Promise<Trip>;
+  /**
+   * Look up a trip by id.
+   *
+   * @param id - the trip id.
+   * @returns the trip, or null if it doesn't exist.
+   */
+  findById(id: string): Promise<Trip | null>;
+  /**
+   * List trips, optionally filtered by route, ordered by scheduled_at ascending.
+   *
+   * @param filter - optional filters (e.g. routeId).
+   * @returns the matching trips.
+   */
+  findAll(filter?: TripFilter): Promise<Trip[]>;
+}
+
+/** In-memory {@link TripRepository} for dev and unit tests. */
+export class InMemoryTripRepository implements TripRepository {
+  private readonly trips = new Map<string, Trip>();
+
+  async create(input: NewTrip): Promise<Trip> {
+    const trip: Trip = {
+      id: crypto.randomUUID(),
+      routeId: input.routeId,
+      vehicleId: input.vehicleId ?? null,
+      assignedDriverId: input.assignedDriverId ?? null,
+      status: input.status ?? 'scheduled',
+      scheduledAt: input.scheduledAt,
+      createdAt: new Date(),
+    };
+    this.trips.set(trip.id, trip);
+    return trip;
+  }
+
+  async findById(id: string): Promise<Trip | null> {
+    return this.trips.get(id) ?? null;
+  }
+
+  async findAll(filter?: TripFilter): Promise<Trip[]> {
+    return Array.from(this.trips.values())
+      .filter((t) => !filter?.routeId || t.routeId === filter.routeId)
+      .sort((a, b) => a.scheduledAt.getTime() - b.scheduledAt.getTime());
+  }
+}

--- a/services/api/src/modules/mobility/trips.routes.ts
+++ b/services/api/src/modules/mobility/trips.routes.ts
@@ -1,0 +1,107 @@
+// Trip routes (#18). Trips are the operational layer over routes — one scheduled
+// run of a route by a vehicle and driver. Reads require authentication (unlike
+// public route browsing): schedules are app-facing data for signed-in commuters
+// and drivers, and this is the guard the issue calls out as a dependency. Write
+// paths (create/assign) live in the admin/ops module (#26). GPS position
+// reporting authorized by assignedDriverId is #25.
+
+import type { FastifyInstance } from 'fastify';
+import type { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { z } from 'zod';
+import { errorResponseSchema } from '../../lib/schemas';
+import type { RateLimitConfig } from '../ratelimit/ratelimit.plugin';
+import {
+  listTripsQuerySchema,
+  tripListResponseSchema,
+  tripResponseSchema,
+} from './mobility.schema';
+import type { Trip, TripRepository } from './trip.repository';
+
+// Map a stored trip to its public (client-facing) shape.
+function toResponse(t: Trip): {
+  id: string;
+  routeId: string;
+  vehicleId: string | null;
+  assignedDriverId: string | null;
+  status: Trip['status'];
+  scheduledAt: Date;
+  createdAt: Date;
+} {
+  return {
+    id: t.id,
+    routeId: t.routeId,
+    vehicleId: t.vehicleId,
+    assignedDriverId: t.assignedDriverId,
+    status: t.status,
+    scheduledAt: t.scheduledAt,
+    createdAt: t.createdAt,
+  };
+}
+
+/**
+ * Register trip routes: `GET /trips` (optional `?routeId`) and `GET /trips/:id`.
+ *
+ * @param app - the Fastify instance to register on.
+ * @param opts - route dependencies.
+ * @param opts.trips - the trip repository (503 when absent).
+ * @param opts.rateLimit - rate-limit config (applied per user).
+ */
+export async function tripRoutes(
+  app: FastifyInstance,
+  opts: { trips?: TripRepository; rateLimit: RateLimitConfig },
+): Promise<void> {
+  const r = app.withTypeProvider<ZodTypeProvider>();
+  const UNAVAILABLE = { error: 'unavailable', message: 'Trips are not configured' };
+
+  r.get(
+    '/trips',
+    {
+      schema: {
+        tags: ['mobility'],
+        summary: 'List trips, optionally filtered by route',
+        security: [{ bearerAuth: [] }],
+        querystring: listTripsQuerySchema,
+        response: {
+          200: tripListResponseSchema,
+          401: errorResponseSchema,
+          429: errorResponseSchema,
+          503: errorResponseSchema,
+        },
+      },
+      preHandler: [app.authenticate, app.rateLimit({ ...opts.rateLimit, by: 'user' })],
+    },
+    async (request, reply) => {
+      if (!opts.trips) return reply.code(503).send(UNAVAILABLE);
+      const trips = await opts.trips.findAll({ routeId: request.query.routeId });
+      return { trips: trips.map(toResponse) };
+    },
+  );
+
+  r.get(
+    '/trips/:id',
+    {
+      schema: {
+        tags: ['mobility'],
+        summary: 'Get a trip by id',
+        security: [{ bearerAuth: [] }],
+        params: z.object({ id: z.string().uuid() }),
+        response: {
+          200: tripResponseSchema,
+          401: errorResponseSchema,
+          404: errorResponseSchema,
+          429: errorResponseSchema,
+          503: errorResponseSchema,
+        },
+      },
+      preHandler: [app.authenticate, app.rateLimit({ ...opts.rateLimit, by: 'user' })],
+    },
+    async (request, reply) => {
+      if (!opts.trips) return reply.code(503).send(UNAVAILABLE);
+      const trip = await opts.trips.findById(request.params.id);
+      if (!trip) {
+        return reply.code(404).send({ error: 'not_found', message: 'Trip not found' });
+      }
+      return toResponse(trip);
+    },
+  );
+}

--- a/services/api/src/modules/mobility/vehicle.repository.pg.ts
+++ b/services/api/src/modules/mobility/vehicle.repository.pg.ts
@@ -1,0 +1,40 @@
+import type { Pool } from 'pg';
+import type { NewVehicle, Vehicle, VehicleRepository } from './vehicle.repository';
+
+interface VehicleRow {
+  id: string;
+  registration: string;
+  label: string | null;
+  capacity: number;
+  created_at: Date;
+}
+
+function toVehicle(row: VehicleRow): Vehicle {
+  return {
+    id: row.id,
+    registration: row.registration,
+    label: row.label,
+    capacity: row.capacity,
+    createdAt: row.created_at,
+  };
+}
+
+export class PgVehicleRepository implements VehicleRepository {
+  constructor(private readonly pool: Pool) {}
+
+  async create(input: NewVehicle): Promise<Vehicle> {
+    const { rows } = await this.pool.query<VehicleRow>(
+      `INSERT INTO vehicles (registration, label, capacity)
+       VALUES ($1, $2, $3) RETURNING *`,
+      [input.registration, input.label ?? null, input.capacity ?? 0],
+    );
+    return toVehicle(rows[0]!);
+  }
+
+  async findById(id: string): Promise<Vehicle | null> {
+    const { rows } = await this.pool.query<VehicleRow>('SELECT * FROM vehicles WHERE id = $1', [
+      id,
+    ]);
+    return rows[0] ? toVehicle(rows[0]) : null;
+  }
+}

--- a/services/api/src/modules/mobility/vehicle.repository.ts
+++ b/services/api/src/modules/mobility/vehicle.repository.ts
@@ -1,0 +1,59 @@
+// Vehicle repository — a vehicle is a bus in the fleet, identified by its
+// registration (plate). It carries only fleet metadata; a vehicle is placed on a
+// specific run by a trip's vehicle_id. Two implementations: InMemory for unit
+// tests and zero-infra dev, Postgres (vehicle.repository.pg.ts) for real runs.
+
+/** A bus in the fleet, identified by its registration (plate). */
+export interface Vehicle {
+  id: string;
+  registration: string;
+  label: string | null;
+  capacity: number;
+  createdAt: Date;
+}
+
+/** Fields needed to create a {@link Vehicle}. */
+export interface NewVehicle {
+  registration: string;
+  label?: string | null;
+  capacity?: number;
+}
+
+/** Persistence for vehicles (Postgres in prod, in-memory in dev/tests). */
+export interface VehicleRepository {
+  /**
+   * Create a vehicle.
+   *
+   * @param input - the vehicle's registration and optional metadata.
+   * @returns the created vehicle.
+   */
+  create(input: NewVehicle): Promise<Vehicle>;
+  /**
+   * Look up a vehicle by id.
+   *
+   * @param id - the vehicle id.
+   * @returns the vehicle, or null if it doesn't exist.
+   */
+  findById(id: string): Promise<Vehicle | null>;
+}
+
+/** In-memory {@link VehicleRepository} for dev and unit tests. */
+export class InMemoryVehicleRepository implements VehicleRepository {
+  private readonly vehicles = new Map<string, Vehicle>();
+
+  async create(input: NewVehicle): Promise<Vehicle> {
+    const vehicle: Vehicle = {
+      id: crypto.randomUUID(),
+      registration: input.registration,
+      label: input.label ?? null,
+      capacity: input.capacity ?? 0,
+      createdAt: new Date(),
+    };
+    this.vehicles.set(vehicle.id, vehicle);
+    return vehicle;
+  }
+
+  async findById(id: string): Promise<Vehicle | null> {
+    return this.vehicles.get(id) ?? null;
+  }
+}

--- a/services/api/src/server.ts
+++ b/services/api/src/server.ts
@@ -34,6 +34,8 @@ import { InMemoryRouteRepository, type RouteRepository } from './modules/mobilit
 import { PgRouteRepository } from './modules/mobility/route.repository.pg';
 import { InMemoryStopRepository, type StopRepository } from './modules/mobility/stop.repository';
 import { PgStopRepository } from './modules/mobility/stop.repository.pg';
+import { InMemoryTripRepository, type TripRepository } from './modules/mobility/trip.repository';
+import { PgTripRepository } from './modules/mobility/trip.repository.pg';
 import {
   InMemorySubscriptionRepository,
   type SubscriptionRepository,
@@ -124,6 +126,7 @@ async function main(): Promise<void> {
   let routes: RouteRepository;
   let stops: StopRepository;
   let routeStops: RouteStopRepository;
+  let trips: TripRepository;
   let sessions: SessionRepository;
   let authIdentities: AuthIdentityRepository;
   let payments: PaymentRepository;
@@ -139,6 +142,7 @@ async function main(): Promise<void> {
     routes = new PgRouteRepository(pool);
     stops = new PgStopRepository(pool);
     routeStops = new PgRouteStopRepository(pool);
+    trips = new PgTripRepository(pool);
     sessions = new PgSessionRepository(pool);
     authIdentities = new PgAuthIdentityRepository(pool);
     payments = new PgPaymentRepository(pool);
@@ -154,6 +158,7 @@ async function main(): Promise<void> {
     routes = new InMemoryRouteRepository();
     stops = new InMemoryStopRepository();
     routeStops = new InMemoryRouteStopRepository();
+    trips = new InMemoryTripRepository();
     sessions = new InMemorySessionRepository();
     authIdentities = new InMemoryAuthIdentityRepository();
     payments = new InMemoryPaymentRepository();
@@ -241,6 +246,7 @@ async function main(): Promise<void> {
     routes,
     stops,
     routeStops,
+    trips,
     deviceTokens,
     boardingService,
     authService,

--- a/services/api/tests/driver.repository.test.ts
+++ b/services/api/tests/driver.repository.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { InMemoryDriverRepository } from '../src/modules/mobility/driver.repository';
+
+describe('InMemoryDriverRepository', () => {
+  it('creates a driver and finds it by id', async () => {
+    const repo = new InMemoryDriverRepository();
+    const created = await repo.create({
+      fullName: 'Kwame Mensah',
+      phone: '+233200000000',
+      licenseNumber: 'DL-0001',
+    });
+
+    expect(created.id).toBeTruthy();
+    expect(created.fullName).toBe('Kwame Mensah');
+    expect(created.phone).toBe('+233200000000');
+    expect(created.licenseNumber).toBe('DL-0001');
+
+    const found = await repo.findById(created.id);
+    expect(found?.fullName).toBe('Kwame Mensah');
+  });
+
+  it('defaults optional contact/license/user fields to null', async () => {
+    const repo = new InMemoryDriverRepository();
+    const created = await repo.create({ fullName: 'Ama Owusu' });
+    expect(created.phone).toBeNull();
+    expect(created.licenseNumber).toBeNull();
+    expect(created.userId).toBeNull();
+  });
+
+  it('returns null for an unknown id', async () => {
+    const repo = new InMemoryDriverRepository();
+    expect(await repo.findById('does-not-exist')).toBeNull();
+  });
+});

--- a/services/api/tests/trip.repository.test.ts
+++ b/services/api/tests/trip.repository.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { InMemoryTripRepository } from '../src/modules/mobility/trip.repository';
+
+const ROUTE_A = '00000000-0000-0000-0000-0000000000a1';
+const ROUTE_B = '00000000-0000-0000-0000-0000000000b2';
+
+describe('InMemoryTripRepository', () => {
+  it('creates a trip and finds it by id', async () => {
+    const repo = new InMemoryTripRepository();
+    const scheduledAt = new Date('2026-07-08T06:30:00Z');
+    const created = await repo.create({
+      routeId: ROUTE_A,
+      vehicleId: 'veh-1',
+      assignedDriverId: 'drv-1',
+      scheduledAt,
+    });
+
+    expect(created.id).toBeTruthy();
+    expect(created.routeId).toBe(ROUTE_A);
+    expect(created.vehicleId).toBe('veh-1');
+    expect(created.assignedDriverId).toBe('drv-1');
+    expect(created.scheduledAt).toEqual(scheduledAt);
+
+    const found = await repo.findById(created.id);
+    expect(found?.id).toBe(created.id);
+  });
+
+  it('defaults status to scheduled and vehicle/driver to null', async () => {
+    const repo = new InMemoryTripRepository();
+    const trip = await repo.create({ routeId: ROUTE_A, scheduledAt: new Date() });
+    expect(trip.status).toBe('scheduled');
+    expect(trip.vehicleId).toBeNull();
+    expect(trip.assignedDriverId).toBeNull();
+  });
+
+  it('returns null for an unknown id', async () => {
+    const repo = new InMemoryTripRepository();
+    expect(await repo.findById('does-not-exist')).toBeNull();
+  });
+
+  it('findAll returns all trips ordered by scheduled_at ascending', async () => {
+    const repo = new InMemoryTripRepository();
+    await repo.create({ routeId: ROUTE_A, scheduledAt: new Date('2026-07-08T18:00:00Z') });
+    await repo.create({ routeId: ROUTE_B, scheduledAt: new Date('2026-07-08T06:00:00Z') });
+    await repo.create({ routeId: ROUTE_A, scheduledAt: new Date('2026-07-08T12:00:00Z') });
+
+    const all = await repo.findAll();
+    expect(all).toHaveLength(3);
+    expect(all.map((t) => t.scheduledAt.toISOString())).toEqual([
+      '2026-07-08T06:00:00.000Z',
+      '2026-07-08T12:00:00.000Z',
+      '2026-07-08T18:00:00.000Z',
+    ]);
+  });
+
+  it('findAll filters by routeId', async () => {
+    const repo = new InMemoryTripRepository();
+    await repo.create({ routeId: ROUTE_A, scheduledAt: new Date('2026-07-08T06:00:00Z') });
+    await repo.create({ routeId: ROUTE_A, scheduledAt: new Date('2026-07-08T07:00:00Z') });
+    await repo.create({ routeId: ROUTE_B, scheduledAt: new Date('2026-07-08T08:00:00Z') });
+
+    const onA = await repo.findAll({ routeId: ROUTE_A });
+    expect(onA).toHaveLength(2);
+    expect(onA.every((t) => t.routeId === ROUTE_A)).toBe(true);
+  });
+});

--- a/services/api/tests/trips.routes.test.ts
+++ b/services/api/tests/trips.routes.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest';
+import { buildApp } from '../src/app';
+import { createJwtService, type AuthConfig } from '../src/modules/auth/jwt';
+import { InMemoryTripRepository } from '../src/modules/mobility/trip.repository';
+
+const auth: AuthConfig = {
+  secret: 'test-secret-at-least-32-characters-long-0000',
+  accessTtl: '15m',
+  issuer: 'trotxi',
+  audience: 'trotxi-api',
+};
+const jwt = createJwtService(auth);
+const bearer = (t: string) => ({ authorization: `Bearer ${t}` });
+const token = () => jwt.signAccessToken({ userId: 'rider-1', role: 'commuter' });
+
+const ROUTE_A = '00000000-0000-0000-0000-0000000000a1';
+const ROUTE_B = '00000000-0000-0000-0000-0000000000b2';
+
+async function appWithTrips() {
+  const trips = new InMemoryTripRepository();
+  const app = await buildApp({ auth, trips });
+  return { app, trips };
+}
+
+describe('GET /trips', () => {
+  it('requires authentication', async () => {
+    const { app } = await appWithTrips();
+    const res = await app.inject({ method: 'GET', url: '/trips' });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('returns 503 when the repository is not wired', async () => {
+    const app = await buildApp({ auth });
+    const res = await app.inject({ method: 'GET', url: '/trips', headers: bearer(await token()) });
+    expect(res.statusCode).toBe(503);
+    expect(res.json()).toMatchObject({ error: 'unavailable' });
+  });
+
+  it('returns an empty list when no trips exist', async () => {
+    const { app } = await appWithTrips();
+    const res = await app.inject({ method: 'GET', url: '/trips', headers: bearer(await token()) });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ trips: [] });
+  });
+
+  it('returns seeded trips ordered by scheduled_at', async () => {
+    const { app, trips } = await appWithTrips();
+    await trips.create({ routeId: ROUTE_A, scheduledAt: new Date('2026-07-08T18:00:00Z') });
+    await trips.create({ routeId: ROUTE_A, scheduledAt: new Date('2026-07-08T06:00:00Z') });
+
+    const res = await app.inject({ method: 'GET', url: '/trips', headers: bearer(await token()) });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.trips).toHaveLength(2);
+    expect(body.trips[0].scheduledAt).toBe('2026-07-08T06:00:00.000Z');
+    expect(body.trips[0]).toMatchObject({ routeId: ROUTE_A, status: 'scheduled' });
+  });
+
+  it('filters by routeId', async () => {
+    const { app, trips } = await appWithTrips();
+    await trips.create({ routeId: ROUTE_A, scheduledAt: new Date('2026-07-08T06:00:00Z') });
+    await trips.create({ routeId: ROUTE_B, scheduledAt: new Date('2026-07-08T07:00:00Z') });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/trips?routeId=${ROUTE_A}`,
+      headers: bearer(await token()),
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.trips).toHaveLength(1);
+    expect(body.trips[0].routeId).toBe(ROUTE_A);
+  });
+
+  it('returns 400 for a non-UUID routeId', async () => {
+    const { app } = await appWithTrips();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/trips?routeId=not-a-uuid',
+      headers: bearer(await token()),
+    });
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+describe('GET /trips/:id', () => {
+  it('requires authentication', async () => {
+    const { app } = await appWithTrips();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/trips/00000000-0000-0000-0000-000000000001',
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('returns 404 for an unknown id', async () => {
+    const { app } = await appWithTrips();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/trips/00000000-0000-0000-0000-000000000001',
+      headers: bearer(await token()),
+    });
+    expect(res.statusCode).toBe(404);
+    expect(res.json()).toMatchObject({ error: 'not_found' });
+  });
+
+  it('returns 400 for a non-UUID id', async () => {
+    const { app } = await appWithTrips();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/trips/not-a-uuid',
+      headers: bearer(await token()),
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns the trip with its assignment fields', async () => {
+    const { app, trips } = await appWithTrips();
+    const trip = await trips.create({
+      routeId: ROUTE_A,
+      vehicleId: '00000000-0000-0000-0000-0000000000f1',
+      assignedDriverId: '00000000-0000-0000-0000-0000000000f2',
+      status: 'active',
+      scheduledAt: new Date('2026-07-08T06:00:00Z'),
+    });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/trips/${trip.id}`,
+      headers: bearer(await token()),
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({
+      id: trip.id,
+      routeId: ROUTE_A,
+      vehicleId: '00000000-0000-0000-0000-0000000000f1',
+      assignedDriverId: '00000000-0000-0000-0000-0000000000f2',
+      status: 'active',
+    });
+  });
+});

--- a/services/api/tests/vehicle.repository.test.ts
+++ b/services/api/tests/vehicle.repository.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { InMemoryVehicleRepository } from '../src/modules/mobility/vehicle.repository';
+
+describe('InMemoryVehicleRepository', () => {
+  it('creates a vehicle and finds it by id', async () => {
+    const repo = new InMemoryVehicleRepository();
+    const created = await repo.create({
+      registration: 'GR-1234-24',
+      label: 'Yutong #7',
+      capacity: 33,
+    });
+
+    expect(created.id).toBeTruthy();
+    expect(created.registration).toBe('GR-1234-24');
+    expect(created.label).toBe('Yutong #7');
+    expect(created.capacity).toBe(33);
+
+    const found = await repo.findById(created.id);
+    expect(found?.registration).toBe('GR-1234-24');
+  });
+
+  it('defaults label to null and capacity to 0', async () => {
+    const repo = new InMemoryVehicleRepository();
+    const created = await repo.create({ registration: 'GT-9999-24' });
+    expect(created.label).toBeNull();
+    expect(created.capacity).toBe(0);
+  });
+
+  it('returns null for an unknown id', async () => {
+    const repo = new InMemoryVehicleRepository();
+    expect(await repo.findById('does-not-exist')).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #18. Wave-2 mobility slice: the operational layer over routes — scheduled **trips** run by a **vehicle** and a **driver**.

## What's here
- **Migration `015_mobility_trips.sql`** — `vehicles`, `drivers`, `trips` (`route_id`, `vehicle_id`, **`assigned_driver_id`**, `status`, `scheduled_at`). Idempotent (`IF NOT EXISTS`); indexed on `route_id`, `assigned_driver_id`, `scheduled_at`.
  - `route_id` cascades (mirrors `route_stops`); `vehicle_id`/`assigned_driver_id` `ON DELETE SET NULL` so retiring a bus/driver never deletes trip history.
  - `status` CHECK: `scheduled | active | completed | cancelled`.
- **Repositories** (in-memory + Postgres, ADR-0009) for vehicles, drivers, trips. `TripRepository.findAll({ routeId? })` powers the filter.
- **Endpoints** — `GET /trips` (`?routeId`), `GET /trips/:id`. Wired in `app.ts` + `server.ts`.

## Design notes
- **`assigned_driver_id` is modelled now** because it later authorizes GPS position reporting — only the assigned driver may report a trip's live position (system-design §7, follow-up #25). The `idx_trips_driver` index backs that lookup.
- **Trip reads are auth-gated** (`app.authenticate`, `security: [{ bearerAuth: [] }]`, 503 when unwired) — deliberately unlike the *public* `/routes` browse. Schedules are app-facing data for signed-in commuters/drivers; this is the auth guard the issue lists as a dependency. Easy to relax to public if product prefers.
- **vehicles/drivers repos are delivered but not yet wired into a running consumer** — management/assignment is the admin/ops slice (#26). Classes are exported and ready.
- `drivers.user_id` (nullable FK → users) links a driver to an auth principal once driver sign-in lands (#25); no consumer yet.

## Acceptance (#18)
- ✅ Migration applies + idempotent
- ✅ Repos (in-memory + Postgres) + unit tests
- ✅ Endpoints return seeded trips (`GET /trips`, `GET /trips/:id`)

## Verification
- `tsc --noEmit` clean · `eslint .` clean (also enforced by pre-commit hook)
- **34 tests pass** (21 new: 11 repo + 10 HTTP)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
