### PR TITLE
feat(api): ride deduction on boarding scan (#20, E4)

### DIFF
--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -25,7 +25,7 @@ repo (`system-design.md`, `security.md`). Each doc links to both.
 | Daily ride confirmation — `POST /me/reservations` (confirm/decline) (#101)  | [reservations.md](reservations.md)               | 🟡 E3 core (ask-dispatch deferred #18) |
 | Mobility — routes, stops, browse                                            | _(in review — #57)_                              | 🚧                                     |
 | Rate limiting (#23)                                                         | [rate-limiting.md](rate-limiting.md)             | ✅ live                                |
-| Boarding — QR passes + scan verification (#20)                              | [boarding.md](boarding.md)                       | 🟡 integrity slice                     |
+| Boarding — QR scan + ride deduction (#20, E4)                               | [boarding.md](boarding.md)                       | 🟢 scan + deduction (manifest/PIN #26) |
 | Observability & performance (#28)                                           | [design](../design/observability.md)             | ✅ backend live (metrics/traces/logs)  |
 
 ## Conventions for a feature doc

--- a/docs/features/boarding.md
+++ b/docs/features/boarding.md
@@ -2,9 +2,10 @@
 
 **Owner:** Godfred Awuku · **Last updated:** 2026-07-02
 
-**Status:** 🟡 integrity slice live (#20). The **eligibility gates** (active
-membership + token debit on board) and the **photo-pass** fallback are deferred —
-see below.
+**Status:** 🟢 QR scan **+ ride deduction** live (#20, E4). A valid scan now
+consumes the rider's confirmed reservation and **debits one ride** from their
+entitlement (ADR-0014). Still deferred: the **manifest + daily-PIN** layers and
+the confirmed-yes **no-show** job (both need trips/admin #26) — see below.
 
 Lets a driver confirm a rider is boarding with a **genuine, unforged, unexpired
 pass**, and logs every scan for audit. Rationale: #20.
@@ -20,9 +21,13 @@ pass**, and logs every scan for audit. Rationale: #20.
   scan, not just at the TTL. Signed with the server key but a distinct audience,
   so a pass can't be used as an access token (or vice-versa). Verification allows
   5s clock tolerance (drift across instances).
-- **Integrity vs eligibility** — verifying a pass proves it's a **real pass for
-  rider X**. It does **not** (yet) check membership or debit tokens — those are the
-  money-gated part (#19/#21), deliberately deferred.
+- **Integrity → boarding** — verifying a pass proves it's a **real pass for
+  rider X**; a valid scan then **boards the rider's confirmed reservation for
+  today** and debits **1 ride** from their entitlement (E1 ledger). The debit is
+  **idempotent per reservation** (`board:<reservationId>`), and `findBoardable`
+  skips already-boarded seats — so re-scanning a rider (even with a freshly
+  rotated QR) never double-charges. A valid pass with **no confirmed reservation**
+  boards nothing (`deducted: false`) — walk-up/standby is E6.
 - **Scan event** — every verification is one **append-only** audit row
   (`scan_events`): rider, driver, trip, result, method. `rider_id` is null for an
   invalid/forged pass (unattributable).
@@ -44,9 +49,10 @@ Verify a scanned pass (drivers only) and record the scan.
 
 - **Auth:** `Bearer` + **role `driver`** (else **403**). **Rate limit:** per user.
 - **Body:** `{ "pass": "<scanned token>", "tripId?": "<uuid>" }`
-- **200:** `{ "valid": true|false, "riderId": "<uuid>|null", "reason": "ok"|"invalid"|"expired"|"reused" }`
-  (`reused` = the pass was already consumed by an earlier scan; `riderId` is still
-  returned so the driver sees who presented it)
+- **200:** `{ "valid": true|false, "riderId": "<uuid>|null", "reason": "ok"|"invalid"|"expired"|"reused", "deducted": true|false }`
+  (`reused` = the pass was already consumed; `deducted` = a confirmed reservation
+  was boarded and a ride debited. `riderId` is still returned so the driver sees
+  who presented it.)
 
 ---
 
@@ -75,18 +81,21 @@ no FK yet (trips are #18).
 ## Next (Hybrid Subscription Model — ADR-0014, boarding v2 / epic E4)
 
 The commercial model is decided
-([ADR-0014](../adr/0014-hybrid-subscription-model.md)): this QR core becomes
-**one of three verification layers**, and boarding consumes **1 ride from the
-subscription entitlement** (not a fare debit from a wallet). Coming in E4:
+([ADR-0014](../adr/0014-hybrid-subscription-model.md)): this QR scan is **one of
+three verification layers**, and boarding consumes **1 ride from the subscription
+entitlement**. **Done in this slice:** ride deduction on a valid scan (above).
+Still to come (blocked on trips/admin, #26):
 
 - **Driver manifest layer** — name + **photo** (server-side, R2 #24) + pickup
   point for the day's reservations. The photo pass is now required product.
-- **Daily 4-digit PIN layer** — offline-friendly fallback; any layer completes
-  verification.
-- **Ride deduction on verify** (idempotency key = reservation id) + the
-  confirmed-yes **no-show** deduction job; operator cancellation never deducts.
-- Eligibility: active subscription + a **confirmed reservation** for the trip
-  (from the daily-confirmation flow), replacing the old wallet-balance gate.
+- **Daily 4-digit PIN layer** — offline-friendly fallback; only works _with_ the
+  manifest (a 4-digit code can't identify a rider alone), so it ships with #26.
+- **Confirmed-yes no-show** deduction job (cron); operator cancellation never
+  deducts. Same idempotency key space (`board:<reservationId>`) so a late board
+  and the no-show sweep can't both charge.
+- Direction/trip resolution: today a scan boards the rider's **earliest open leg
+  for the day** (morning before evening); when trips carry the run's direction,
+  the scan will target that specific reservation.
 
 ## Where the code lives
 

--- a/services/api/src/app.ts
+++ b/services/api/src/app.ts
@@ -158,6 +158,11 @@ export async function buildApp(deps: AppDeps = {}): Promise<FastifyInstance> {
   // Guards first (decorators on the root instance), then routes that use them.
   const kv = deps.kv ?? new InMemoryKvStore();
   const objectStore = deps.objectStore ?? new FakeObjectStore();
+  // Shared so a boarding scan boards the same reservation the rider confirmed
+  // and debits the same entitlement ledger GET /me/rides reads (E4).
+  const entitlements = deps.entitlements ?? new InMemoryEntitlementLedgerRepository();
+  const credits = deps.credits ?? new InMemoryCreditLedgerRepository();
+  const reservations = deps.reservations ?? new InMemoryReservationRepository();
   const authConfig = deps.auth ?? DEV_AUTH_CONFIG;
   await app.register(authPlugin, { config: authConfig });
   await app.register(rateLimitPlugin, { kv });
@@ -181,12 +186,12 @@ export async function buildApp(deps: AppDeps = {}): Promise<FastifyInstance> {
     rateLimit: deps.rateLimit ?? DEFAULT_RATE_LIMIT,
   });
   await app.register(entitlementRoutes, {
-    entitlements: deps.entitlements ?? new InMemoryEntitlementLedgerRepository(),
-    credits: deps.credits ?? new InMemoryCreditLedgerRepository(),
+    entitlements,
+    credits,
     rateLimit: deps.rateLimit ?? DEFAULT_RATE_LIMIT,
   });
   await app.register(reservationRoutes, {
-    reservations: deps.reservations ?? new InMemoryReservationRepository(),
+    reservations,
     rateLimit: deps.rateLimit ?? DEFAULT_RATE_LIMIT,
   });
   await app.register(boardingRoutes, {
@@ -195,6 +200,8 @@ export async function buildApp(deps: AppDeps = {}): Promise<FastifyInstance> {
       new BoardingService({
         scanEvents: new InMemoryScanEventRepository(),
         kv,
+        reservations,
+        entitlements,
         secret: authConfig.secret,
         passTtlSeconds: 60,
       }),

--- a/services/api/src/modules/boarding/boarding.schema.ts
+++ b/services/api/src/modules/boarding/boarding.schema.ts
@@ -16,4 +16,7 @@ export const scanResponseSchema = z.object({
   valid: z.boolean(),
   riderId: z.string().nullable(),
   reason: z.enum(['ok', 'invalid', 'expired', 'reused']),
+  /** True when the scan consumed a ride (the rider had a confirmed reservation
+   * for today). False for a valid pass with no reservation to board. */
+  deducted: z.boolean(),
 });

--- a/services/api/src/modules/boarding/boarding.service.ts
+++ b/services/api/src/modules/boarding/boarding.service.ts
@@ -13,6 +13,8 @@
 
 import { errors } from 'jose';
 import type { KvStore } from '../../kv/kv.store';
+import type { EntitlementLedgerRepository } from '../entitlements/entitlement-ledger.repository';
+import type { ReservationRepository } from '../reservations/reservation.repository';
 import { signPass, verifyPass, type IssuedPass } from './pass';
 import type { ScanEventRepository } from './scan-event.repository';
 
@@ -32,6 +34,8 @@ export interface VerifyScanResult {
   /** The rider the pass belongs to (null when invalid/forged). */
   riderId: string | null;
   reason: 'ok' | 'invalid' | 'expired' | 'reused';
+  /** True when this scan consumed a ride (a confirmed reservation was boarded). */
+  deducted: boolean;
 }
 
 /** Collaborators for {@link BoardingService}, injected at app wiring. */
@@ -40,10 +44,20 @@ export interface BoardingServiceDeps {
   scanEvents: ScanEventRepository;
   /** Marks passes consumed (single-use); Redis in prod, in-memory in dev/tests. */
   kv: KvStore;
+  /** Reservations — a valid scan boards the rider's confirmed seat. Optional:
+   * when unwired, verification stays integrity-only (no deduction). */
+  reservations?: ReservationRepository;
+  /** Ride entitlement ledger — a boarded seat debits one ride. Optional (see above). */
+  entitlements?: EntitlementLedgerRepository;
   /** Server signing key for passes (the JWT secret). */
   secret: string;
   /** Pass lifetime in seconds (short → the QR rotates). */
   passTtlSeconds: number;
+}
+
+// Today's date as `YYYY-MM-DD` (UTC), the day a scan boards against.
+function todayISO(): string {
+  return new Date().toISOString().slice(0, 10);
 }
 
 /** Boarding-pass issuance + scan verification (see the file header). */
@@ -96,6 +110,32 @@ export class BoardingService {
       }
     }
 
+    // A valid scan consumes the rider's confirmed reservation for today: mark it
+    // boarded and debit one ride (ADR-0014, E4). Idempotent by reservation, and
+    // findBoardable skips already-boarded seats, so re-scanning a rider (with a
+    // freshly rotated QR) can't double-charge. Fails OPEN — a hiccup here must
+    // not stop the bus; reconciliation catches any gap.
+    let deducted = false;
+    if (reason === 'ok' && riderId && this.deps.reservations && this.deps.entitlements) {
+      try {
+        const boardable = await this.deps.reservations.findBoardable(riderId, todayISO());
+        if (boardable) {
+          await this.deps.reservations.markBoarded(boardable.id);
+          await this.deps.entitlements.record({
+            userId: riderId,
+            deltaRides: -1,
+            reason: 'boarding',
+            refType: 'reservation',
+            refId: boardable.id,
+            idempotencyKey: `board:${boardable.id}`,
+          });
+          deducted = true;
+        }
+      } catch (err) {
+        console.error('boarding: ride deduction failed (allowed to board anyway)', err);
+      }
+    }
+
     // Audit is best-effort here: verification already answered the driver, and a
     // DB blip (or a rider deleted mid-window tripping the FK) must not 500 the
     // scan. Failures are logged loudly instead.
@@ -111,6 +151,6 @@ export class BoardingService {
       console.error('boarding: failed to record scan event (audit gap)', err);
     }
 
-    return { valid: reason === 'ok', riderId, reason };
+    return { valid: reason === 'ok', riderId, reason, deducted };
   }
 }

--- a/services/api/src/modules/reservations/reservation.repository.pg.ts
+++ b/services/api/src/modules/reservations/reservation.repository.pg.ts
@@ -102,4 +102,25 @@ export class PgReservationRepository implements ReservationRepository {
     );
     return rows[0] ? toReservation(rows[0]) : null;
   }
+
+  async findBoardable(userId: string, travelDate: string): Promise<Reservation | null> {
+    // Earliest still-open leg (morning before evening — explicit, not
+    // alphabetical); boarded seats excluded.
+    const { rows } = await this.pool.query<ReservationRow>(
+      `SELECT * FROM reservations
+       WHERE user_id = $1 AND travel_date = $2 AND status = 'reserved'
+       ORDER BY CASE direction WHEN 'morning' THEN 0 ELSE 1 END
+       LIMIT 1`,
+      [userId, travelDate],
+    );
+    return rows[0] ? toReservation(rows[0]) : null;
+  }
+
+  async markBoarded(id: string): Promise<Reservation | null> {
+    const { rows } = await this.pool.query<ReservationRow>(
+      `UPDATE reservations SET status = 'boarded', updated_at = now() WHERE id = $1 RETURNING *`,
+      [id],
+    );
+    return rows[0] ? toReservation(rows[0]) : null;
+  }
 }

--- a/services/api/src/modules/reservations/reservation.repository.ts
+++ b/services/api/src/modules/reservations/reservation.repository.ts
@@ -109,6 +109,24 @@ export interface ReservationRepository {
     travelDate: string,
     direction: ReservationDirection,
   ): Promise<Reservation | null>;
+  /**
+   * The rider's next boardable reservation for a day — the earliest still-open
+   * `reserved` seat (morning before evening), or null. This is what a boarding
+   * scan consumes; already-`boarded` seats are skipped so a re-scan can't
+   * double-deduct.
+   *
+   * @param userId - the rider.
+   * @param travelDate - the travel day (`YYYY-MM-DD`).
+   * @returns the reservation to board, or null.
+   */
+  findBoardable(userId: string, travelDate: string): Promise<Reservation | null>;
+  /**
+   * Mark a reservation `boarded` (the rider verified onto the vehicle).
+   *
+   * @param id - the reservation id.
+   * @returns the updated reservation, or null if not found.
+   */
+  markBoarded(id: string): Promise<Reservation | null>;
 }
 
 /** In-memory {@link ReservationRepository} for dev and unit tests. */
@@ -209,5 +227,23 @@ export class InMemoryReservationRepository implements ReservationRepository {
   ): Promise<Reservation | null> {
     const i = this.index(userId, travelDate, direction);
     return i >= 0 ? this.rows[i]! : null;
+  }
+
+  async findBoardable(userId: string, travelDate: string): Promise<Reservation | null> {
+    // Earliest open leg first — morning before evening (not alphabetical:
+    // 'evening' < 'morning', so we rank explicitly).
+    const rank = (d: ReservationDirection): number => (d === 'morning' ? 0 : 1);
+    const open = this.rows
+      .filter((r) => r.userId === userId && r.travelDate === travelDate && r.status === 'reserved')
+      .sort((a, b) => rank(a.direction) - rank(b.direction));
+    return open[0] ?? null;
+  }
+
+  async markBoarded(id: string): Promise<Reservation | null> {
+    const row = this.rows.find((r) => r.id === id);
+    if (!row) return null;
+    row.status = 'boarded';
+    row.updatedAt = new Date();
+    return row;
   }
 }

--- a/services/api/src/server.ts
+++ b/services/api/src/server.ts
@@ -171,10 +171,13 @@ async function main(): Promise<void> {
   }
 
   // Boarding: short-lived QR passes signed with the server key + a scan audit
-  // log; the KV store marks passes consumed (single-use).
+  // log; the KV store marks passes consumed (single-use). A valid scan boards
+  // the rider's confirmed reservation and debits a ride (E4).
   const boardingService = new BoardingService({
     scanEvents,
     kv,
+    reservations,
+    entitlements,
     secret: auth.secret,
     passTtlSeconds: 60,
   });

--- a/services/api/tests/boarding.deduction.test.ts
+++ b/services/api/tests/boarding.deduction.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+import { buildApp } from '../src/app';
+import { InMemoryReservationRepository } from '../src/modules/reservations/reservation.repository';
+import { InMemoryEntitlementLedgerRepository } from '../src/modules/entitlements/entitlement-ledger.repository';
+import { createJwtService, type AuthConfig } from '../src/modules/auth/jwt';
+
+const auth: AuthConfig = {
+  secret: 'test-secret-at-least-32-characters-long-0000',
+  accessTtl: '15m',
+  issuer: 'trotxi',
+  audience: 'trotxi-api',
+};
+const jwt = createJwtService(auth);
+const bearer = (t: string) => ({ authorization: `Bearer ${t}` });
+const today = () => new Date().toISOString().slice(0, 10);
+
+/** App wired with shared reservation + entitlement stores, rider pre-allocated rides. */
+async function setup(riderId = 'rider-1') {
+  const reservations = new InMemoryReservationRepository();
+  const entitlements = new InMemoryEntitlementLedgerRepository();
+  await entitlements.record({
+    userId: riderId,
+    deltaRides: 44,
+    reason: 'allocation',
+    idempotencyKey: `alloc-${riderId}`,
+  });
+  const app = await buildApp({ auth, reservations, entitlements });
+  const riderToken = await jwt.signAccessToken({ userId: riderId, role: 'commuter' });
+  const driverToken = await jwt.signAccessToken({ userId: 'driver-1', role: 'driver' });
+  return { app, reservations, entitlements, riderToken, driverToken, riderId };
+}
+
+const getPass = async (app: Awaited<ReturnType<typeof buildApp>>, riderToken: string) =>
+  (await app.inject({ method: 'GET', url: '/me/pass', headers: bearer(riderToken) })).json().pass;
+
+const scan = async (app: Awaited<ReturnType<typeof buildApp>>, driverToken: string, pass: string) =>
+  app.inject({
+    method: 'POST',
+    url: '/boarding/scan',
+    headers: bearer(driverToken),
+    payload: { pass },
+  });
+
+const rides = async (app: Awaited<ReturnType<typeof buildApp>>, riderToken: string) =>
+  (await app.inject({ method: 'GET', url: '/me/rides', headers: bearer(riderToken) })).json()
+    .remainingRides;
+
+describe('boarding deduction (E4)', () => {
+  it('a valid scan of a confirmed rider boards the seat and debits one ride', async () => {
+    const { app, reservations, riderToken, driverToken, riderId } = await setup();
+    await app.inject({
+      method: 'POST',
+      url: '/me/reservations',
+      headers: bearer(riderToken),
+      payload: { travelDate: today(), direction: 'morning', travelling: true },
+    });
+    expect(await rides(app, riderToken)).toBe(44);
+
+    const res = await scan(app, driverToken, await getPass(app, riderToken));
+    expect(res.json()).toMatchObject({ valid: true, riderId, reason: 'ok', deducted: true });
+    expect(await rides(app, riderToken)).toBe(43);
+    expect((await reservations.find(riderId, today(), 'morning'))?.status).toBe('boarded');
+  });
+
+  it('re-scanning a boarded rider (fresh QR) does not double-charge', async () => {
+    const { app, riderToken, driverToken } = await setup();
+    await app.inject({
+      method: 'POST',
+      url: '/me/reservations',
+      headers: bearer(riderToken),
+      payload: { travelDate: today(), direction: 'morning', travelling: true },
+    });
+    await scan(app, driverToken, await getPass(app, riderToken)); // boards, -1
+    expect(await rides(app, riderToken)).toBe(43);
+
+    // a freshly issued pass (new jti) passes single-use, but the seat is boarded
+    const replay = await scan(app, driverToken, await getPass(app, riderToken));
+    expect(replay.json()).toMatchObject({ valid: true, deducted: false });
+    expect(await rides(app, riderToken)).toBe(43); // unchanged
+  });
+
+  it('a valid scan with no confirmed reservation boards nothing (no debit)', async () => {
+    const { app, riderToken, driverToken } = await setup();
+    const res = await scan(app, driverToken, await getPass(app, riderToken));
+    expect(res.json()).toMatchObject({ valid: true, reason: 'ok', deducted: false });
+    expect(await rides(app, riderToken)).toBe(44);
+  });
+
+  it('a declined reservation is not boardable (no debit)', async () => {
+    const { app, riderToken, driverToken } = await setup();
+    await app.inject({
+      method: 'POST',
+      url: '/me/reservations',
+      headers: bearer(riderToken),
+      payload: { travelDate: today(), direction: 'morning', travelling: false },
+    });
+    const res = await scan(app, driverToken, await getPass(app, riderToken));
+    expect(res.json()).toMatchObject({ valid: true, deducted: false });
+    expect(await rides(app, riderToken)).toBe(44);
+  });
+
+  it('morning boards before evening (earliest open leg first)', async () => {
+    const { app, reservations, riderToken, driverToken, riderId } = await setup();
+    for (const direction of ['evening', 'morning'] as const) {
+      await app.inject({
+        method: 'POST',
+        url: '/me/reservations',
+        headers: bearer(riderToken),
+        payload: { travelDate: today(), direction, travelling: true },
+      });
+    }
+    await scan(app, driverToken, await getPass(app, riderToken));
+    expect((await reservations.find(riderId, today(), 'morning'))?.status).toBe('boarded');
+    expect((await reservations.find(riderId, today(), 'evening'))?.status).toBe('reserved');
+    expect(await rides(app, riderToken)).toBe(43);
+  });
+});


### PR DESCRIPTION
The **money-critical half of E4** — a valid QR scan now consumes the rider's confirmed reservation and **debits one ride** from their entitlement (ADR-0014). Built on E1 (ledger, merged) + E3 (reservations, merged); **no dependency on trips/admin (#26)**.

### What
- **`ReservationRepository`** gains `findBoardable(user, date)` — the earliest still-open `reserved` leg (**morning before evening**, explicit rank; boarded seats excluded) — and `markBoarded(id)`. Both InMemory + Pg.
- **`BoardingService.verifyScan`**: on a valid scan, board that reservation + record `entitlement −1`, idempotency key **`board:<reservationId>`**. Because `findBoardable` skips already-boarded seats *and* the debit is keyed by reservation, re-scanning a rider (even with a **freshly rotated QR**) can't double-charge. **Fails open** — a deduction hiccup never blocks the bus. New `reservations`/`entitlements` deps are **optional** (verification stays integrity-only when unwired).
- **Scan response** gains `deducted: boolean`. Repos hoisted to shared instances in `app.ts` so the scan boards the same reservation the rider confirmed and debits the ledger `GET /me/rides` reads.

### Scope note (honest)
PIN turned out to be **manifest-coupled** (a 4-digit code can't identify a rider alone), so it ships with the **manifest + no-show cron in #26**. This PR is the deduction, which the QR scan *does* enable standalone.

### Tests
6 new: confirm→scan→−1, **no-double-charge on re-scan**, no-reservation ⇒ no debit, declined not boardable, morning-before-evening. **189 green**, coverage gate passes. (Caught + fixed a real ordering bug: `'evening' < 'morning'` alphabetically.)