### PR TITLE
feat(api): admin/ops endpoints — fleet CRUD + driver↔trip assignment (#26)

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -18,7 +18,7 @@ areas land; it is not authoritative once the code moves.
 | Domain repos | `users/*`, `subscriptions/*` — **repos only, no routes**; `mobility/*` — repos + browse routes (#17)                                                                                                     |
 | Contract     | `lib/schemas.ts`, `user.schema.ts`, `mobility.schema.ts`, OpenAPI via zod type-provider (ADR-0008)                                                                                                       |
 
-**Live HTTP surface:** `/`, `/version`, `/healthz`, `/readyz`, `/me`, `/docs`, `/routes`, `/routes/:id`, `/trips`, `/trips/:id`.
+**Live HTTP surface:** `/`, `/version`, `/healthz`, `/readyz`, `/me`, `/docs`, `/routes`, `/routes/:id`, `/trips`, `/trips/:id`, `/admin/*` (fleet CRUD + trip assignment, admin-only, #26).
 
 **Cross-cutting (in place):** repository pattern (ADR-0009), KV fallback
 (ADR-0010), readiness pings DB+KV, rate limiting, typed OpenAPI, ~100% unit
@@ -72,12 +72,13 @@ operational layer now has schedules — boarding and live positions are next.
 
 **Still missing (mobility):**
 
-| Area                               | Issue | Notes                                                                                                               |
-| ---------------------------------- | ----- | ------------------------------------------------------------------------------------------------------------------- |
-| Trips & schedules                  | #18   | ✅ landed — trips/vehicles/drivers + `assigned_driver_id`; `GET /trips` (`?routeId`), `GET /trips/:id` (auth-gated) |
-| QR boarding / passes / scan_events | #20   | none                                                                                                                |
-| Live vehicle positions (polling)   | #25   | no positions table; ADR-0002 telemetry deferred                                                                     |
-| Nearest-stop spatial query         | —     | GiST index is in place; no endpoint yet                                                                             |
+| Area                                | Issue | Notes                                                                                                                 |
+| ----------------------------------- | ----- | --------------------------------------------------------------------------------------------------------------------- |
+| Trips & schedules                   | #18   | ✅ landed — trips/vehicles/drivers + `assigned_driver_id`; `GET /trips` (`?routeId`), `GET /trips/:id` (auth-gated)   |
+| Admin/ops (fleet CRUD + assignment) | #26   | ✅ landed — `/admin/*` admin-guarded CRUD for routes/stops/vehicles/drivers/trips + `PUT /admin/trips/:id/assignment` |
+| QR boarding / passes / scan_events  | #20   | none                                                                                                                  |
+| Live vehicle positions (polling)    | #25   | no positions table; ADR-0002 telemetry deferred                                                                       |
+| Nearest-stop spatial query          | —     | GiST index is in place; no endpoint yet                                                                               |
 
 ### ❌ Not started (mapped to issues)
 

--- a/services/api/src/app.ts
+++ b/services/api/src/app.ts
@@ -48,9 +48,12 @@ import {
 import type { RouteStopRepository } from './modules/mobility/route-stop.repository';
 import { mobilityRoutes } from './modules/mobility/mobility.routes';
 import { tripRoutes } from './modules/mobility/trips.routes';
+import { adminRoutes } from './modules/admin/admin.routes';
 import type { RouteRepository } from './modules/mobility/route.repository';
 import type { StopRepository } from './modules/mobility/stop.repository';
 import type { TripRepository } from './modules/mobility/trip.repository';
+import type { VehicleRepository } from './modules/mobility/vehicle.repository';
+import type { DriverRepository } from './modules/mobility/driver.repository';
 import type { SubscriptionRepository } from './modules/subscriptions/subscription.repository';
 import type { UserRepository } from './modules/users/user.repository';
 
@@ -72,6 +75,9 @@ export interface AppDeps {
   routeStops?: RouteStopRepository;
   /** Trips (scheduled route runs). Reads require auth; routes return 503 when absent. */
   trips?: TripRepository;
+  /** Fleet vehicles + drivers. Managed via the admin/ops endpoints (#26). */
+  vehicles?: VehicleRepository;
+  drivers?: DriverRepository;
   /** Device push-token registry (in-memory vs Postgres). Defaults to in-memory. */
   deviceTokens?: DeviceTokenRepository;
   /** Boarding pass issuance + scan verification. Defaults to an in-memory scan store. */
@@ -135,6 +141,10 @@ export async function buildApp(deps: AppDeps = {}): Promise<FastifyInstance> {
         { name: 'rides', description: 'Ride entitlement + Ride Credit balance' },
         { name: 'reservations', description: 'Daily ride confirmation (confirm/decline)' },
         { name: 'mobility', description: 'Routes and stops' },
+        {
+          name: 'admin',
+          description: 'Admin/ops: manage fleet (routes/stops/vehicles/drivers/trips) + assignment',
+        },
         { name: 'boarding', description: 'QR boarding passes + scan verification' },
       ],
       components: {
@@ -213,6 +223,15 @@ export async function buildApp(deps: AppDeps = {}): Promise<FastifyInstance> {
     routeStops: deps.routeStops,
   });
   await app.register(tripRoutes, {
+    trips: deps.trips,
+    rateLimit: deps.rateLimit ?? DEFAULT_RATE_LIMIT,
+  });
+  await app.register(adminRoutes, {
+    routes: deps.routes,
+    stops: deps.stops,
+    routeStops: deps.routeStops,
+    vehicles: deps.vehicles,
+    drivers: deps.drivers,
     trips: deps.trips,
     rateLimit: deps.rateLimit ?? DEFAULT_RATE_LIMIT,
   });

--- a/services/api/src/lib/patch.ts
+++ b/services/api/src/lib/patch.ts
@@ -1,0 +1,24 @@
+// Shared helper for partial (PATCH) updates in the repositories. Merging a patch
+// over a stored row must treat a key whose value is `undefined` as "not
+// provided" — leaving the stored value unchanged — while an explicit `null`
+// still clears a nullable field. A plain `{ ...base, ...patch }` spread breaks
+// this: an `undefined` in the patch overwrites the stored value (and, on the
+// Postgres path, would write NULL). applyPatch copies only defined keys.
+
+/**
+ * Merge a partial patch over a base object, ignoring keys whose value is
+ * `undefined` (an omitted field leaves the stored value unchanged; an explicit
+ * `null` is applied).
+ *
+ * @param base - the current object.
+ * @param patch - the fields to change; `undefined` values are skipped.
+ * @returns a new object with the defined patch fields applied.
+ */
+export function applyPatch<T extends object>(base: T, patch: Partial<T>): T {
+  const out = { ...base };
+  for (const key of Object.keys(patch) as (keyof T)[]) {
+    const value = patch[key];
+    if (value !== undefined) out[key] = value as T[keyof T];
+  }
+  return out;
+}

--- a/services/api/src/modules/admin/admin.routes.ts
+++ b/services/api/src/modules/admin/admin.routes.ts
@@ -1,0 +1,461 @@
+// Admin/ops endpoints (#26). Operations manages the mobility fleet here rather
+// than via seed scripts: CRUD for routes/stops/vehicles/drivers/trips plus the
+// driver↔trip assignment that authorizes GPS reporting (#25). Every route is
+// gated by `requireRole('admin')` (401 unauth → 403 non-admin). Handlers call
+// repositories directly (no service layer yet) and 503 when a repo is unwired,
+// matching the rest of the API. Update bodies are partial; the repository merges
+// the patch over the existing row (see admin.schema.ts).
+
+import type { FastifyInstance } from 'fastify';
+import type { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { z } from 'zod';
+import { errorResponseSchema } from '../../lib/schemas';
+import type { RateLimitConfig } from '../ratelimit/ratelimit.plugin';
+import type { DriverRepository } from '../mobility/driver.repository';
+import type { RouteStopRepository } from '../mobility/route-stop.repository';
+import type { RouteRepository } from '../mobility/route.repository';
+import type { StopRepository } from '../mobility/stop.repository';
+import type { TripRepository } from '../mobility/trip.repository';
+import type { VehicleRepository } from '../mobility/vehicle.repository';
+import {
+  driverResponseSchema,
+  routeResponseSchema,
+  stopResponseSchema,
+  tripResponseSchema,
+  vehicleResponseSchema,
+} from '../mobility/mobility.schema';
+import {
+  assignTripBodySchema,
+  attachStopBodySchema,
+  createDriverBodySchema,
+  createRouteBodySchema,
+  createStopBodySchema,
+  createTripBodySchema,
+  createVehicleBodySchema,
+  updateDriverBodySchema,
+  updateRouteBodySchema,
+  updateStopBodySchema,
+  updateTripBodySchema,
+  updateVehicleBodySchema,
+} from './admin.schema';
+
+const idParam = z.object({ id: z.string().uuid() });
+
+const routeStopResponseSchema = z.object({
+  id: z.string().uuid(),
+  routeId: z.string().uuid(),
+  stopId: z.string().uuid(),
+  seq: z.number().int(),
+  createdAt: z.date(),
+});
+
+// Shared error-response maps. Spread into a route's `response` — this only
+// affects the (error) response shapes, never request body/param inference.
+const authErrors = {
+  401: errorResponseSchema,
+  403: errorResponseSchema,
+  503: errorResponseSchema,
+};
+const authErrorsNF = { ...authErrors, 404: errorResponseSchema };
+
+/** Dependencies for the admin router — the full mobility repository set. */
+export interface AdminDeps {
+  routes?: RouteRepository;
+  stops?: StopRepository;
+  routeStops?: RouteStopRepository;
+  vehicles?: VehicleRepository;
+  drivers?: DriverRepository;
+  trips?: TripRepository;
+  rateLimit: RateLimitConfig;
+}
+
+/**
+ * Register the admin/ops endpoints under `/admin/*`, all admin-role guarded.
+ *
+ * @param app - the Fastify instance to register on.
+ * @param opts - the mobility repositories and rate-limit config.
+ */
+export async function adminRoutes(app: FastifyInstance, opts: AdminDeps): Promise<void> {
+  const r = app.withTypeProvider<ZodTypeProvider>();
+  const UNAVAILABLE = { error: 'unavailable', message: 'Admin ops are not configured' };
+  const notFound = (message: string) => ({ error: 'not_found', message });
+
+  // authenticate → requireRole('admin') → rate limit. Reused by every route.
+  const adminOnly = [
+    app.authenticate,
+    app.requireRole('admin'),
+    app.rateLimit({ ...opts.rateLimit, by: 'user' }),
+  ];
+
+  // ---------------------------------------------------------------- routes ---
+  r.post(
+    '/admin/routes',
+    {
+      schema: {
+        tags: ['admin'],
+        summary: 'Create a route',
+        security: [{ bearerAuth: [] }],
+        body: createRouteBodySchema,
+        response: { 200: routeResponseSchema, ...authErrors },
+      },
+      preHandler: adminOnly,
+    },
+    async (request, reply) => {
+      if (!opts.routes) return reply.code(503).send(UNAVAILABLE);
+      return opts.routes.create(request.body);
+    },
+  );
+
+  r.get(
+    '/admin/routes',
+    {
+      schema: {
+        tags: ['admin'],
+        summary: 'List all routes',
+        security: [{ bearerAuth: [] }],
+        response: { 200: z.array(routeResponseSchema), ...authErrors },
+      },
+      preHandler: adminOnly,
+    },
+    async (_request, reply) => {
+      if (!opts.routes) return reply.code(503).send(UNAVAILABLE);
+      return opts.routes.findAll();
+    },
+  );
+
+  r.patch(
+    '/admin/routes/:id',
+    {
+      schema: {
+        tags: ['admin'],
+        summary: 'Update a route',
+        security: [{ bearerAuth: [] }],
+        params: idParam,
+        body: updateRouteBodySchema,
+        response: { 200: routeResponseSchema, ...authErrorsNF },
+      },
+      preHandler: adminOnly,
+    },
+    async (request, reply) => {
+      if (!opts.routes) return reply.code(503).send(UNAVAILABLE);
+      const updated = await opts.routes.update(request.params.id, request.body);
+      if (!updated) return reply.code(404).send(notFound('Route not found'));
+      return updated;
+    },
+  );
+
+  // Attach an existing stop to a route at a sequence position (route_stops).
+  r.post(
+    '/admin/routes/:id/stops',
+    {
+      schema: {
+        tags: ['admin'],
+        summary: 'Attach a stop to a route at a sequence position',
+        security: [{ bearerAuth: [] }],
+        params: idParam,
+        body: attachStopBodySchema,
+        response: { 200: routeStopResponseSchema, ...authErrorsNF },
+      },
+      preHandler: adminOnly,
+    },
+    async (request, reply) => {
+      if (!opts.routes || !opts.stops || !opts.routeStops) {
+        return reply.code(503).send(UNAVAILABLE);
+      }
+      if (!(await opts.routes.findById(request.params.id))) {
+        return reply.code(404).send(notFound('Route not found'));
+      }
+      if (!(await opts.stops.findById(request.body.stopId))) {
+        return reply.code(404).send(notFound('Stop not found'));
+      }
+      return opts.routeStops.create({
+        routeId: request.params.id,
+        stopId: request.body.stopId,
+        seq: request.body.seq,
+      });
+    },
+  );
+
+  // ----------------------------------------------------------------- stops ---
+  r.post(
+    '/admin/stops',
+    {
+      schema: {
+        tags: ['admin'],
+        summary: 'Create a stop',
+        security: [{ bearerAuth: [] }],
+        body: createStopBodySchema,
+        response: { 200: stopResponseSchema, ...authErrors },
+      },
+      preHandler: adminOnly,
+    },
+    async (request, reply) => {
+      if (!opts.stops) return reply.code(503).send(UNAVAILABLE);
+      return opts.stops.create(request.body);
+    },
+  );
+
+  r.get(
+    '/admin/stops',
+    {
+      schema: {
+        tags: ['admin'],
+        summary: 'List all stops',
+        security: [{ bearerAuth: [] }],
+        response: { 200: z.array(stopResponseSchema), ...authErrors },
+      },
+      preHandler: adminOnly,
+    },
+    async (_request, reply) => {
+      if (!opts.stops) return reply.code(503).send(UNAVAILABLE);
+      return opts.stops.findAll();
+    },
+  );
+
+  r.patch(
+    '/admin/stops/:id',
+    {
+      schema: {
+        tags: ['admin'],
+        summary: 'Update a stop',
+        security: [{ bearerAuth: [] }],
+        params: idParam,
+        body: updateStopBodySchema,
+        response: { 200: stopResponseSchema, ...authErrorsNF },
+      },
+      preHandler: adminOnly,
+    },
+    async (request, reply) => {
+      if (!opts.stops) return reply.code(503).send(UNAVAILABLE);
+      const updated = await opts.stops.update(request.params.id, request.body);
+      if (!updated) return reply.code(404).send(notFound('Stop not found'));
+      return updated;
+    },
+  );
+
+  // -------------------------------------------------------------- vehicles ---
+  r.post(
+    '/admin/vehicles',
+    {
+      schema: {
+        tags: ['admin'],
+        summary: 'Create a vehicle',
+        security: [{ bearerAuth: [] }],
+        body: createVehicleBodySchema,
+        response: { 200: vehicleResponseSchema, ...authErrors },
+      },
+      preHandler: adminOnly,
+    },
+    async (request, reply) => {
+      if (!opts.vehicles) return reply.code(503).send(UNAVAILABLE);
+      return opts.vehicles.create(request.body);
+    },
+  );
+
+  r.get(
+    '/admin/vehicles',
+    {
+      schema: {
+        tags: ['admin'],
+        summary: 'List all vehicles',
+        security: [{ bearerAuth: [] }],
+        response: { 200: z.array(vehicleResponseSchema), ...authErrors },
+      },
+      preHandler: adminOnly,
+    },
+    async (_request, reply) => {
+      if (!opts.vehicles) return reply.code(503).send(UNAVAILABLE);
+      return opts.vehicles.findAll();
+    },
+  );
+
+  r.patch(
+    '/admin/vehicles/:id',
+    {
+      schema: {
+        tags: ['admin'],
+        summary: 'Update a vehicle',
+        security: [{ bearerAuth: [] }],
+        params: idParam,
+        body: updateVehicleBodySchema,
+        response: { 200: vehicleResponseSchema, ...authErrorsNF },
+      },
+      preHandler: adminOnly,
+    },
+    async (request, reply) => {
+      if (!opts.vehicles) return reply.code(503).send(UNAVAILABLE);
+      const updated = await opts.vehicles.update(request.params.id, request.body);
+      if (!updated) return reply.code(404).send(notFound('Vehicle not found'));
+      return updated;
+    },
+  );
+
+  // --------------------------------------------------------------- drivers ---
+  r.post(
+    '/admin/drivers',
+    {
+      schema: {
+        tags: ['admin'],
+        summary: 'Create a driver',
+        security: [{ bearerAuth: [] }],
+        body: createDriverBodySchema,
+        response: { 200: driverResponseSchema, ...authErrors },
+      },
+      preHandler: adminOnly,
+    },
+    async (request, reply) => {
+      if (!opts.drivers) return reply.code(503).send(UNAVAILABLE);
+      return opts.drivers.create(request.body);
+    },
+  );
+
+  r.get(
+    '/admin/drivers',
+    {
+      schema: {
+        tags: ['admin'],
+        summary: 'List all drivers',
+        security: [{ bearerAuth: [] }],
+        response: { 200: z.array(driverResponseSchema), ...authErrors },
+      },
+      preHandler: adminOnly,
+    },
+    async (_request, reply) => {
+      if (!opts.drivers) return reply.code(503).send(UNAVAILABLE);
+      return opts.drivers.findAll();
+    },
+  );
+
+  r.patch(
+    '/admin/drivers/:id',
+    {
+      schema: {
+        tags: ['admin'],
+        summary: 'Update a driver',
+        security: [{ bearerAuth: [] }],
+        params: idParam,
+        body: updateDriverBodySchema,
+        response: { 200: driverResponseSchema, ...authErrorsNF },
+      },
+      preHandler: adminOnly,
+    },
+    async (request, reply) => {
+      if (!opts.drivers) return reply.code(503).send(UNAVAILABLE);
+      const updated = await opts.drivers.update(request.params.id, request.body);
+      if (!updated) return reply.code(404).send(notFound('Driver not found'));
+      return updated;
+    },
+  );
+
+  // ----------------------------------------------------------------- trips ---
+  r.post(
+    '/admin/trips',
+    {
+      schema: {
+        tags: ['admin'],
+        summary: 'Create a trip',
+        security: [{ bearerAuth: [] }],
+        body: createTripBodySchema,
+        response: { 200: tripResponseSchema, ...authErrorsNF },
+      },
+      preHandler: adminOnly,
+    },
+    async (request, reply) => {
+      if (!opts.trips || !opts.routes || !opts.vehicles || !opts.drivers) {
+        return reply.code(503).send(UNAVAILABLE);
+      }
+      const { routeId, vehicleId, assignedDriverId, status, scheduledAt } = request.body;
+      // Validate FK targets up front so the client gets a clean 404 rather than
+      // a DB constraint error (and so it works in the in-memory adapter too).
+      if (!(await opts.routes.findById(routeId))) {
+        return reply.code(404).send(notFound('Route not found'));
+      }
+      if (vehicleId && !(await opts.vehicles.findById(vehicleId))) {
+        return reply.code(404).send(notFound('Vehicle not found'));
+      }
+      if (assignedDriverId && !(await opts.drivers.findById(assignedDriverId))) {
+        return reply.code(404).send(notFound('Driver not found'));
+      }
+      return opts.trips.create({
+        routeId,
+        vehicleId: vehicleId ?? null,
+        assignedDriverId: assignedDriverId ?? null,
+        status,
+        scheduledAt: new Date(scheduledAt),
+      });
+    },
+  );
+
+  r.get(
+    '/admin/trips',
+    {
+      schema: {
+        tags: ['admin'],
+        summary: 'List all trips',
+        security: [{ bearerAuth: [] }],
+        response: { 200: z.array(tripResponseSchema), ...authErrors },
+      },
+      preHandler: adminOnly,
+    },
+    async (_request, reply) => {
+      if (!opts.trips) return reply.code(503).send(UNAVAILABLE);
+      return opts.trips.findAll();
+    },
+  );
+
+  r.patch(
+    '/admin/trips/:id',
+    {
+      schema: {
+        tags: ['admin'],
+        summary: 'Update a trip (status / schedule)',
+        security: [{ bearerAuth: [] }],
+        params: idParam,
+        body: updateTripBodySchema,
+        response: { 200: tripResponseSchema, ...authErrorsNF },
+      },
+      preHandler: adminOnly,
+    },
+    async (request, reply) => {
+      if (!opts.trips) return reply.code(503).send(UNAVAILABLE);
+      const updated = await opts.trips.update(request.params.id, {
+        status: request.body.status,
+        scheduledAt: request.body.scheduledAt ? new Date(request.body.scheduledAt) : undefined,
+      });
+      if (!updated) return reply.code(404).send(notFound('Trip not found'));
+      return updated;
+    },
+  );
+
+  // Driver↔trip (and vehicle) assignment — the field that authorizes GPS
+  // reporting (#25). Validates the targets exist; explicit null unassigns.
+  r.put(
+    '/admin/trips/:id/assignment',
+    {
+      schema: {
+        tags: ['admin'],
+        summary: 'Assign a vehicle and/or driver to a trip',
+        security: [{ bearerAuth: [] }],
+        params: idParam,
+        body: assignTripBodySchema,
+        response: { 200: tripResponseSchema, ...authErrorsNF },
+      },
+      preHandler: adminOnly,
+    },
+    async (request, reply) => {
+      if (!opts.trips || !opts.vehicles || !opts.drivers) {
+        return reply.code(503).send(UNAVAILABLE);
+      }
+      const { vehicleId, assignedDriverId } = request.body;
+      if (vehicleId && !(await opts.vehicles.findById(vehicleId))) {
+        return reply.code(404).send(notFound('Vehicle not found'));
+      }
+      if (assignedDriverId && !(await opts.drivers.findById(assignedDriverId))) {
+        return reply.code(404).send(notFound('Driver not found'));
+      }
+      const updated = await opts.trips.update(request.params.id, { vehicleId, assignedDriverId });
+      if (!updated) return reply.code(404).send(notFound('Trip not found'));
+      return updated;
+    },
+  );
+}

--- a/services/api/src/modules/admin/admin.schema.ts
+++ b/services/api/src/modules/admin/admin.schema.ts
@@ -1,0 +1,87 @@
+// Request-body schemas for the admin/ops endpoints (#26). Responses reuse the
+// domain schemas from mobility.schema.ts. Create bodies mirror the repositories'
+// New* inputs; update bodies are partial (every field optional) — the handler
+// merges the patch over the existing row, so an omitted field is left unchanged
+// and an explicit null clears a nullable field. Timestamps are ISO-8601 strings
+// on the wire and converted to Date at the handler boundary.
+
+import { z } from 'zod';
+import { TRIP_STATUSES } from '../mobility/trip.repository';
+
+const latitude = z.number().min(-90).max(90);
+const longitude = z.number().min(-180).max(180);
+
+// --- routes ---
+export const createRouteBodySchema = z.object({
+  name: z.string().min(1),
+  description: z.string().nullable().optional(),
+});
+export const updateRouteBodySchema = z.object({
+  name: z.string().min(1).optional(),
+  description: z.string().nullable().optional(),
+});
+
+// --- stops ---
+export const createStopBodySchema = z.object({
+  name: z.string().min(1),
+  latitude,
+  longitude,
+});
+export const updateStopBodySchema = z.object({
+  name: z.string().min(1).optional(),
+  latitude: latitude.optional(),
+  longitude: longitude.optional(),
+});
+
+// Attach an existing stop to a route at a sequence position (route_stops).
+export const attachStopBodySchema = z.object({
+  stopId: z.string().uuid(),
+  seq: z.number().int().nonnegative(),
+});
+
+// --- vehicles ---
+export const createVehicleBodySchema = z.object({
+  registration: z.string().min(1),
+  label: z.string().nullable().optional(),
+  capacity: z.number().int().nonnegative().optional(),
+});
+export const updateVehicleBodySchema = z.object({
+  registration: z.string().min(1).optional(),
+  label: z.string().nullable().optional(),
+  capacity: z.number().int().nonnegative().optional(),
+});
+
+// --- drivers ---
+export const createDriverBodySchema = z.object({
+  fullName: z.string().min(1),
+  phone: z.string().nullable().optional(),
+  licenseNumber: z.string().nullable().optional(),
+  userId: z.string().uuid().nullable().optional(),
+});
+export const updateDriverBodySchema = z.object({
+  fullName: z.string().min(1).optional(),
+  phone: z.string().nullable().optional(),
+  licenseNumber: z.string().nullable().optional(),
+  userId: z.string().uuid().nullable().optional(),
+});
+
+// --- trips ---
+export const createTripBodySchema = z.object({
+  routeId: z.string().uuid(),
+  vehicleId: z.string().uuid().nullable().optional(),
+  assignedDriverId: z.string().uuid().nullable().optional(),
+  status: z.enum(TRIP_STATUSES).optional(),
+  scheduledAt: z.string().datetime(),
+});
+export const updateTripBodySchema = z.object({
+  status: z.enum(TRIP_STATUSES).optional(),
+  scheduledAt: z.string().datetime().optional(),
+});
+
+// Driver↔trip (and vehicle) assignment — the field that authorizes GPS
+// reporting (#25). Both optional so a call can assign either or both; an
+// explicit null unassigns.
+export const assignTripBodySchema = z.object({
+  vehicleId: z.string().uuid().nullable().optional(),
+  assignedDriverId: z.string().uuid().nullable().optional(),
+});

--- a/services/api/src/modules/mobility/driver.repository.pg.ts
+++ b/services/api/src/modules/mobility/driver.repository.pg.ts
@@ -1,5 +1,6 @@
 import type { Pool } from 'pg';
-import type { Driver, DriverRepository, NewDriver } from './driver.repository';
+import { applyPatch } from '../../lib/patch';
+import type { Driver, DriverRepository, DriverUpdate, NewDriver } from './driver.repository';
 
 interface DriverRow {
   id: string;
@@ -35,6 +36,23 @@ export class PgDriverRepository implements DriverRepository {
 
   async findById(id: string): Promise<Driver | null> {
     const { rows } = await this.pool.query<DriverRow>('SELECT * FROM drivers WHERE id = $1', [id]);
+    return rows[0] ? toDriver(rows[0]) : null;
+  }
+
+  async findAll(): Promise<Driver[]> {
+    const { rows } = await this.pool.query<DriverRow>('SELECT * FROM drivers ORDER BY created_at');
+    return rows.map(toDriver);
+  }
+
+  async update(id: string, patch: DriverUpdate): Promise<Driver | null> {
+    const existing = await this.findById(id);
+    if (!existing) return null;
+    const next = applyPatch(existing, patch);
+    const { rows } = await this.pool.query<DriverRow>(
+      `UPDATE drivers SET full_name = $2, phone = $3, license_number = $4, user_id = $5
+       WHERE id = $1 RETURNING *`,
+      [id, next.fullName, next.phone, next.licenseNumber, next.userId],
+    );
     return rows[0] ? toDriver(rows[0]) : null;
   }
 }

--- a/services/api/src/modules/mobility/driver.repository.ts
+++ b/services/api/src/modules/mobility/driver.repository.ts
@@ -5,6 +5,8 @@
 // authorized (only the assigned driver — system-design §7, #25). Two
 // implementations: InMemory for dev/tests, Postgres (driver.repository.pg.ts).
 
+import { applyPatch } from '../../lib/patch';
+
 /** A driver who operates a vehicle on a trip. */
 export interface Driver {
   id: string;
@@ -19,6 +21,14 @@ export interface Driver {
 /** Fields needed to create a {@link Driver}. */
 export interface NewDriver {
   fullName: string;
+  phone?: string | null;
+  licenseNumber?: string | null;
+  userId?: string | null;
+}
+
+/** Editable {@link Driver} fields for a partial update (admin, #26). */
+export interface DriverUpdate {
+  fullName?: string;
   phone?: string | null;
   licenseNumber?: string | null;
   userId?: string | null;
@@ -40,6 +50,16 @@ export interface DriverRepository {
    * @returns the driver, or null if it doesn't exist.
    */
   findById(id: string): Promise<Driver | null>;
+  /** Returns all drivers. Used by admin ops (#26). */
+  findAll(): Promise<Driver[]>;
+  /**
+   * Update a driver's editable fields (partial — omitted fields are unchanged).
+   *
+   * @param id - the driver id.
+   * @param patch - the fields to change.
+   * @returns the updated driver, or null if not found.
+   */
+  update(id: string, patch: DriverUpdate): Promise<Driver | null>;
 }
 
 /** In-memory {@link DriverRepository} for dev and unit tests. */
@@ -61,5 +81,17 @@ export class InMemoryDriverRepository implements DriverRepository {
 
   async findById(id: string): Promise<Driver | null> {
     return this.drivers.get(id) ?? null;
+  }
+
+  async findAll(): Promise<Driver[]> {
+    return Array.from(this.drivers.values());
+  }
+
+  async update(id: string, patch: DriverUpdate): Promise<Driver | null> {
+    const existing = this.drivers.get(id);
+    if (!existing) return null;
+    const updated = applyPatch(existing, patch);
+    this.drivers.set(id, updated);
+    return updated;
   }
 }

--- a/services/api/src/modules/mobility/mobility.schema.ts
+++ b/services/api/src/modules/mobility/mobility.schema.ts
@@ -55,3 +55,22 @@ export const listTripsQuerySchema = z.object({
 export const tripListResponseSchema = z.object({
   trips: z.array(tripResponseSchema),
 });
+
+// A vehicle (bus) in the fleet. Exposed by admin ops (#26); no public endpoint.
+export const vehicleResponseSchema = z.object({
+  id: z.string().uuid(),
+  registration: z.string(),
+  label: z.string().nullable(),
+  capacity: z.number().int(),
+  createdAt: z.date(),
+});
+
+// A driver. userId links to an auth principal once driver sign-in lands (#25).
+export const driverResponseSchema = z.object({
+  id: z.string().uuid(),
+  fullName: z.string(),
+  phone: z.string().nullable(),
+  licenseNumber: z.string().nullable(),
+  userId: z.string().uuid().nullable(),
+  createdAt: z.date(),
+});

--- a/services/api/src/modules/mobility/route.repository.pg.ts
+++ b/services/api/src/modules/mobility/route.repository.pg.ts
@@ -1,5 +1,6 @@
 import type { Pool } from 'pg';
-import type { NewRoute, Route, RouteRepository } from './route.repository';
+import { applyPatch } from '../../lib/patch';
+import type { NewRoute, Route, RouteRepository, RouteUpdate } from './route.repository';
 
 interface RouteRow {
   id: string;
@@ -36,5 +37,20 @@ export class PgRouteRepository implements RouteRepository {
   async findAll(): Promise<Route[]> {
     const { rows } = await this.pool.query<RouteRow>('SELECT * FROM routes ORDER BY created_at');
     return rows.map(toRoute);
+  }
+
+  // Partial update via read-modify-write: merge the patch over the current row,
+  // then write the full editable set in one statement. This keeps the SQL static
+  // (no dynamic column list) while letting a nullable field be cleared with an
+  // explicit null — which COALESCE(col, $n) could not express.
+  async update(id: string, patch: RouteUpdate): Promise<Route | null> {
+    const existing = await this.findById(id);
+    if (!existing) return null;
+    const next = applyPatch(existing, patch);
+    const { rows } = await this.pool.query<RouteRow>(
+      `UPDATE routes SET name = $2, description = $3 WHERE id = $1 RETURNING *`,
+      [id, next.name, next.description],
+    );
+    return rows[0] ? toRoute(rows[0]) : null;
   }
 }

--- a/services/api/src/modules/mobility/route.repository.ts
+++ b/services/api/src/modules/mobility/route.repository.ts
@@ -3,6 +3,8 @@
 // in route_stops. Two implementations: InMemory for unit tests and zero-infra
 // dev, Postgres (route.repository.pg.ts) for real runs.
 
+import { applyPatch } from '../../lib/patch';
+
 /** A named journey path (e.g. "Circle to Legon"). Metadata only — the ordered
  * stops it passes through live in route_stops. */
 export interface Route {
@@ -15,6 +17,12 @@ export interface Route {
 /** Fields needed to create a {@link Route}. */
 export interface NewRoute {
   name: string;
+  description?: string | null;
+}
+
+/** Editable {@link Route} fields for a partial update (admin, #26). */
+export interface RouteUpdate {
+  name?: string;
   description?: string | null;
 }
 
@@ -36,6 +44,14 @@ export interface RouteRepository {
   findById(id: string): Promise<Route | null>;
   /** Returns all routes. Used by GET /routes (public browse). */
   findAll(): Promise<Route[]>;
+  /**
+   * Update a route's editable fields (partial — omitted fields are unchanged).
+   *
+   * @param id - the route id.
+   * @param patch - the fields to change.
+   * @returns the updated route, or null if not found.
+   */
+  update(id: string, patch: RouteUpdate): Promise<Route | null>;
 }
 
 /** In-memory {@link RouteRepository} for dev and unit tests. */
@@ -59,5 +75,13 @@ export class InMemoryRouteRepository implements RouteRepository {
 
   async findAll(): Promise<Route[]> {
     return Array.from(this.routes.values());
+  }
+
+  async update(id: string, patch: RouteUpdate): Promise<Route | null> {
+    const existing = this.routes.get(id);
+    if (!existing) return null;
+    const updated = applyPatch(existing, patch);
+    this.routes.set(id, updated);
+    return updated;
   }
 }

--- a/services/api/src/modules/mobility/stop.repository.pg.ts
+++ b/services/api/src/modules/mobility/stop.repository.pg.ts
@@ -5,7 +5,8 @@
 // Note: ST_MakePoint takes (longitude, latitude) — X is longitude, Y is latitude.
 
 import type { Pool } from 'pg';
-import type { NewStop, Stop, StopRepository } from './stop.repository';
+import { applyPatch } from '../../lib/patch';
+import type { NewStop, Stop, StopRepository, StopUpdate } from './stop.repository';
 
 interface StopRow {
   id: string;
@@ -47,6 +48,35 @@ export class PgStopRepository implements StopRepository {
          ST_X(location::geometry) AS longitude
        FROM stops WHERE id = $1`,
       [id],
+    );
+    return rows[0] ? toStop(rows[0]) : null;
+  }
+
+  async findAll(): Promise<Stop[]> {
+    const { rows } = await this.pool.query<StopRow>(
+      `SELECT id, name, created_at,
+         ST_Y(location::geometry) AS latitude,
+         ST_X(location::geometry) AS longitude
+       FROM stops ORDER BY created_at`,
+    );
+    return rows.map(toStop);
+  }
+
+  // Read-modify-write so a partial patch can change name and/or coordinates; the
+  // location point is rebuilt from the merged lat/lng (ST_MakePoint is lng, lat).
+  async update(id: string, patch: StopUpdate): Promise<Stop | null> {
+    const existing = await this.findById(id);
+    if (!existing) return null;
+    const next = applyPatch(existing, patch);
+    const { rows } = await this.pool.query<StopRow>(
+      `UPDATE stops
+         SET name = $2,
+             location = ST_SetSRID(ST_MakePoint($3, $4), 4326)::geography
+       WHERE id = $1
+       RETURNING id, name, created_at,
+         ST_Y(location::geometry) AS latitude,
+         ST_X(location::geometry) AS longitude`,
+      [id, next.name, next.longitude, next.latitude],
     );
     return rows[0] ? toStop(rows[0]) : null;
   }

--- a/services/api/src/modules/mobility/stop.repository.ts
+++ b/services/api/src/modules/mobility/stop.repository.ts
@@ -3,6 +3,8 @@
 // In Postgres the location column is a PostGIS geography(Point, 4326) — the
 // Pg adapter handles the conversion (see stop.repository.pg.ts).
 
+import { applyPatch } from '../../lib/patch';
+
 /** A physical location where passengers board or alight. */
 export interface Stop {
   id: string;
@@ -17,6 +19,13 @@ export interface NewStop {
   name: string;
   latitude: number;
   longitude: number;
+}
+
+/** Editable {@link Stop} fields for a partial update (admin, #26). */
+export interface StopUpdate {
+  name?: string;
+  latitude?: number;
+  longitude?: number;
 }
 
 /** Persistence for stops (Postgres in prod, in-memory in dev/tests). */
@@ -35,6 +44,16 @@ export interface StopRepository {
    * @returns the stop, or null if it doesn't exist.
    */
   findById(id: string): Promise<Stop | null>;
+  /** Returns all stops. Used by admin ops (#26). */
+  findAll(): Promise<Stop[]>;
+  /**
+   * Update a stop's editable fields (partial — omitted fields are unchanged).
+   *
+   * @param id - the stop id.
+   * @param patch - the fields to change.
+   * @returns the updated stop, or null if not found.
+   */
+  update(id: string, patch: StopUpdate): Promise<Stop | null>;
 }
 
 /** In-memory {@link StopRepository} for dev and unit tests. */
@@ -55,5 +74,17 @@ export class InMemoryStopRepository implements StopRepository {
 
   async findById(id: string): Promise<Stop | null> {
     return this.stops.get(id) ?? null;
+  }
+
+  async findAll(): Promise<Stop[]> {
+    return Array.from(this.stops.values());
+  }
+
+  async update(id: string, patch: StopUpdate): Promise<Stop | null> {
+    const existing = this.stops.get(id);
+    if (!existing) return null;
+    const updated = applyPatch(existing, patch);
+    this.stops.set(id, updated);
+    return updated;
   }
 }

--- a/services/api/src/modules/mobility/trip.repository.pg.ts
+++ b/services/api/src/modules/mobility/trip.repository.pg.ts
@@ -1,5 +1,13 @@
 import type { Pool } from 'pg';
-import type { NewTrip, Trip, TripFilter, TripRepository, TripStatus } from './trip.repository';
+import { applyPatch } from '../../lib/patch';
+import type {
+  NewTrip,
+  Trip,
+  TripFilter,
+  TripRepository,
+  TripStatus,
+  TripUpdate,
+} from './trip.repository';
 
 interface TripRow {
   id: string;
@@ -56,5 +64,18 @@ export class PgTripRepository implements TripRepository {
         )
       : await this.pool.query<TripRow>('SELECT * FROM trips ORDER BY scheduled_at');
     return rows.map(toTrip);
+  }
+
+  async update(id: string, patch: TripUpdate): Promise<Trip | null> {
+    const existing = await this.findById(id);
+    if (!existing) return null;
+    const next = applyPatch(existing, patch);
+    const { rows } = await this.pool.query<TripRow>(
+      `UPDATE trips
+         SET status = $2, scheduled_at = $3, vehicle_id = $4, assigned_driver_id = $5
+       WHERE id = $1 RETURNING *`,
+      [id, next.status, next.scheduledAt, next.vehicleId, next.assignedDriverId],
+    );
+    return rows[0] ? toTrip(rows[0]) : null;
   }
 }

--- a/services/api/src/modules/mobility/trip.repository.ts
+++ b/services/api/src/modules/mobility/trip.repository.ts
@@ -5,6 +5,8 @@
 // a trip's live position (system-design §7, #25). Two implementations: InMemory
 // for dev/tests, Postgres (trip.repository.pg.ts) for real runs.
 
+import { applyPatch } from '../../lib/patch';
+
 /** Valid trip lifecycle states — the source of truth for the DB CHECK, the
  * domain type, and the response enum (imported by mobility.schema.ts). */
 export const TRIP_STATUSES = ['scheduled', 'active', 'completed', 'cancelled'] as const;
@@ -35,6 +37,17 @@ export interface TripFilter {
   routeId?: string;
 }
 
+/** Editable {@link Trip} fields for a partial update (admin, #26). routeId is
+ * intentionally not editable — a trip belongs to the route it was created for.
+ * vehicleId/assignedDriverId cover the driver↔trip assignment (set null to
+ * unassign); the assignment endpoint validates they exist before writing. */
+export interface TripUpdate {
+  status?: TripStatus;
+  scheduledAt?: Date;
+  vehicleId?: string | null;
+  assignedDriverId?: string | null;
+}
+
 /** Persistence for trips (Postgres in prod, in-memory in dev/tests). */
 export interface TripRepository {
   /**
@@ -58,6 +71,15 @@ export interface TripRepository {
    * @returns the matching trips.
    */
   findAll(filter?: TripFilter): Promise<Trip[]>;
+  /**
+   * Update a trip's editable fields (partial — omitted fields are unchanged).
+   * Covers status/schedule changes and driver↔vehicle assignment.
+   *
+   * @param id - the trip id.
+   * @param patch - the fields to change.
+   * @returns the updated trip, or null if not found.
+   */
+  update(id: string, patch: TripUpdate): Promise<Trip | null>;
 }
 
 /** In-memory {@link TripRepository} for dev and unit tests. */
@@ -86,5 +108,13 @@ export class InMemoryTripRepository implements TripRepository {
     return Array.from(this.trips.values())
       .filter((t) => !filter?.routeId || t.routeId === filter.routeId)
       .sort((a, b) => a.scheduledAt.getTime() - b.scheduledAt.getTime());
+  }
+
+  async update(id: string, patch: TripUpdate): Promise<Trip | null> {
+    const existing = this.trips.get(id);
+    if (!existing) return null;
+    const updated = applyPatch(existing, patch);
+    this.trips.set(id, updated);
+    return updated;
   }
 }

--- a/services/api/src/modules/mobility/vehicle.repository.pg.ts
+++ b/services/api/src/modules/mobility/vehicle.repository.pg.ts
@@ -1,5 +1,6 @@
 import type { Pool } from 'pg';
-import type { NewVehicle, Vehicle, VehicleRepository } from './vehicle.repository';
+import { applyPatch } from '../../lib/patch';
+import type { NewVehicle, Vehicle, VehicleRepository, VehicleUpdate } from './vehicle.repository';
 
 interface VehicleRow {
   id: string;
@@ -35,6 +36,24 @@ export class PgVehicleRepository implements VehicleRepository {
     const { rows } = await this.pool.query<VehicleRow>('SELECT * FROM vehicles WHERE id = $1', [
       id,
     ]);
+    return rows[0] ? toVehicle(rows[0]) : null;
+  }
+
+  async findAll(): Promise<Vehicle[]> {
+    const { rows } = await this.pool.query<VehicleRow>(
+      'SELECT * FROM vehicles ORDER BY created_at',
+    );
+    return rows.map(toVehicle);
+  }
+
+  async update(id: string, patch: VehicleUpdate): Promise<Vehicle | null> {
+    const existing = await this.findById(id);
+    if (!existing) return null;
+    const next = applyPatch(existing, patch);
+    const { rows } = await this.pool.query<VehicleRow>(
+      `UPDATE vehicles SET registration = $2, label = $3, capacity = $4 WHERE id = $1 RETURNING *`,
+      [id, next.registration, next.label, next.capacity],
+    );
     return rows[0] ? toVehicle(rows[0]) : null;
   }
 }

--- a/services/api/src/modules/mobility/vehicle.repository.ts
+++ b/services/api/src/modules/mobility/vehicle.repository.ts
@@ -3,6 +3,8 @@
 // specific run by a trip's vehicle_id. Two implementations: InMemory for unit
 // tests and zero-infra dev, Postgres (vehicle.repository.pg.ts) for real runs.
 
+import { applyPatch } from '../../lib/patch';
+
 /** A bus in the fleet, identified by its registration (plate). */
 export interface Vehicle {
   id: string;
@@ -15,6 +17,13 @@ export interface Vehicle {
 /** Fields needed to create a {@link Vehicle}. */
 export interface NewVehicle {
   registration: string;
+  label?: string | null;
+  capacity?: number;
+}
+
+/** Editable {@link Vehicle} fields for a partial update (admin, #26). */
+export interface VehicleUpdate {
+  registration?: string;
   label?: string | null;
   capacity?: number;
 }
@@ -35,6 +44,16 @@ export interface VehicleRepository {
    * @returns the vehicle, or null if it doesn't exist.
    */
   findById(id: string): Promise<Vehicle | null>;
+  /** Returns all vehicles. Used by admin ops (#26). */
+  findAll(): Promise<Vehicle[]>;
+  /**
+   * Update a vehicle's editable fields (partial — omitted fields are unchanged).
+   *
+   * @param id - the vehicle id.
+   * @param patch - the fields to change.
+   * @returns the updated vehicle, or null if not found.
+   */
+  update(id: string, patch: VehicleUpdate): Promise<Vehicle | null>;
 }
 
 /** In-memory {@link VehicleRepository} for dev and unit tests. */
@@ -55,5 +74,17 @@ export class InMemoryVehicleRepository implements VehicleRepository {
 
   async findById(id: string): Promise<Vehicle | null> {
     return this.vehicles.get(id) ?? null;
+  }
+
+  async findAll(): Promise<Vehicle[]> {
+    return Array.from(this.vehicles.values());
+  }
+
+  async update(id: string, patch: VehicleUpdate): Promise<Vehicle | null> {
+    const existing = this.vehicles.get(id);
+    if (!existing) return null;
+    const updated = applyPatch(existing, patch);
+    this.vehicles.set(id, updated);
+    return updated;
   }
 }

--- a/services/api/src/server.ts
+++ b/services/api/src/server.ts
@@ -37,6 +37,16 @@ import { PgStopRepository } from './modules/mobility/stop.repository.pg';
 import { InMemoryTripRepository, type TripRepository } from './modules/mobility/trip.repository';
 import { PgTripRepository } from './modules/mobility/trip.repository.pg';
 import {
+  InMemoryVehicleRepository,
+  type VehicleRepository,
+} from './modules/mobility/vehicle.repository';
+import { PgVehicleRepository } from './modules/mobility/vehicle.repository.pg';
+import {
+  InMemoryDriverRepository,
+  type DriverRepository,
+} from './modules/mobility/driver.repository';
+import { PgDriverRepository } from './modules/mobility/driver.repository.pg';
+import {
   InMemorySubscriptionRepository,
   type SubscriptionRepository,
 } from './modules/subscriptions/subscription.repository';
@@ -127,6 +137,8 @@ async function main(): Promise<void> {
   let stops: StopRepository;
   let routeStops: RouteStopRepository;
   let trips: TripRepository;
+  let vehicles: VehicleRepository;
+  let drivers: DriverRepository;
   let sessions: SessionRepository;
   let authIdentities: AuthIdentityRepository;
   let payments: PaymentRepository;
@@ -143,6 +155,8 @@ async function main(): Promise<void> {
     stops = new PgStopRepository(pool);
     routeStops = new PgRouteStopRepository(pool);
     trips = new PgTripRepository(pool);
+    vehicles = new PgVehicleRepository(pool);
+    drivers = new PgDriverRepository(pool);
     sessions = new PgSessionRepository(pool);
     authIdentities = new PgAuthIdentityRepository(pool);
     payments = new PgPaymentRepository(pool);
@@ -159,6 +173,8 @@ async function main(): Promise<void> {
     stops = new InMemoryStopRepository();
     routeStops = new InMemoryRouteStopRepository();
     trips = new InMemoryTripRepository();
+    vehicles = new InMemoryVehicleRepository();
+    drivers = new InMemoryDriverRepository();
     sessions = new InMemorySessionRepository();
     authIdentities = new InMemoryAuthIdentityRepository();
     payments = new InMemoryPaymentRepository();
@@ -250,6 +266,8 @@ async function main(): Promise<void> {
     stops,
     routeStops,
     trips,
+    vehicles,
+    drivers,
     deviceTokens,
     boardingService,
     authService,

--- a/services/api/tests/admin.routes.test.ts
+++ b/services/api/tests/admin.routes.test.ts
@@ -1,0 +1,345 @@
+import { describe, expect, it } from 'vitest';
+import { buildApp } from '../src/app';
+import { createJwtService, type AuthConfig } from '../src/modules/auth/jwt';
+import { InMemoryDriverRepository } from '../src/modules/mobility/driver.repository';
+import { InMemoryRouteStopRepository } from '../src/modules/mobility/route-stop.repository';
+import { InMemoryRouteRepository } from '../src/modules/mobility/route.repository';
+import { InMemoryStopRepository } from '../src/modules/mobility/stop.repository';
+import { InMemoryTripRepository } from '../src/modules/mobility/trip.repository';
+import { InMemoryVehicleRepository } from '../src/modules/mobility/vehicle.repository';
+
+const auth: AuthConfig = {
+  secret: 'test-secret-at-least-32-characters-long-0000',
+  accessTtl: '15m',
+  issuer: 'trotxi',
+  audience: 'trotxi-api',
+};
+const jwt = createJwtService(auth);
+const bearer = (t: string) => ({ authorization: `Bearer ${t}` });
+const adminToken = () => jwt.signAccessToken({ userId: 'admin-1', role: 'admin' });
+const commuterToken = () => jwt.signAccessToken({ userId: 'rider-1', role: 'commuter' });
+const UNKNOWN = '00000000-0000-0000-0000-0000000000ff';
+const SCHEDULED_AT = '2026-07-08T06:00:00.000Z';
+
+async function adminApp() {
+  const routes = new InMemoryRouteRepository();
+  const stops = new InMemoryStopRepository();
+  const routeStops = new InMemoryRouteStopRepository();
+  const vehicles = new InMemoryVehicleRepository();
+  const drivers = new InMemoryDriverRepository();
+  const trips = new InMemoryTripRepository();
+  const app = await buildApp({ auth, routes, stops, routeStops, vehicles, drivers, trips });
+  return { app, routes, stops, routeStops, vehicles, drivers, trips };
+}
+
+describe('admin authz', () => {
+  it('401 without a token', async () => {
+    const { app } = await adminApp();
+    const res = await app.inject({ method: 'GET', url: '/admin/routes' });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('403 for a non-admin (commuter) on a read', async () => {
+    const { app } = await adminApp();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/admin/routes',
+      headers: bearer(await commuterToken()),
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('403 for a non-admin on a write', async () => {
+    const { app } = await adminApp();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/admin/vehicles',
+      headers: bearer(await commuterToken()),
+      payload: { registration: 'GR-1' },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('503 when repos are not wired', async () => {
+    const app = await buildApp({ auth });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/admin/routes',
+      headers: bearer(await adminToken()),
+    });
+    expect(res.statusCode).toBe(503);
+  });
+});
+
+describe('admin routes CRUD', () => {
+  it('creates, lists, and updates a route', async () => {
+    const { app } = await adminApp();
+    const token = await adminToken();
+
+    const created = await app.inject({
+      method: 'POST',
+      url: '/admin/routes',
+      headers: bearer(token),
+      payload: { name: 'Circle to Legon', description: 'Main' },
+    });
+    expect(created.statusCode).toBe(200);
+    const routeId = created.json().id;
+
+    const list = await app.inject({ method: 'GET', url: '/admin/routes', headers: bearer(token) });
+    expect(list.json()).toHaveLength(1);
+
+    const patched = await app.inject({
+      method: 'PATCH',
+      url: `/admin/routes/${routeId}`,
+      headers: bearer(token),
+      payload: { name: 'Circle to Madina' },
+    });
+    expect(patched.statusCode).toBe(200);
+    expect(patched.json()).toMatchObject({ name: 'Circle to Madina', description: 'Main' });
+  });
+
+  it('clears a nullable field with an explicit null', async () => {
+    const { app } = await adminApp();
+    const token = await adminToken();
+    const created = await app.inject({
+      method: 'POST',
+      url: '/admin/routes',
+      headers: bearer(token),
+      payload: { name: 'R', description: 'has desc' },
+    });
+    const patched = await app.inject({
+      method: 'PATCH',
+      url: `/admin/routes/${created.json().id}`,
+      headers: bearer(token),
+      payload: { description: null },
+    });
+    expect(patched.json().description).toBeNull();
+  });
+
+  it('404 updating an unknown route', async () => {
+    const { app } = await adminApp();
+    const res = await app.inject({
+      method: 'PATCH',
+      url: `/admin/routes/${UNKNOWN}`,
+      headers: bearer(await adminToken()),
+      payload: { name: 'x' },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+describe('admin stops + attach', () => {
+  it('creates a stop and attaches it to a route at a seq', async () => {
+    const { app, routes } = await adminApp();
+    const token = await adminToken();
+    const route = await routes.create({ name: 'R' });
+
+    const stop = await app.inject({
+      method: 'POST',
+      url: '/admin/stops',
+      headers: bearer(token),
+      payload: { name: 'Circle', latitude: 5.5502, longitude: -0.2174 },
+    });
+    expect(stop.statusCode).toBe(200);
+    expect(stop.json()).toMatchObject({ name: 'Circle', latitude: 5.5502 });
+
+    const attached = await app.inject({
+      method: 'POST',
+      url: `/admin/routes/${route.id}/stops`,
+      headers: bearer(token),
+      payload: { stopId: stop.json().id, seq: 1 },
+    });
+    expect(attached.statusCode).toBe(200);
+    expect(attached.json()).toMatchObject({ routeId: route.id, stopId: stop.json().id, seq: 1 });
+  });
+
+  it('404 attaching to an unknown route', async () => {
+    const { app, stops } = await adminApp();
+    const stop = await stops.create({ name: 'S', latitude: 1, longitude: 2 });
+    const res = await app.inject({
+      method: 'POST',
+      url: `/admin/routes/${UNKNOWN}/stops`,
+      headers: bearer(await adminToken()),
+      payload: { stopId: stop.id, seq: 1 },
+    });
+    expect(res.statusCode).toBe(404);
+    expect(res.json().message).toMatch(/route/i);
+  });
+
+  it('404 attaching an unknown stop', async () => {
+    const { app, routes } = await adminApp();
+    const route = await routes.create({ name: 'R' });
+    const res = await app.inject({
+      method: 'POST',
+      url: `/admin/routes/${route.id}/stops`,
+      headers: bearer(await adminToken()),
+      payload: { stopId: UNKNOWN, seq: 1 },
+    });
+    expect(res.statusCode).toBe(404);
+    expect(res.json().message).toMatch(/stop/i);
+  });
+});
+
+describe('admin vehicles + drivers', () => {
+  it('creates, lists, and updates a vehicle', async () => {
+    const { app } = await adminApp();
+    const token = await adminToken();
+    const created = await app.inject({
+      method: 'POST',
+      url: '/admin/vehicles',
+      headers: bearer(token),
+      payload: { registration: 'GR-1234-24', label: 'Bus 7', capacity: 33 },
+    });
+    expect(created.statusCode).toBe(200);
+
+    const list = await app.inject({
+      method: 'GET',
+      url: '/admin/vehicles',
+      headers: bearer(token),
+    });
+    expect(list.json()).toHaveLength(1);
+
+    const patched = await app.inject({
+      method: 'PATCH',
+      url: `/admin/vehicles/${created.json().id}`,
+      headers: bearer(token),
+      payload: { capacity: 40 },
+    });
+    expect(patched.json()).toMatchObject({ registration: 'GR-1234-24', capacity: 40 });
+  });
+
+  it('creates and updates a driver', async () => {
+    const { app } = await adminApp();
+    const token = await adminToken();
+    const created = await app.inject({
+      method: 'POST',
+      url: '/admin/drivers',
+      headers: bearer(token),
+      payload: { fullName: 'Kwame Mensah', phone: '+233200000000' },
+    });
+    expect(created.statusCode).toBe(200);
+    const patched = await app.inject({
+      method: 'PATCH',
+      url: `/admin/drivers/${created.json().id}`,
+      headers: bearer(token),
+      payload: { licenseNumber: 'DL-1' },
+    });
+    expect(patched.json()).toMatchObject({ fullName: 'Kwame Mensah', licenseNumber: 'DL-1' });
+  });
+});
+
+describe('admin trips + assignment', () => {
+  it('creates a trip on an existing route', async () => {
+    const { app, routes } = await adminApp();
+    const route = await routes.create({ name: 'R' });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/admin/trips',
+      headers: bearer(await adminToken()),
+      payload: { routeId: route.id, scheduledAt: SCHEDULED_AT },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ routeId: route.id, status: 'scheduled' });
+  });
+
+  it('404 creating a trip on an unknown route', async () => {
+    const { app } = await adminApp();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/admin/trips',
+      headers: bearer(await adminToken()),
+      payload: { routeId: UNKNOWN, scheduledAt: SCHEDULED_AT },
+    });
+    expect(res.statusCode).toBe(404);
+    expect(res.json().message).toMatch(/route/i);
+  });
+
+  it('404 creating a trip with an unknown vehicle', async () => {
+    const { app, routes } = await adminApp();
+    const route = await routes.create({ name: 'R' });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/admin/trips',
+      headers: bearer(await adminToken()),
+      payload: { routeId: route.id, vehicleId: UNKNOWN, scheduledAt: SCHEDULED_AT },
+    });
+    expect(res.statusCode).toBe(404);
+    expect(res.json().message).toMatch(/vehicle/i);
+  });
+
+  it('updates trip status', async () => {
+    const { app, routes, trips } = await adminApp();
+    const route = await routes.create({ name: 'R' });
+    const trip = await trips.create({ routeId: route.id, scheduledAt: new Date(SCHEDULED_AT) });
+    const res = await app.inject({
+      method: 'PATCH',
+      url: `/admin/trips/${trip.id}`,
+      headers: bearer(await adminToken()),
+      payload: { status: 'active' },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().status).toBe('active');
+  });
+
+  it('assigns a vehicle and driver to a trip', async () => {
+    const { app, routes, vehicles, drivers, trips } = await adminApp();
+    const route = await routes.create({ name: 'R' });
+    const vehicle = await vehicles.create({ registration: 'GR-1' });
+    const driver = await drivers.create({ fullName: 'Ama' });
+    const trip = await trips.create({ routeId: route.id, scheduledAt: new Date(SCHEDULED_AT) });
+
+    const res = await app.inject({
+      method: 'PUT',
+      url: `/admin/trips/${trip.id}/assignment`,
+      headers: bearer(await adminToken()),
+      payload: { vehicleId: vehicle.id, assignedDriverId: driver.id },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ vehicleId: vehicle.id, assignedDriverId: driver.id });
+  });
+
+  it('unassigns a driver with an explicit null', async () => {
+    const { app, routes, drivers, trips } = await adminApp();
+    const route = await routes.create({ name: 'R' });
+    const driver = await drivers.create({ fullName: 'Ama' });
+    const trip = await trips.create({
+      routeId: route.id,
+      assignedDriverId: driver.id,
+      scheduledAt: new Date(SCHEDULED_AT),
+    });
+    const res = await app.inject({
+      method: 'PUT',
+      url: `/admin/trips/${trip.id}/assignment`,
+      headers: bearer(await adminToken()),
+      payload: { assignedDriverId: null },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().assignedDriverId).toBeNull();
+  });
+
+  it('404 assigning an unknown driver', async () => {
+    const { app, routes, trips } = await adminApp();
+    const route = await routes.create({ name: 'R' });
+    const trip = await trips.create({ routeId: route.id, scheduledAt: new Date(SCHEDULED_AT) });
+    const res = await app.inject({
+      method: 'PUT',
+      url: `/admin/trips/${trip.id}/assignment`,
+      headers: bearer(await adminToken()),
+      payload: { assignedDriverId: UNKNOWN },
+    });
+    expect(res.statusCode).toBe(404);
+    expect(res.json().message).toMatch(/driver/i);
+  });
+
+  it('404 assigning to an unknown trip', async () => {
+    const { app } = await adminApp();
+    const res = await app.inject({
+      method: 'PUT',
+      url: `/admin/trips/${UNKNOWN}/assignment`,
+      headers: bearer(await adminToken()),
+      payload: {},
+    });
+    expect(res.statusCode).toBe(404);
+    expect(res.json().message).toMatch(/trip/i);
+  });
+});

--- a/services/api/tests/driver.repository.test.ts
+++ b/services/api/tests/driver.repository.test.ts
@@ -31,4 +31,23 @@ describe('InMemoryDriverRepository', () => {
     const repo = new InMemoryDriverRepository();
     expect(await repo.findById('does-not-exist')).toBeNull();
   });
+
+  it('findAll returns every driver', async () => {
+    const repo = new InMemoryDriverRepository();
+    await repo.create({ fullName: 'A' });
+    await repo.create({ fullName: 'B' });
+    expect(await repo.findAll()).toHaveLength(2);
+  });
+
+  it('update merges a partial patch and can clear a nullable field', async () => {
+    const repo = new InMemoryDriverRepository();
+    const driver = await repo.create({ fullName: 'Kwame', phone: '+233200000000' });
+    const updated = await repo.update(driver.id, { licenseNumber: 'DL-1', phone: null });
+    expect(updated).toMatchObject({ fullName: 'Kwame', licenseNumber: 'DL-1', phone: null });
+  });
+
+  it('update returns null for an unknown id', async () => {
+    const repo = new InMemoryDriverRepository();
+    expect(await repo.update('does-not-exist', { fullName: 'x' })).toBeNull();
+  });
 });

--- a/services/api/tests/patch.test.ts
+++ b/services/api/tests/patch.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { applyPatch } from '../src/lib/patch';
+
+describe('applyPatch', () => {
+  it('applies defined fields and leaves the base otherwise unchanged', () => {
+    const base = { a: 1, b: 'x', c: true };
+    expect(applyPatch(base, { b: 'y' })).toEqual({ a: 1, b: 'y', c: true });
+  });
+
+  it('ignores keys whose value is undefined (omitted → unchanged)', () => {
+    const base = { a: 1, b: 'x' };
+    expect(applyPatch(base, { a: undefined, b: 'y' })).toEqual({ a: 1, b: 'y' });
+  });
+
+  it('applies an explicit null (clears a nullable field)', () => {
+    const base = { a: 1, note: 'keep' as string | null };
+    expect(applyPatch(base, { note: null })).toEqual({ a: 1, note: null });
+  });
+
+  it('does not mutate the base object', () => {
+    const base = { a: 1 };
+    applyPatch(base, { a: 2 });
+    expect(base.a).toBe(1);
+  });
+});

--- a/services/api/tests/route.repository.test.ts
+++ b/services/api/tests/route.repository.test.ts
@@ -33,4 +33,24 @@ describe('InMemoryRouteRepository', () => {
     const repo = new InMemoryRouteRepository();
     expect(await repo.findById('does-not-exist')).toBeNull();
   });
+
+  it('update merges a partial patch and leaves omitted fields unchanged', async () => {
+    const repo = new InMemoryRouteRepository();
+    const route = await repo.create({ name: 'Old', description: 'keep me' });
+
+    const updated = await repo.update(route.id, { name: 'New' });
+    expect(updated).toMatchObject({ name: 'New', description: 'keep me' });
+  });
+
+  it('update clears a nullable field with an explicit null', async () => {
+    const repo = new InMemoryRouteRepository();
+    const route = await repo.create({ name: 'R', description: 'has desc' });
+    const updated = await repo.update(route.id, { description: null });
+    expect(updated?.description).toBeNull();
+  });
+
+  it('update returns null for an unknown id', async () => {
+    const repo = new InMemoryRouteRepository();
+    expect(await repo.update('does-not-exist', { name: 'x' })).toBeNull();
+  });
 });

--- a/services/api/tests/stop.repository.test.ts
+++ b/services/api/tests/stop.repository.test.ts
@@ -19,4 +19,23 @@ describe('InMemoryStopRepository', () => {
     const repo = new InMemoryStopRepository();
     expect(await repo.findById('does-not-exist')).toBeNull();
   });
+
+  it('findAll returns every stop', async () => {
+    const repo = new InMemoryStopRepository();
+    await repo.create({ name: 'A', latitude: 1, longitude: 2 });
+    await repo.create({ name: 'B', latitude: 3, longitude: 4 });
+    expect(await repo.findAll()).toHaveLength(2);
+  });
+
+  it('update changes coordinates and leaves the name unchanged', async () => {
+    const repo = new InMemoryStopRepository();
+    const stop = await repo.create({ name: 'Circle', latitude: 5.55, longitude: -0.21 });
+    const updated = await repo.update(stop.id, { latitude: 5.65, longitude: -0.18 });
+    expect(updated).toMatchObject({ name: 'Circle', latitude: 5.65, longitude: -0.18 });
+  });
+
+  it('update returns null for an unknown id', async () => {
+    const repo = new InMemoryStopRepository();
+    expect(await repo.update('does-not-exist', { name: 'x' })).toBeNull();
+  });
 });

--- a/services/api/tests/trip.repository.test.ts
+++ b/services/api/tests/trip.repository.test.ts
@@ -63,4 +63,28 @@ describe('InMemoryTripRepository', () => {
     expect(onA).toHaveLength(2);
     expect(onA.every((t) => t.routeId === ROUTE_A)).toBe(true);
   });
+
+  it('update changes status and assignment; explicit null unassigns', async () => {
+    const repo = new InMemoryTripRepository();
+    const trip = await repo.create({
+      routeId: ROUTE_A,
+      assignedDriverId: 'drv-1',
+      scheduledAt: new Date('2026-07-08T06:00:00Z'),
+    });
+
+    const activated = await repo.update(trip.id, { status: 'active', vehicleId: 'veh-1' });
+    expect(activated).toMatchObject({
+      status: 'active',
+      vehicleId: 'veh-1',
+      assignedDriverId: 'drv-1',
+    });
+
+    const unassigned = await repo.update(trip.id, { assignedDriverId: null });
+    expect(unassigned?.assignedDriverId).toBeNull();
+  });
+
+  it('update returns null for an unknown id', async () => {
+    const repo = new InMemoryTripRepository();
+    expect(await repo.update('does-not-exist', { status: 'active' })).toBeNull();
+  });
 });

--- a/services/api/tests/vehicle.repository.test.ts
+++ b/services/api/tests/vehicle.repository.test.ts
@@ -30,4 +30,23 @@ describe('InMemoryVehicleRepository', () => {
     const repo = new InMemoryVehicleRepository();
     expect(await repo.findById('does-not-exist')).toBeNull();
   });
+
+  it('findAll returns every vehicle', async () => {
+    const repo = new InMemoryVehicleRepository();
+    await repo.create({ registration: 'GR-1' });
+    await repo.create({ registration: 'GR-2' });
+    expect(await repo.findAll()).toHaveLength(2);
+  });
+
+  it('update merges a partial patch', async () => {
+    const repo = new InMemoryVehicleRepository();
+    const vehicle = await repo.create({ registration: 'GR-1', label: 'Bus 7', capacity: 33 });
+    const updated = await repo.update(vehicle.id, { capacity: 40 });
+    expect(updated).toMatchObject({ registration: 'GR-1', label: 'Bus 7', capacity: 40 });
+  });
+
+  it('update returns null for an unknown id', async () => {
+    const repo = new InMemoryVehicleRepository();
+    expect(await repo.update('does-not-exist', { capacity: 1 })).toBeNull();
+  });
 });


### PR DESCRIPTION
Closes #26. Operations manages the mobility fleet over HTTP rather than via seed scripts. Builds on trips (#18) and the auth guard (#16).

## Endpoints — all under `/admin/*`, gated by `requireRole('admin')` (401 unauth → 403 non-admin)
| Entity | Endpoints |
|---|---|
| routes | `POST` / `GET` / `PATCH /admin/routes[/:id]` + `POST /admin/routes/:id/stops` (attach a stop at a seq) |
| stops | `POST` / `GET` / `PATCH /admin/stops[/:id]` |
| vehicles | `POST` / `GET` / `PATCH /admin/vehicles[/:id]` |
| drivers | `POST` / `GET` / `PATCH /admin/drivers[/:id]` |
| trips | `POST` / `GET` / `PATCH /admin/trips[/:id]` + **`PUT /admin/trips/:id/assignment`** |

## Design notes
- **Assignment** (`PUT /admin/trips/:id/assignment`) is the point of the issue — sets `vehicleId` and/or `assignedDriverId` (the field that authorizes GPS reporting, #25). Validates the targets exist so the client gets a clean 404 instead of a DB constraint error; an explicit `null` unassigns. Trip create likewise validates its route/vehicle/driver FKs up front.
- **Repositories** gain `findAll` (stops/vehicles/drivers) and partial `update` (all five), in-memory + Postgres. The `vehicles`/`drivers` repos delivered in #18 are now wired through `AppDeps` + `server.ts` for the first time.
- **Partial-update correctness:** updates go through a shared [`applyPatch`](services/api/src/lib/patch.ts) helper that skips `undefined` keys (omitted → unchanged) while honoring an explicit `null`. This fixes a latent bug found in testing where a `{ ...existing, ...patch }` merge overwrote stored values with `undefined` — and would have written `NULL` to a column on the Postgres path.
- Handlers call repositories directly (no service layer yet) and return **503** when a repo is unwired, matching the rest of the API.

## Open questions for review
- Admin lists return **bare arrays** (`GET /admin/routes` → `[...]`), whereas public `GET /trips` returns `{ trips: [...] }`. Intentional (uniform across admin entities) — flag if you'd prefer they match.
- No `DELETE` endpoints — acceptance says create/update/list only; retiring/soft-delete can be a follow-up.

## Acceptance (#26)
- ✅ All admin-role guarded
- ✅ create / update / list for routes/stops/vehicles/drivers/trips
- ✅ Assignment endpoint
- ✅ Tests

## Verification
- `tsc --noEmit` clean · `eslint .` clean (also enforced by pre-commit hook)
- **New tests: 24** (20 admin HTTP incl. authz/CRUD/assignment/FK-404s, 4 `applyPatch`) + repo `update`/`findAll` cases across 5 files
- Full suite: 226/227 — the single failure is a pre-existing **flaky 5s timeout in `payments.routes.test.ts`** (untouched here; passes 7/7 in isolation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
