### PR TITLE
fix(api): admin/ops hardening — role grant + review follow-ups to #115

### DIFF
--- a/services/api/src/app.ts
+++ b/services/api/src/app.ts
@@ -233,6 +233,7 @@ export async function buildApp(deps: AppDeps = {}): Promise<FastifyInstance> {
     vehicles: deps.vehicles,
     drivers: deps.drivers,
     trips: deps.trips,
+    users: deps.users,
     rateLimit: deps.rateLimit ?? DEFAULT_RATE_LIMIT,
   });
 

--- a/services/api/src/modules/admin/admin.routes.ts
+++ b/services/api/src/modules/admin/admin.routes.ts
@@ -17,6 +17,7 @@ import type { RouteRepository } from '../mobility/route.repository';
 import type { StopRepository } from '../mobility/stop.repository';
 import type { TripRepository } from '../mobility/trip.repository';
 import type { VehicleRepository } from '../mobility/vehicle.repository';
+import type { UserRepository } from '../users/user.repository';
 import {
   driverResponseSchema,
   routeResponseSchema,
@@ -25,6 +26,7 @@ import {
   vehicleResponseSchema,
 } from '../mobility/mobility.schema';
 import {
+  adminUserResponseSchema,
   assignTripBodySchema,
   attachStopBodySchema,
   createDriverBodySchema,
@@ -32,12 +34,21 @@ import {
   createStopBodySchema,
   createTripBodySchema,
   createVehicleBodySchema,
+  listTripsAdminQuerySchema,
+  setRoleBodySchema,
   updateDriverBodySchema,
   updateRouteBodySchema,
   updateStopBodySchema,
   updateTripBodySchema,
   updateVehicleBodySchema,
 } from './admin.schema';
+
+// True when a repository error is a (Postgres-shaped) unique-constraint
+// violation — SQLSTATE 23505. The in-memory route-stop adapter throws the same
+// shape, so both paths map to a clean 409.
+function isUniqueViolation(err: unknown): boolean {
+  return (err as { code?: string }).code === '23505';
+}
 
 const idParam = z.object({ id: z.string().uuid() });
 
@@ -66,6 +77,8 @@ export interface AdminDeps {
   vehicles?: VehicleRepository;
   drivers?: DriverRepository;
   trips?: TripRepository;
+  /** For the role grant (PATCH /admin/users/:id/role) + driver user_id checks. */
+  users?: UserRepository;
   rateLimit: RateLimitConfig;
 }
 
@@ -80,11 +93,13 @@ export async function adminRoutes(app: FastifyInstance, opts: AdminDeps): Promis
   const UNAVAILABLE = { error: 'unavailable', message: 'Admin ops are not configured' };
   const notFound = (message: string) => ({ error: 'not_found', message });
 
-  // authenticate → requireRole('admin') → rate limit. Reused by every route.
+  // authenticate → rate limit → requireRole('admin'). Throttle BEFORE the role
+  // check (house convention, cf. boarding #93) — otherwise non-admin tokens
+  // could hammer 403s without ever being rate limited. Reused by every route.
   const adminOnly = [
     app.authenticate,
-    app.requireRole('admin'),
     app.rateLimit({ ...opts.rateLimit, by: 'user' }),
+    app.requireRole('admin'),
   ];
 
   // ---------------------------------------------------------------- routes ---
@@ -154,7 +169,7 @@ export async function adminRoutes(app: FastifyInstance, opts: AdminDeps): Promis
         security: [{ bearerAuth: [] }],
         params: idParam,
         body: attachStopBodySchema,
-        response: { 200: routeStopResponseSchema, ...authErrorsNF },
+        response: { 200: routeStopResponseSchema, 409: errorResponseSchema, ...authErrorsNF },
       },
       preHandler: adminOnly,
     },
@@ -168,11 +183,22 @@ export async function adminRoutes(app: FastifyInstance, opts: AdminDeps): Promis
       if (!(await opts.stops.findById(request.body.stopId))) {
         return reply.code(404).send(notFound('Stop not found'));
       }
-      return opts.routeStops.create({
-        routeId: request.params.id,
-        stopId: request.body.stopId,
-        seq: request.body.seq,
-      });
+      try {
+        return await opts.routeStops.create({
+          routeId: request.params.id,
+          stopId: request.body.stopId,
+          seq: request.body.seq,
+        });
+      } catch (err) {
+        // UNIQUE (route_id, seq) — the position is already taken on this route.
+        if (isUniqueViolation(err)) {
+          return reply.code(409).send({
+            error: 'conflict',
+            message: `Sequence position ${request.body.seq} is already taken on this route`,
+          });
+        }
+        throw err;
+      }
     },
   );
 
@@ -299,12 +325,21 @@ export async function adminRoutes(app: FastifyInstance, opts: AdminDeps): Promis
         summary: 'Create a driver',
         security: [{ bearerAuth: [] }],
         body: createDriverBodySchema,
-        response: { 200: driverResponseSchema, ...authErrors },
+        response: { 200: driverResponseSchema, ...authErrorsNF },
       },
       preHandler: adminOnly,
     },
     async (request, reply) => {
       if (!opts.drivers) return reply.code(503).send(UNAVAILABLE);
+      // Validate the linked auth principal exists — clean 404 instead of a DB
+      // FK violation (consistent with trip create). users is only needed when a
+      // link is actually being made.
+      if (request.body.userId) {
+        if (!opts.users) return reply.code(503).send(UNAVAILABLE);
+        if (!(await opts.users.findById(request.body.userId))) {
+          return reply.code(404).send(notFound('User not found'));
+        }
+      }
       return opts.drivers.create(request.body);
     },
   );
@@ -341,6 +376,12 @@ export async function adminRoutes(app: FastifyInstance, opts: AdminDeps): Promis
     },
     async (request, reply) => {
       if (!opts.drivers) return reply.code(503).send(UNAVAILABLE);
+      if (request.body.userId) {
+        if (!opts.users) return reply.code(503).send(UNAVAILABLE);
+        if (!(await opts.users.findById(request.body.userId))) {
+          return reply.code(404).send(notFound('User not found'));
+        }
+      }
       const updated = await opts.drivers.update(request.params.id, request.body);
       if (!updated) return reply.code(404).send(notFound('Driver not found'));
       return updated;
@@ -391,15 +432,20 @@ export async function adminRoutes(app: FastifyInstance, opts: AdminDeps): Promis
     {
       schema: {
         tags: ['admin'],
-        summary: 'List all trips',
+        summary: 'List trips, filterable by route, status, and UTC day',
         security: [{ bearerAuth: [] }],
+        querystring: listTripsAdminQuerySchema,
         response: { 200: z.array(tripResponseSchema), ...authErrors },
       },
       preHandler: adminOnly,
     },
-    async (_request, reply) => {
+    async (request, reply) => {
       if (!opts.trips) return reply.code(503).send(UNAVAILABLE);
-      return opts.trips.findAll();
+      return opts.trips.findAll({
+        routeId: request.query.routeId,
+        status: request.query.status,
+        date: request.query.date,
+      });
     },
   );
 
@@ -455,6 +501,36 @@ export async function adminRoutes(app: FastifyInstance, opts: AdminDeps): Promis
       }
       const updated = await opts.trips.update(request.params.id, { vehicleId, assignedDriverId });
       if (!updated) return reply.code(404).send(notFound('Trip not found'));
+      return updated;
+    },
+  );
+
+  // ----------------------------------------------------------- users (role) ---
+  // The missing half of "make a user a driver": creating a `drivers` fleet row
+  // never touches users.role, but the JWT is signed from users.role at sign-in —
+  // so without this, a linked driver still authenticates as a commuter and gets
+  // 403 on POST /boarding/scan. The change takes effect on the user's next token
+  // refresh/sign-in (existing access tokens keep their old role until expiry,
+  // ≤15m). Bootstrap note: the FIRST admin cannot be created through this
+  // endpoint (it requires an admin) — grant it once via SQL:
+  //   UPDATE users SET role = 'admin' WHERE id = '<uuid>';
+  r.patch(
+    '/admin/users/:id/role',
+    {
+      schema: {
+        tags: ['admin'],
+        summary: "Change a user's role (commuter | driver | admin)",
+        security: [{ bearerAuth: [] }],
+        params: idParam,
+        body: setRoleBodySchema,
+        response: { 200: adminUserResponseSchema, ...authErrorsNF },
+      },
+      preHandler: adminOnly,
+    },
+    async (request, reply) => {
+      if (!opts.users) return reply.code(503).send(UNAVAILABLE);
+      const updated = await opts.users.setRole(request.params.id, request.body.role);
+      if (!updated) return reply.code(404).send(notFound('User not found'));
       return updated;
     },
   );

--- a/services/api/src/modules/admin/admin.schema.ts
+++ b/services/api/src/modules/admin/admin.schema.ts
@@ -7,6 +7,7 @@
 
 import { z } from 'zod';
 import { TRIP_STATUSES } from '../mobility/trip.repository';
+import { USER_ROLES } from '../users/user.repository';
 
 const latitude = z.number().min(-90).max(90);
 const longitude = z.number().min(-180).max(180);
@@ -76,6 +77,33 @@ export const createTripBodySchema = z.object({
 export const updateTripBodySchema = z.object({
   status: z.enum(TRIP_STATUSES).optional(),
   scheduledAt: z.string().datetime().optional(),
+});
+
+// List filters for GET /admin/trips — `date` is the UTC calendar day, the shape
+// the E3 ask-dispatch needs ("tomorrow's scheduled trips").
+export const listTripsAdminQuerySchema = z.object({
+  routeId: z.string().uuid().optional(),
+  status: z.enum(TRIP_STATUSES).optional(),
+  date: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, 'expected YYYY-MM-DD')
+    .optional(),
+});
+
+// --- users (role grant) ---
+// Changing users.role is what turns a signed-in account into a driver/admin —
+// the JWT carries the role, so it takes effect on the next refresh/sign-in.
+export const setRoleBodySchema = z.object({
+  role: z.enum(USER_ROLES),
+});
+// Slim admin view of a user (no avatar URL — that needs the object store and
+// belongs to the profile endpoints).
+export const adminUserResponseSchema = z.object({
+  id: z.string().uuid(),
+  displayName: z.string(),
+  phone: z.string().nullable(),
+  role: z.enum(USER_ROLES),
+  createdAt: z.date(),
 });
 
 // Driver↔trip (and vehicle) assignment — the field that authorizes GPS

--- a/services/api/src/modules/mobility/route-stop.repository.ts
+++ b/services/api/src/modules/mobility/route-stop.repository.ts
@@ -37,6 +37,15 @@ export class InMemoryRouteStopRepository implements RouteStopRepository {
   private readonly routeStops = new Map<string, RouteStop>();
 
   async create(input: NewRouteStop): Promise<RouteStop> {
+    // Mirror the DB's UNIQUE (route_id, seq): throw the same shape as a Postgres
+    // unique violation (SQLSTATE 23505) so handlers behave identically on both
+    // adapters — the admin attach-stop route maps this to a 409.
+    const duplicate = Array.from(this.routeStops.values()).some(
+      (rs) => rs.routeId === input.routeId && rs.seq === input.seq,
+    );
+    if (duplicate) {
+      throw Object.assign(new Error('duplicate (route_id, seq)'), { code: '23505' });
+    }
     const routeStop: RouteStop = {
       id: crypto.randomUUID(),
       routeId: input.routeId,

--- a/services/api/src/modules/mobility/trip.repository.pg.ts
+++ b/services/api/src/modules/mobility/trip.repository.pg.ts
@@ -55,14 +55,26 @@ export class PgTripRepository implements TripRepository {
   }
 
   async findAll(filter?: TripFilter): Promise<Trip[]> {
-    // routeId is the only filter today (GET /trips?routeId); build the WHERE
-    // clause conditionally so the unfiltered list stays a plain scan + sort.
-    const { rows } = filter?.routeId
-      ? await this.pool.query<TripRow>(
-          'SELECT * FROM trips WHERE route_id = $1 ORDER BY scheduled_at',
-          [filter.routeId],
-        )
-      : await this.pool.query<TripRow>('SELECT * FROM trips ORDER BY scheduled_at');
+    // Build the WHERE clause from whichever filters are present. `date` compares
+    // the UTC calendar day, matching the in-memory adapter's toISOString().
+    const where: string[] = [];
+    const params: unknown[] = [];
+    if (filter?.routeId) {
+      params.push(filter.routeId);
+      where.push(`route_id = $${params.length}`);
+    }
+    if (filter?.status) {
+      params.push(filter.status);
+      where.push(`status = $${params.length}`);
+    }
+    if (filter?.date) {
+      params.push(filter.date);
+      where.push(`(scheduled_at AT TIME ZONE 'UTC')::date = $${params.length}::date`);
+    }
+    const { rows } = await this.pool.query<TripRow>(
+      `SELECT * FROM trips ${where.length ? `WHERE ${where.join(' AND ')}` : ''} ORDER BY scheduled_at`,
+      params,
+    );
     return rows.map(toTrip);
   }
 

--- a/services/api/src/modules/mobility/trip.repository.ts
+++ b/services/api/src/modules/mobility/trip.repository.ts
@@ -35,6 +35,10 @@ export interface NewTrip {
 /** Optional filters for {@link TripRepository.findAll}. */
 export interface TripFilter {
   routeId?: string;
+  status?: TripStatus;
+  /** UTC calendar day (`YYYY-MM-DD`) the trip is scheduled on — what the
+   * ask-dispatch will use for "tomorrow's trips" (E3). */
+  date?: string;
 }
 
 /** Editable {@link Trip} fields for a partial update (admin, #26). routeId is
@@ -107,6 +111,8 @@ export class InMemoryTripRepository implements TripRepository {
   async findAll(filter?: TripFilter): Promise<Trip[]> {
     return Array.from(this.trips.values())
       .filter((t) => !filter?.routeId || t.routeId === filter.routeId)
+      .filter((t) => !filter?.status || t.status === filter.status)
+      .filter((t) => !filter?.date || t.scheduledAt.toISOString().slice(0, 10) === filter.date)
       .sort((a, b) => a.scheduledAt.getTime() - b.scheduledAt.getTime());
   }
 

--- a/services/api/src/modules/users/user.repository.pg.ts
+++ b/services/api/src/modules/users/user.repository.pg.ts
@@ -54,4 +54,12 @@ export class PgUserRepository implements UserRepository {
     );
     return rows[0] ? toUser(rows[0]) : null;
   }
+
+  async setRole(id: string, role: UserRole): Promise<User | null> {
+    const { rows } = await this.pool.query<UserRow>(
+      `UPDATE users SET role = $2, updated_at = now() WHERE id = $1 RETURNING *`,
+      [id, role],
+    );
+    return rows[0] ? toUser(rows[0]) : null;
+  }
 }

--- a/services/api/src/modules/users/user.repository.ts
+++ b/services/api/src/modules/users/user.repository.ts
@@ -56,6 +56,15 @@ export interface UserRepository {
    * @returns the updated user, or null if not found.
    */
   setAvatarKey(id: string, key: string | null): Promise<User | null>;
+  /**
+   * Change a user's role (admin op, #26). The JWT carries the role at sign-in,
+   * so the change takes effect on the user's next token refresh/sign-in.
+   *
+   * @param id - the user id.
+   * @param role - the role to grant.
+   * @returns the updated user, or null if not found.
+   */
+  setRole(id: string, role: UserRole): Promise<User | null>;
 }
 
 /** In-memory {@link UserRepository} for dev and unit tests. */
@@ -91,6 +100,14 @@ export class InMemoryUserRepository implements UserRepository {
     const user = this.users.get(id);
     if (!user) return null;
     const updated = { ...user, avatarUrl: key };
+    this.users.set(id, updated);
+    return updated;
+  }
+
+  async setRole(id: string, role: UserRole): Promise<User | null> {
+    const user = this.users.get(id);
+    if (!user) return null;
+    const updated = { ...user, role };
     this.users.set(id, updated);
     return updated;
   }

--- a/services/api/tests/admin.hardening.test.ts
+++ b/services/api/tests/admin.hardening.test.ts
@@ -1,0 +1,198 @@
+// Hardening fixes on the admin/ops endpoints (follow-up to #115): the role
+// grant that makes the driver app usable, throttle-before-role ordering, 409 on
+// duplicate stop seq, driver user_id validation, and trip list filters.
+
+import { describe, expect, it } from 'vitest';
+import { buildApp } from '../src/app';
+import { InMemoryRouteRepository } from '../src/modules/mobility/route.repository';
+import { InMemoryStopRepository } from '../src/modules/mobility/stop.repository';
+import { InMemoryRouteStopRepository } from '../src/modules/mobility/route-stop.repository';
+import { InMemoryDriverRepository } from '../src/modules/mobility/driver.repository';
+import { InMemoryTripRepository } from '../src/modules/mobility/trip.repository';
+import { InMemoryUserRepository } from '../src/modules/users/user.repository';
+import { createJwtService, type AuthConfig } from '../src/modules/auth/jwt';
+
+const auth: AuthConfig = {
+  secret: 'test-secret-at-least-32-characters-long-0000',
+  accessTtl: '15m',
+  issuer: 'trotxi',
+  audience: 'trotxi-api',
+};
+const jwt = createJwtService(auth);
+const bearer = (t: string) => ({ authorization: `Bearer ${t}` });
+const admin = () => jwt.signAccessToken({ userId: 'admin-1', role: 'admin' });
+
+describe('PATCH /admin/users/:id/role', () => {
+  it('requires the admin role (commuter → 403)', async () => {
+    const users = new InMemoryUserRepository();
+    const user = await users.create({ displayName: 'Ama' });
+    const app = await buildApp({ auth, users });
+    const res = await app.inject({
+      method: 'PATCH',
+      url: `/admin/users/${user.id}/role`,
+      headers: bearer(await jwt.signAccessToken({ userId: 'u1', role: 'commuter' })),
+      payload: { role: 'driver' },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('promotes a commuter to driver — and their next token can scan', async () => {
+    const users = new InMemoryUserRepository();
+    const rider = await users.create({ displayName: 'Kofi' });
+    expect(rider.role).toBe('commuter');
+    const app = await buildApp({ auth, users });
+
+    const res = await app.inject({
+      method: 'PATCH',
+      url: `/admin/users/${rider.id}/role`,
+      headers: bearer(await admin()),
+      payload: { role: 'driver' },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ id: rider.id, role: 'driver' });
+    expect((await users.findById(rider.id))?.role).toBe('driver');
+
+    // The point of the endpoint: a token minted with the new role clears the
+    // driver guard on the scan route (403 before, non-403 after).
+    const promotedToken = await jwt.signAccessToken({ userId: rider.id, role: 'driver' });
+    const scan = await app.inject({
+      method: 'POST',
+      url: '/boarding/scan',
+      headers: bearer(promotedToken),
+      payload: { pass: 'garbage' },
+    });
+    expect(scan.statusCode).toBe(200); // authorized; pass itself is just invalid
+    expect(scan.json()).toMatchObject({ valid: false, reason: 'invalid' });
+  });
+
+  it('404 for an unknown user; 400 for an unknown role', async () => {
+    const users = new InMemoryUserRepository();
+    const app = await buildApp({ auth, users });
+    const missing = await app.inject({
+      method: 'PATCH',
+      url: `/admin/users/${crypto.randomUUID()}/role`,
+      headers: bearer(await admin()),
+      payload: { role: 'driver' },
+    });
+    expect(missing.statusCode).toBe(404);
+
+    const badRole = await app.inject({
+      method: 'PATCH',
+      url: `/admin/users/${crypto.randomUUID()}/role`,
+      headers: bearer(await admin()),
+      payload: { role: 'superuser' },
+    });
+    expect(badRole.statusCode).toBe(400);
+  });
+});
+
+describe('admin rate limiting', () => {
+  it('throttles before the role check (non-admins cannot hammer 403s)', async () => {
+    const app = await buildApp({
+      auth,
+      routes: new InMemoryRouteRepository(),
+      rateLimit: { max: 2, windowSeconds: 60 },
+    });
+    const commuter = await jwt.signAccessToken({ userId: 'u1', role: 'commuter' });
+    const get = () =>
+      app.inject({ method: 'GET', url: '/admin/routes', headers: bearer(commuter) });
+    expect((await get()).statusCode).toBe(403);
+    expect((await get()).statusCode).toBe(403);
+    expect((await get()).statusCode).toBe(429); // throttled, not another 403
+  });
+});
+
+describe('POST /admin/routes/:id/stops', () => {
+  it('409 when the sequence position is already taken on the route', async () => {
+    const routes = new InMemoryRouteRepository();
+    const stops = new InMemoryStopRepository();
+    const routeStops = new InMemoryRouteStopRepository();
+    const route = await routes.create({ name: 'Circle → Legon' });
+    const a = await stops.create({ name: 'Circle', latitude: 5.57, longitude: -0.21 });
+    const b = await stops.create({ name: 'Legon', latitude: 5.65, longitude: -0.18 });
+    const app = await buildApp({ auth, routes, stops, routeStops });
+    const token = await admin();
+    const attach = (stopId: string) =>
+      app.inject({
+        method: 'POST',
+        url: `/admin/routes/${route.id}/stops`,
+        headers: bearer(token),
+        payload: { stopId, seq: 1 },
+      });
+
+    expect((await attach(a.id)).statusCode).toBe(200);
+
+    const dup = await attach(b.id);
+    expect(dup.statusCode).toBe(409);
+    expect(dup.json().error).toBe('conflict');
+  });
+});
+
+describe('POST /admin/drivers', () => {
+  it('404 for a userId that does not exist (clean error, not a DB 500)', async () => {
+    const app = await buildApp({
+      auth,
+      drivers: new InMemoryDriverRepository(),
+      users: new InMemoryUserRepository(),
+    });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/admin/drivers',
+      headers: bearer(await admin()),
+      payload: { fullName: 'Yaw Driver', userId: crypto.randomUUID() },
+    });
+    expect(res.statusCode).toBe(404);
+    expect(res.json().message).toBe('User not found');
+  });
+
+  it('creates a driver linked to a real user', async () => {
+    const users = new InMemoryUserRepository();
+    const user = await users.create({ displayName: 'Yaw' });
+    const app = await buildApp({ auth, drivers: new InMemoryDriverRepository(), users });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/admin/drivers',
+      headers: bearer(await admin()),
+      payload: { fullName: 'Yaw Driver', userId: user.id },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().userId).toBe(user.id);
+  });
+});
+
+describe('GET /admin/trips filters', () => {
+  it('filters by status and UTC day', async () => {
+    const trips = new InMemoryTripRepository();
+    const routeId = crypto.randomUUID();
+    await trips.create({ routeId, scheduledAt: new Date('2026-07-08T06:30:00Z') });
+    await trips.create({
+      routeId,
+      scheduledAt: new Date('2026-07-08T17:00:00Z'),
+      status: 'cancelled',
+    });
+    await trips.create({ routeId, scheduledAt: new Date('2026-07-09T06:30:00Z') });
+    const app = await buildApp({ auth, trips });
+    const token = await admin();
+
+    const day = await app.inject({
+      method: 'GET',
+      url: '/admin/trips?date=2026-07-08',
+      headers: bearer(token),
+    });
+    expect(day.json()).toHaveLength(2);
+
+    const dayScheduled = await app.inject({
+      method: 'GET',
+      url: '/admin/trips?date=2026-07-08&status=scheduled',
+      headers: bearer(token),
+    });
+    expect(dayScheduled.json()).toHaveLength(1);
+
+    const badDate = await app.inject({
+      method: 'GET',
+      url: '/admin/trips?date=08-07-2026',
+      headers: bearer(token),
+    });
+    expect(badDate.statusCode).toBe(400);
+  });
+});


### PR DESCRIPTION
The agreed follow-up to #115's review. Five fixes, most important first:

### 1. `PATCH /admin/users/:id/role` — the real gap
Creating a `drivers` fleet row never touched `users.role`, but the JWT is signed from `users.role` at sign-in — so a linked driver still authenticated as a **commuter** and got **403 on `POST /boarding/scan`**. This endpoint closes the loop: ops promotes the account (`commuter | driver | admin`), effective on the next token refresh/sign-in (≤15 min for live tokens). Tested end-to-end: **promote → new token clears the driver guard on scan**.
**Bootstrap note** (documented in the route header): the *first* admin can't come through this endpoint — grant once via SQL: `UPDATE users SET role='admin' WHERE id='<uuid>';`

### 2. Throttle before the role check
`adminOnly` reordered to `[authenticate, rateLimit, requireRole]` — same convention we settled in #93; non-admin tokens can no longer hammer unthrottled 403s. Regression test: `403, 403, 429`.

### 3. Duplicate stop `seq` → 409 (was a Pg-only 500)
`UNIQUE (route_id, seq)` violations now map to a clean **409**; the in-memory adapter mirrors the 23505 shape so both paths behave identically (and it's testable in CI).

### 4. Driver `userId` validated → 404 (was a FK 500)
Consistent with trip create. The `users` dep is only required when a link is actually made — existing tests/wiring untouched.

### 5. `GET /admin/trips?routeId&status&date`
Repo-level `TripFilter` too — `date` is the UTC calendar day, which is exactly the query the **E3 ask-dispatch** needs for "tomorrow's scheduled trips".

### Verification
8 new tests (role grant incl. promote→scan, throttle order, 409, userId 404 + happy path, filters + bad-date 400). **235 green**, coverage gate passes, lint/typecheck clean. No migration (role column exists).