### PR TITLE
feat(api): driver manifest — the photo pass (#20, E4)

### DIFF
--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -25,7 +25,7 @@ repo (`system-design.md`, `security.md`). Each doc links to both.
 | Daily ride confirmation — `POST /me/reservations` (confirm/decline) (#101)  | [reservations.md](reservations.md)               | 🟡 E3 core (ask-dispatch deferred #18) |
 | Mobility — routes, stops, browse                                            | _(in review — #57)_                              | 🚧                                     |
 | Rate limiting (#23)                                                         | [rate-limiting.md](rate-limiting.md)             | ✅ live                                |
-| Boarding — QR scan + ride deduction (#20, E4)                               | [boarding.md](boarding.md)                       | 🟢 scan + deduction (manifest/PIN #26) |
+| Boarding — QR scan + manifest + PIN, all deduct (#20, E4)                   | [boarding.md](boarding.md)                       | 🟢 3-layer verification live           |
 | Observability & performance (#28)                                           | [design](../design/observability.md)             | ✅ backend live (metrics/traces/logs)  |
 
 ## Conventions for a feature doc

--- a/docs/features/boarding.md
+++ b/docs/features/boarding.md
@@ -86,10 +86,14 @@ three verification layers**, and boarding consumes **1 ride from the subscriptio
 entitlement**. **Done in this slice:** ride deduction on a valid scan (above).
 Still to come (blocked on trips/admin, #26):
 
-- **Driver manifest layer** — name + **photo** (server-side, R2 #24) + pickup
-  point for the day's reservations. The photo pass is now required product.
-- **Daily 4-digit PIN layer** — offline-friendly fallback; only works _with_ the
-  manifest (a 4-digit code can't identify a rider alone), so it ships with #26.
+- ✅ **Driver manifest layer** — `GET /boarding/manifest?tripId=` (driver only)
+  returns the trip's confirmed riders with **name + signed photo URL** + boarded
+  status (the photo pass; the photo comes from the server, never the QR). Only
+  `reserved`/`boarded` seats appear. _Follow-ups:_ restrict to the trip's
+  **assigned driver** (needs the driver↔user lookup #25 also uses; they land
+  together), and add a per-rider **pickup point** (needs a rider↔stop link).
+- **Daily 4-digit PIN layer** — offline-friendly fallback; rides on the manifest
+  (a 4-digit code can't identify a rider alone) — next up.
 - **Confirmed-yes no-show** deduction job (cron); operator cancellation never
   deducts. Same idempotency key space (`board:<reservationId>`) so a late board
   and the no-show sweep can't both charge.

--- a/docs/features/boarding.md
+++ b/docs/features/boarding.md
@@ -2,10 +2,11 @@
 
 **Owner:** Godfred Awuku · **Last updated:** 2026-07-02
 
-**Status:** 🟢 QR scan **+ ride deduction** live (#20, E4). A valid scan now
-consumes the rider's confirmed reservation and **debits one ride** from their
-entitlement (ADR-0014). Still deferred: the **manifest + daily-PIN** layers and
-the confirmed-yes **no-show** job (both need trips/admin #26) — see below.
+**Status:** 🟢 All three verification layers live (#20, E4): **QR scan**,
+**driver manifest** (photo pass), and **daily PIN** — any one boards the rider's
+confirmed reservation and **debits one ride** (ADR-0014). Still deferred: the
+confirmed-yes **no-show** cron and restricting the manifest to a trip's assigned
+driver (both pair with #25) — see below.
 
 Lets a driver confirm a rider is boarding with a **genuine, unforged, unexpired
 pass**, and logs every scan for audit. Rationale: #20.
@@ -54,13 +55,32 @@ Verify a scanned pass (drivers only) and record the scan.
   was boarded and a ride debited. `riderId` is still returned so the driver sees
   who presented it.)
 
+#### `GET /boarding/manifest?tripId=<uuid>`
+
+The trip's confirmed riders (driver only) — the photo pass.
+
+- **Auth:** `Bearer` + **role `driver`**. **Rate limit:** per user.
+- **200:** `{ "tripId", "riders": [ { reservationId, userId, name, avatarUrl, direction, boarded } ] }`
+  — `avatarUrl` is a short-lived signed URL (null when no photo); only
+  `reserved`/`boarded` seats appear. **400** bad tripId · **403** · **503**
+
+#### `POST /boarding/verify-pin`
+
+Board a rider by their daily 4-digit PIN (driver only) — verification layer 2.
+
+- **Auth:** `Bearer` + **role `driver`**. **Rate limit:** per user.
+- **Body:** `{ "reservationId": "<uuid>", "pin": "1234" }`
+- **200:** `{ "valid", "riderId", "reason": "ok"|"invalid"|"not_found"|"already_boarded", "deducted" }`
+  — `ok` boards + debits; `already_boarded` is the idempotent no-op. **400** bad PIN · **403**
+
 ---
 
 ## Data
 
 `scan_events(id, rider_id, scanned_by, trip_id, result, method, created_at)` —
-`result` ∈ `valid|invalid|expired|reused`, `method` ∈ `qr|photo`. `trip_id` has
-no FK yet (trips are #18).
+`result` ∈ `valid|invalid|expired|reused`, `method` ∈ `qr|photo|pin`. `trip_id`
+has no FK yet (trips are #18). The daily PIN is stored on `reservations`
+(`daily_pin_hash`, a keyed HMAC — never plaintext).
 
 ## Security notes
 
@@ -81,25 +101,23 @@ no FK yet (trips are #18).
 ## Next (Hybrid Subscription Model — ADR-0014, boarding v2 / epic E4)
 
 The commercial model is decided
-([ADR-0014](../adr/0014-hybrid-subscription-model.md)): this QR scan is **one of
-three verification layers**, and boarding consumes **1 ride from the subscription
-entitlement**. **Done in this slice:** ride deduction on a valid scan (above).
-Still to come (blocked on trips/admin, #26):
+([ADR-0014](../adr/0014-hybrid-subscription-model.md)): boarding is **three
+verification layers**, and any one consumes **1 ride from the subscription
+entitlement**. **Done (this + prior slices):** QR scan + deduction, the driver
+**manifest** (photo pass), and the **daily PIN**. Still to come:
 
-- ✅ **Driver manifest layer** — `GET /boarding/manifest?tripId=` (driver only)
-  returns the trip's confirmed riders with **name + signed photo URL** + boarded
-  status (the photo pass; the photo comes from the server, never the QR). Only
-  `reserved`/`boarded` seats appear. _Follow-ups:_ restrict to the trip's
-  **assigned driver** (needs the driver↔user lookup #25 also uses; they land
-  together), and add a per-rider **pickup point** (needs a rider↔stop link).
-- **Daily 4-digit PIN layer** — offline-friendly fallback; rides on the manifest
-  (a 4-digit code can't identify a rider alone) — next up.
+- ✅ **QR scan** — `POST /boarding/scan` (deducts).
+- ✅ **Driver manifest** — `GET /boarding/manifest?tripId=` (name + signed photo).
+- ✅ **Daily PIN** — `POST /boarding/verify-pin` (boards + deducts, idempotent).
 - **Confirmed-yes no-show** deduction job (cron); operator cancellation never
   deducts. Same idempotency key space (`board:<reservationId>`) so a late board
   and the no-show sweep can't both charge.
-- Direction/trip resolution: today a scan boards the rider's **earliest open leg
-  for the day** (morning before evening); when trips carry the run's direction,
-  the scan will target that specific reservation.
+- **Manifest → assigned driver only** — restrict a trip's manifest to its
+  assigned driver (needs the driver↔user lookup #25 also uses; they land together).
+- **Per-rider pickup point** on the manifest — needs a rider↔stop link.
+- Direction/trip resolution: a QR scan still boards the rider's **earliest open
+  leg for the day** (morning before evening); the PIN + manifest target a
+  specific reservation. When trips carry the run's direction, the scan converges.
 
 ## Where the code lives
 

--- a/docs/features/reservations.md
+++ b/docs/features/reservations.md
@@ -41,8 +41,11 @@ Confirm or decline (an upsert per day+direction).
 
 - **Auth:** `Bearer`. **Rate limit:** per user.
 - **Body:** `{ "tripId?": "<uuid>", "travelDate": "YYYY-MM-DD", "direction": "morning"|"evening", "travelling": true|false }`
-- **200:** the reservation `{ id, tripId, travelDate, direction, status, source }`
-  (`reserved` when travelling, else `declined`) · **400** bad date · **401** · **429** · **503**
+- **200:** the reservation `{ id, tripId, travelDate, direction, status, source, pin? }`
+  (`reserved` when travelling, else `declined`). On a **confirm**, `pin` is the
+  rider's daily **4-digit boarding PIN** — returned **once** here; only its keyed
+  hash (`daily_pin_hash`) is stored. The driver types it against the manifest to
+  board (E4, `POST /boarding/verify-pin`). · **400** bad date · **401** · **429** · **503**
 
 #### `GET /me/reservations?from=YYYY-MM-DD`
 

--- a/services/api/src/app.ts
+++ b/services/api/src/app.ts
@@ -205,6 +205,7 @@ export async function buildApp(deps: AppDeps = {}): Promise<FastifyInstance> {
   });
   await app.register(reservationRoutes, {
     reservations,
+    secret: authConfig.secret,
     rateLimit: deps.rateLimit ?? DEFAULT_RATE_LIMIT,
   });
   await app.register(boardingRoutes, {

--- a/services/api/src/app.ts
+++ b/services/api/src/app.ts
@@ -17,6 +17,7 @@ import {
 } from './modules/devices/device-token.repository';
 import { deviceRoutes } from './modules/devices/devices.routes';
 import { BoardingService } from './modules/boarding/boarding.service';
+import { ManifestService } from './modules/boarding/manifest.service';
 import { boardingRoutes } from './modules/boarding/boarding.routes';
 import { InMemoryScanEventRepository } from './modules/boarding/scan-event.repository';
 import { metricsPlugin, type MetricsOptions } from './modules/metrics/metrics.plugin';
@@ -55,7 +56,7 @@ import type { TripRepository } from './modules/mobility/trip.repository';
 import type { VehicleRepository } from './modules/mobility/vehicle.repository';
 import type { DriverRepository } from './modules/mobility/driver.repository';
 import type { SubscriptionRepository } from './modules/subscriptions/subscription.repository';
-import type { UserRepository } from './modules/users/user.repository';
+import { InMemoryUserRepository, type UserRepository } from './modules/users/user.repository';
 
 /**
  * Dependencies are injected here — services and repositories register as the
@@ -169,7 +170,9 @@ export async function buildApp(deps: AppDeps = {}): Promise<FastifyInstance> {
   const kv = deps.kv ?? new InMemoryKvStore();
   const objectStore = deps.objectStore ?? new FakeObjectStore();
   // Shared so a boarding scan boards the same reservation the rider confirmed
-  // and debits the same entitlement ledger GET /me/rides reads (E4).
+  // and debits the same entitlement ledger GET /me/rides reads (E4); the manifest
+  // reads the same users auth writes.
+  const users = deps.users ?? new InMemoryUserRepository();
   const entitlements = deps.entitlements ?? new InMemoryEntitlementLedgerRepository();
   const credits = deps.credits ?? new InMemoryCreditLedgerRepository();
   const reservations = deps.reservations ?? new InMemoryReservationRepository();
@@ -177,13 +180,13 @@ export async function buildApp(deps: AppDeps = {}): Promise<FastifyInstance> {
   await app.register(authPlugin, { config: authConfig });
   await app.register(rateLimitPlugin, { kv });
   await app.register(authRoutes, {
-    users: deps.users,
+    users,
     objectStore,
     authService: deps.authService,
     rateLimit: deps.rateLimit ?? DEFAULT_RATE_LIMIT,
   });
   await app.register(userRoutes, {
-    users: deps.users,
+    users,
     objectStore,
     rateLimit: deps.rateLimit ?? DEFAULT_RATE_LIMIT,
   });
@@ -215,6 +218,7 @@ export async function buildApp(deps: AppDeps = {}): Promise<FastifyInstance> {
         secret: authConfig.secret,
         passTtlSeconds: 60,
       }),
+    manifestService: new ManifestService({ reservations, users, objectStore }),
     rateLimit: deps.rateLimit ?? DEFAULT_RATE_LIMIT,
   });
   await app.register(mobilityRoutes, {

--- a/services/api/src/db/migrations/016_reservation_pin.sql
+++ b/services/api/src/db/migrations/016_reservation_pin.sql
@@ -1,0 +1,6 @@
+-- 016_reservation_pin: the daily 4-digit boarding PIN (ADR-0014, E4 layer 2).
+-- Issued when a rider confirms (status → reserved); the driver types it against
+-- the manifest row to board offline when the QR can't be scanned. Stored as a
+-- keyed hash (HMAC-SHA256 with the server secret) — never plaintext; the
+-- plaintext is returned once, to the rider, in the confirm response.
+ALTER TABLE reservations ADD COLUMN IF NOT EXISTS daily_pin_hash text;

--- a/services/api/src/db/migrations/017_scan_method_pin.sql
+++ b/services/api/src/db/migrations/017_scan_method_pin.sql
@@ -1,0 +1,6 @@
+-- 017_scan_method_pin: allow 'pin' as a scan_events method (ADR-0014, E4 layer 2).
+-- Boarding a rider via their daily 4-digit PIN is audited the same as a QR scan,
+-- so the method CHECK gains 'pin' alongside 'qr' | 'photo'.
+ALTER TABLE scan_events DROP CONSTRAINT IF EXISTS scan_events_method_check;
+ALTER TABLE scan_events
+  ADD CONSTRAINT scan_events_method_check CHECK (method IN ('qr', 'photo', 'pin'));

--- a/services/api/src/modules/boarding/boarding.routes.ts
+++ b/services/api/src/modules/boarding/boarding.routes.ts
@@ -8,19 +8,32 @@ import type { ZodTypeProvider } from 'fastify-type-provider-zod';
 import { errorResponseSchema } from '../../lib/schemas';
 import type { RateLimitConfig } from '../ratelimit/ratelimit.plugin';
 import type { BoardingService } from './boarding.service';
-import { passResponseSchema, scanBodySchema, scanResponseSchema } from './boarding.schema';
+import type { ManifestService } from './manifest.service';
+import {
+  manifestQuerySchema,
+  manifestResponseSchema,
+  passResponseSchema,
+  scanBodySchema,
+  scanResponseSchema,
+} from './boarding.schema';
 
 /**
- * Register the boarding routes (`GET /me/pass`, `POST /boarding/scan`).
+ * Register the boarding routes (`GET /me/pass`, `POST /boarding/scan`,
+ * `GET /boarding/manifest`).
  *
  * @param app - the Fastify instance to register on.
  * @param opts - route dependencies.
  * @param opts.boardingService - issues passes + verifies scans.
+ * @param opts.manifestService - builds a trip's driver manifest (503 when absent).
  * @param opts.rateLimit - per-user rate-limit config.
  */
 export async function boardingRoutes(
   app: FastifyInstance,
-  opts: { boardingService: BoardingService; rateLimit: RateLimitConfig },
+  opts: {
+    boardingService: BoardingService;
+    manifestService?: ManifestService;
+    rateLimit: RateLimitConfig;
+  },
 ): Promise<void> {
   const r = app.withTypeProvider<ZodTypeProvider>();
 
@@ -66,5 +79,41 @@ export async function boardingRoutes(
         scannedBy: request.user!.id,
         tripId: request.body.tripId,
       }),
+  );
+
+  // Driver manifest for a trip — name + photo + boarded status of confirmed
+  // riders (the "photo pass"). Driver-role gated. (Restricting to the trip's
+  // ASSIGNED driver is a security follow-up — it needs the driver↔user lookup
+  // that GPS reporting #25 also requires; both land together.)
+  r.get(
+    '/boarding/manifest',
+    {
+      schema: {
+        tags: ['boarding'],
+        summary: "A trip's manifest — confirmed riders with name + photo (driver only)",
+        security: [{ bearerAuth: [] }],
+        querystring: manifestQuerySchema,
+        response: {
+          200: manifestResponseSchema,
+          401: errorResponseSchema,
+          403: errorResponseSchema,
+          503: errorResponseSchema,
+        },
+      },
+      preHandler: [
+        app.authenticate,
+        app.rateLimit({ ...opts.rateLimit, by: 'user' }),
+        app.requireRole('driver'),
+      ],
+    },
+    async (request, reply) => {
+      if (!opts.manifestService) {
+        return reply
+          .code(503)
+          .send({ error: 'unavailable', message: 'Manifest is not configured' });
+      }
+      const riders = await opts.manifestService.getManifest(request.query.tripId);
+      return { tripId: request.query.tripId, riders };
+    },
   );
 }

--- a/services/api/src/modules/boarding/boarding.routes.ts
+++ b/services/api/src/modules/boarding/boarding.routes.ts
@@ -15,6 +15,8 @@ import {
   passResponseSchema,
   scanBodySchema,
   scanResponseSchema,
+  verifyPinBodySchema,
+  verifyPinResponseSchema,
 } from './boarding.schema';
 
 /**
@@ -78,6 +80,37 @@ export async function boardingRoutes(
         pass: request.body.pass,
         scannedBy: request.user!.id,
         tripId: request.body.tripId,
+      }),
+  );
+
+  // Verification layer 2 — board a rider by the daily PIN they present (driver
+  // types it against the manifest row). Boards + debits like the QR scan.
+  r.post(
+    '/boarding/verify-pin',
+    {
+      schema: {
+        tags: ['boarding'],
+        summary: 'Board a rider via their daily 4-digit PIN (driver only)',
+        security: [{ bearerAuth: [] }],
+        body: verifyPinBodySchema,
+        response: {
+          200: verifyPinResponseSchema,
+          400: errorResponseSchema,
+          401: errorResponseSchema,
+          403: errorResponseSchema,
+        },
+      },
+      preHandler: [
+        app.authenticate,
+        app.rateLimit({ ...opts.rateLimit, by: 'user' }),
+        app.requireRole('driver'),
+      ],
+    },
+    async (request) =>
+      opts.boardingService.verifyPin({
+        reservationId: request.body.reservationId,
+        pin: request.body.pin,
+        scannedBy: request.user!.id,
       }),
   );
 

--- a/services/api/src/modules/boarding/boarding.schema.ts
+++ b/services/api/src/modules/boarding/boarding.schema.ts
@@ -20,3 +20,22 @@ export const scanResponseSchema = z.object({
    * for today). False for a valid pass with no reservation to board. */
   deducted: z.boolean(),
 });
+
+export const manifestQuerySchema = z.object({
+  tripId: z.string().uuid(),
+});
+
+export const manifestResponseSchema = z.object({
+  tripId: z.string().uuid(),
+  riders: z.array(
+    z.object({
+      reservationId: z.string().uuid(),
+      userId: z.string().uuid(),
+      name: z.string().nullable(),
+      /** Short-lived signed avatar URL, or null when the rider has no photo. */
+      avatarUrl: z.string().nullable(),
+      direction: z.enum(['morning', 'evening']),
+      boarded: z.boolean(),
+    }),
+  ),
+});

--- a/services/api/src/modules/boarding/boarding.schema.ts
+++ b/services/api/src/modules/boarding/boarding.schema.ts
@@ -21,6 +21,20 @@ export const scanResponseSchema = z.object({
   deducted: z.boolean(),
 });
 
+export const verifyPinBodySchema = z.object({
+  /** The reservation the driver picked off the manifest. */
+  reservationId: z.string().uuid(),
+  /** The rider's daily 4-digit PIN. */
+  pin: z.string().regex(/^\d{4}$/, 'expected a 4-digit PIN'),
+});
+
+export const verifyPinResponseSchema = z.object({
+  valid: z.boolean(),
+  riderId: z.string().nullable(),
+  reason: z.enum(['ok', 'invalid', 'not_found', 'already_boarded']),
+  deducted: z.boolean(),
+});
+
 export const manifestQuerySchema = z.object({
   tripId: z.string().uuid(),
 });

--- a/services/api/src/modules/boarding/boarding.service.ts
+++ b/services/api/src/modules/boarding/boarding.service.ts
@@ -14,9 +14,10 @@
 import { errors } from 'jose';
 import type { KvStore } from '../../kv/kv.store';
 import type { EntitlementLedgerRepository } from '../entitlements/entitlement-ledger.repository';
-import type { ReservationRepository } from '../reservations/reservation.repository';
+import type { Reservation, ReservationRepository } from '../reservations/reservation.repository';
+import { verifyPin as checkPin } from '../reservations/pin';
 import { signPass, verifyPass, type IssuedPass } from './pass';
-import type { ScanEventRepository } from './scan-event.repository';
+import type { ScanEventRepository, ScanMethod } from './scan-event.repository';
 
 /** A driver's request to verify a scanned pass. */
 export interface VerifyScanInput {
@@ -35,6 +36,24 @@ export interface VerifyScanResult {
   riderId: string | null;
   reason: 'ok' | 'invalid' | 'expired' | 'reused';
   /** True when this scan consumed a ride (a confirmed reservation was boarded). */
+  deducted: boolean;
+}
+
+/** A driver's request to board a rider via their daily PIN (verification layer 2). */
+export interface VerifyPinInput {
+  /** The reservation the driver picked off the manifest. */
+  reservationId: string;
+  /** The 4-digit PIN the rider presented. */
+  pin: string;
+  /** The driver performing the verification. */
+  scannedBy: string;
+}
+
+/** The outcome of a PIN verification. */
+export interface VerifyPinResult {
+  valid: boolean;
+  riderId: string | null;
+  reason: 'ok' | 'invalid' | 'not_found' | 'already_boarded';
   deducted: boolean;
 }
 
@@ -110,47 +129,124 @@ export class BoardingService {
       }
     }
 
-    // A valid scan consumes the rider's confirmed reservation for today: mark it
-    // boarded and debit one ride (ADR-0014, E4). Idempotent by reservation, and
-    // findBoardable skips already-boarded seats, so re-scanning a rider (with a
-    // freshly rotated QR) can't double-charge. Fails OPEN — a hiccup here must
-    // not stop the bus; reconciliation catches any gap.
+    // A valid scan consumes the rider's confirmed reservation for today. Fails
+    // OPEN — a hiccup here must not stop the bus; reconciliation catches any gap.
     let deducted = false;
     if (reason === 'ok' && riderId && this.deps.reservations && this.deps.entitlements) {
       try {
         const boardable = await this.deps.reservations.findBoardable(riderId, todayISO());
-        if (boardable) {
-          await this.deps.reservations.markBoarded(boardable.id);
-          await this.deps.entitlements.record({
-            userId: riderId,
-            deltaRides: -1,
-            reason: 'boarding',
-            refType: 'reservation',
-            refId: boardable.id,
-            idempotencyKey: `board:${boardable.id}`,
-          });
-          deducted = true;
-        }
+        if (boardable) deducted = await this.boardAndDebit(boardable);
       } catch (err) {
         console.error('boarding: ride deduction failed (allowed to board anyway)', err);
       }
     }
 
-    // Audit is best-effort here: verification already answered the driver, and a
-    // DB blip (or a rider deleted mid-window tripping the FK) must not 500 the
-    // scan. Failures are logged loudly instead.
+    await this.recordScan(riderId, input.scannedBy, input.tripId ?? null, reason, 'qr');
+    return { valid: reason === 'ok', riderId, reason, deducted };
+  }
+
+  /**
+   * Verification layer 2 — board a rider via the daily PIN the driver typed
+   * against the manifest (offline-friendly when the QR can't be scanned). The
+   * PIN only matches a `reserved` seat, and boarding is idempotent per
+   * reservation, so a repeat returns `already_boarded` without a second debit.
+   *
+   * @param input - the reservation, the presented PIN, and the driver.
+   * @returns whether the PIN boarded the seat, the rider id, and the reason.
+   */
+  async verifyPin(input: VerifyPinInput): Promise<VerifyPinResult> {
+    if (!this.deps.reservations) {
+      return { valid: false, riderId: null, reason: 'not_found', deducted: false };
+    }
+    const reservation = await this.deps.reservations.findById(input.reservationId);
+    if (!reservation) {
+      return { valid: false, riderId: null, reason: 'not_found', deducted: false };
+    }
+    if (!checkPin(input.pin, reservation.pinHash, this.deps.secret)) {
+      await this.recordScan(
+        reservation.userId,
+        input.scannedBy,
+        reservation.tripId,
+        'invalid',
+        'pin',
+      );
+      return { valid: false, riderId: reservation.userId, reason: 'invalid', deducted: false };
+    }
+    // Correct PIN. A `reserved` seat boards + debits; an already-`boarded` one is
+    // a no-op (idempotent — no second charge).
+    if (reservation.status !== 'reserved') {
+      await this.recordScan(
+        reservation.userId,
+        input.scannedBy,
+        reservation.tripId,
+        'reused',
+        'pin',
+      );
+      return {
+        valid: true,
+        riderId: reservation.userId,
+        reason: 'already_boarded',
+        deducted: false,
+      };
+    }
+    let deducted = false;
+    try {
+      deducted = await this.boardAndDebit(reservation);
+    } catch (err) {
+      console.error('boarding: PIN ride deduction failed (allowed to board anyway)', err);
+    }
+    await this.recordScan(reservation.userId, input.scannedBy, reservation.tripId, 'ok', 'pin');
+    return { valid: true, riderId: reservation.userId, reason: 'ok', deducted };
+  }
+
+  /**
+   * Board a reservation and debit one ride — the shared consume step for both
+   * the QR scan and the PIN. Idempotent per reservation (`board:<id>`).
+   *
+   * @param reservation - the confirmed reservation being boarded.
+   * @returns whether a ride was debited (true when the ledger is wired).
+   */
+  private async boardAndDebit(reservation: Reservation): Promise<boolean> {
+    if (!this.deps.reservations || !this.deps.entitlements) return false;
+    await this.deps.reservations.markBoarded(reservation.id);
+    await this.deps.entitlements.record({
+      userId: reservation.userId,
+      deltaRides: -1,
+      reason: 'boarding',
+      refType: 'reservation',
+      refId: reservation.id,
+      idempotencyKey: `board:${reservation.id}`,
+    });
+    return true;
+  }
+
+  /**
+   * Append a best-effort scan-audit row. A DB blip (or an FK race on a deleted
+   * rider) must not fail the boarding, so errors are logged, never thrown.
+   *
+   * @param riderId - the rider (null when unattributable).
+   * @param scannedBy - the driver.
+   * @param tripId - the trip, if known.
+   * @param result - the verification outcome to record.
+   * @param method - how the rider was verified (`qr` | `pin`).
+   */
+  private async recordScan(
+    riderId: string | null,
+    scannedBy: string,
+    tripId: string | null,
+    result: VerifyScanResult['reason'],
+    method: ScanMethod,
+  ): Promise<void> {
     try {
       await this.deps.scanEvents.record({
         riderId,
-        scannedBy: input.scannedBy,
-        tripId: input.tripId ?? null,
-        result: reason === 'ok' ? 'valid' : reason,
-        method: 'qr',
+        scannedBy,
+        tripId,
+        result: result === 'ok' ? 'valid' : result,
+        method,
       });
     } catch (err) {
       console.error('boarding: failed to record scan event (audit gap)', err);
     }
-
-    return { valid: reason === 'ok', riderId, reason, deducted };
   }
 }

--- a/services/api/src/modules/boarding/manifest.service.ts
+++ b/services/api/src/modules/boarding/manifest.service.ts
@@ -1,0 +1,68 @@
+// Driver manifest (#20, E4) — the "photo pass". For a trip, the list of riders
+// expected to board, each with their name and a short-lived signed avatar URL so
+// the driver can eyeball the right person (security.md §7: the photo comes from
+// the SERVER, never the QR — a faker can't embed their own face). Only confirmed
+// seats appear (reserved | boarded); declined/pending rows are excluded.
+//
+// Enrichment reads the user (name + avatar key) and signs the key. Any rider
+// whose lookup fails still appears (name null) rather than dropping them from the
+// manifest — the driver should see every seat.
+
+import type { ObjectStore } from '../../storage/object-store';
+import type { Reservation, ReservationRepository } from '../reservations/reservation.repository';
+import type { UserRepository } from '../users/user.repository';
+
+/** One line on a driver's manifest. */
+export interface ManifestRider {
+  reservationId: string;
+  userId: string;
+  /** The rider's display name (null if the user record is missing). */
+  name: string | null;
+  /** Short-lived signed avatar URL, or null when the rider has no photo. */
+  avatarUrl: string | null;
+  direction: Reservation['direction'];
+  /** Whether the rider has already been verified onto the vehicle. */
+  boarded: boolean;
+}
+
+/** Collaborators for {@link ManifestService}. */
+export interface ManifestServiceDeps {
+  reservations: ReservationRepository;
+  users: UserRepository;
+  objectStore: ObjectStore;
+}
+
+/** Builds the driver manifest for a trip (see the file header). */
+export class ManifestService {
+  /** @param deps - the reservation store, user store, and object store. */
+  constructor(private readonly deps: ManifestServiceDeps) {}
+
+  /**
+   * The manifest for a trip: confirmed riders with name + signed photo.
+   *
+   * @param tripId - the trip whose riders to list.
+   * @returns the manifest riders (morning before evening).
+   */
+  async getManifest(tripId: string): Promise<ManifestRider[]> {
+    const reservations = await this.deps.reservations.listForTrip(tripId);
+    const confirmed = reservations.filter(
+      (rsv) => rsv.status === 'reserved' || rsv.status === 'boarded',
+    );
+    return Promise.all(
+      confirmed.map(async (rsv) => {
+        const user = await this.deps.users.findById(rsv.userId);
+        const avatarUrl = user?.avatarUrl
+          ? await this.deps.objectStore.signedUrl(user.avatarUrl)
+          : null;
+        return {
+          reservationId: rsv.id,
+          userId: rsv.userId,
+          name: user?.displayName ?? null,
+          avatarUrl,
+          direction: rsv.direction,
+          boarded: rsv.status === 'boarded',
+        };
+      }),
+    );
+  }
+}

--- a/services/api/src/modules/boarding/scan-event.repository.ts
+++ b/services/api/src/modules/boarding/scan-event.repository.ts
@@ -5,7 +5,7 @@
 /** Outcome of a scan. */
 export type ScanResult = 'valid' | 'invalid' | 'expired' | 'reused';
 /** How the rider was verified. */
-export type ScanMethod = 'qr' | 'photo';
+export type ScanMethod = 'qr' | 'photo' | 'pin';
 
 /** A recorded boarding scan. */
 export interface ScanEvent {

--- a/services/api/src/modules/reservations/pin.ts
+++ b/services/api/src/modules/reservations/pin.ts
@@ -1,0 +1,43 @@
+// Daily boarding PIN (ADR-0014, E4 layer 2). A rider gets a 4-digit code when
+// they confirm; the driver types it against the manifest to board offline. Low
+// entropy by design (4 digits), so the protection is layered: it's verified only
+// for a specific reservation the driver already sees on the manifest, the
+// verify endpoint is driver-gated + rate limited, and the stored value is a
+// KEYED hash (HMAC-SHA256 with the server secret) so a DB leak doesn't reveal it.
+
+import { createHmac, randomInt, timingSafeEqual } from 'node:crypto';
+
+/**
+ * Generate a random 4-digit PIN (`"0000"`–`"9999"`).
+ *
+ * @returns the plaintext PIN.
+ */
+export function generatePin(): string {
+  return String(randomInt(0, 10000)).padStart(4, '0');
+}
+
+/**
+ * Keyed hash of a PIN for storage (HMAC-SHA256 with the server secret).
+ *
+ * @param pin - the plaintext PIN.
+ * @param secret - the server signing key.
+ * @returns the hex-encoded hash.
+ */
+export function hashPin(pin: string, secret: string): string {
+  return createHmac('sha256', secret).update(pin).digest('hex');
+}
+
+/**
+ * Constant-time check of a PIN against a stored hash.
+ *
+ * @param pin - the presented plaintext PIN.
+ * @param hash - the stored hash (or null when the reservation has no PIN).
+ * @param secret - the server signing key.
+ * @returns whether the PIN matches.
+ */
+export function verifyPin(pin: string, hash: string | null, secret: string): boolean {
+  if (!hash) return false;
+  const expected = Buffer.from(hashPin(pin, secret), 'hex');
+  const actual = Buffer.from(hash, 'hex');
+  return expected.length === actual.length && timingSafeEqual(expected, actual);
+}

--- a/services/api/src/modules/reservations/reservation.repository.pg.ts
+++ b/services/api/src/modules/reservations/reservation.repository.pg.ts
@@ -17,6 +17,7 @@ interface ReservationRow {
   direction: ReservationDirection;
   status: ReservationStatus;
   source: ReservationSource;
+  daily_pin_hash: string | null;
   confirmed_at: Date | null;
   created_at: Date;
   updated_at: Date;
@@ -31,6 +32,7 @@ function toReservation(row: ReservationRow): Reservation {
     direction: row.direction,
     status: row.status,
     source: row.source,
+    pinHash: row.daily_pin_hash,
     confirmedAt: row.confirmed_at,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
@@ -43,16 +45,24 @@ export class PgReservationRepository implements ReservationRepository {
   async respond(input: ReservationResponse): Promise<Reservation> {
     const status: ReservationStatus = input.travelling ? 'reserved' : 'declined';
     const { rows } = await this.pool.query<ReservationRow>(
-      `INSERT INTO reservations (user_id, trip_id, travel_date, direction, status, source, confirmed_at)
-       VALUES ($1, $2, $3, $4, $5, 'confirmation', now())
+      `INSERT INTO reservations (user_id, trip_id, travel_date, direction, status, source, daily_pin_hash, confirmed_at)
+       VALUES ($1, $2, $3, $4, $5, 'confirmation', $6, now())
        ON CONFLICT (user_id, travel_date, direction)
        DO UPDATE SET trip_id = COALESCE(EXCLUDED.trip_id, reservations.trip_id),
                      status = EXCLUDED.status,
                      source = 'confirmation',
+                     daily_pin_hash = EXCLUDED.daily_pin_hash,
                      confirmed_at = now(),
                      updated_at = now()
        RETURNING *`,
-      [input.userId, input.tripId ?? null, input.travelDate, input.direction, status],
+      [
+        input.userId,
+        input.tripId ?? null,
+        input.travelDate,
+        input.direction,
+        status,
+        input.pinHash ?? null,
+      ],
     );
     return toReservation(rows[0]!);
   }
@@ -131,5 +141,13 @@ export class PgReservationRepository implements ReservationRepository {
       [tripId],
     );
     return rows.map(toReservation);
+  }
+
+  async findById(id: string): Promise<Reservation | null> {
+    const { rows } = await this.pool.query<ReservationRow>(
+      'SELECT * FROM reservations WHERE id = $1',
+      [id],
+    );
+    return rows[0] ? toReservation(rows[0]) : null;
   }
 }

--- a/services/api/src/modules/reservations/reservation.repository.pg.ts
+++ b/services/api/src/modules/reservations/reservation.repository.pg.ts
@@ -123,4 +123,13 @@ export class PgReservationRepository implements ReservationRepository {
     );
     return rows[0] ? toReservation(rows[0]) : null;
   }
+
+  async listForTrip(tripId: string): Promise<Reservation[]> {
+    const { rows } = await this.pool.query<ReservationRow>(
+      `SELECT * FROM reservations WHERE trip_id = $1
+       ORDER BY CASE direction WHEN 'morning' THEN 0 ELSE 1 END`,
+      [tripId],
+    );
+    return rows.map(toReservation);
+  }
 }

--- a/services/api/src/modules/reservations/reservation.repository.ts
+++ b/services/api/src/modules/reservations/reservation.repository.ts
@@ -127,6 +127,15 @@ export interface ReservationRepository {
    * @returns the updated reservation, or null if not found.
    */
   markBoarded(id: string): Promise<Reservation | null>;
+  /**
+   * All reservations attached to a trip — the raw rows behind a driver's
+   * manifest (the handler filters to the confirmed ones and enriches with rider
+   * name/photo).
+   *
+   * @param tripId - the trip.
+   * @returns the trip's reservations (any status).
+   */
+  listForTrip(tripId: string): Promise<Reservation[]>;
 }
 
 /** In-memory {@link ReservationRepository} for dev and unit tests. */
@@ -245,5 +254,11 @@ export class InMemoryReservationRepository implements ReservationRepository {
     row.status = 'boarded';
     row.updatedAt = new Date();
     return row;
+  }
+
+  async listForTrip(tripId: string): Promise<Reservation[]> {
+    return this.rows
+      .filter((r) => r.tripId === tripId)
+      .sort((a, b) => (a.direction < b.direction ? -1 : 1));
   }
 }

--- a/services/api/src/modules/reservations/reservation.repository.ts
+++ b/services/api/src/modules/reservations/reservation.repository.ts
@@ -35,6 +35,9 @@ export interface Reservation {
   direction: ReservationDirection;
   status: ReservationStatus;
   source: ReservationSource;
+  /** Keyed hash of the rider's daily boarding PIN (null until confirmed / when
+   * declined). Never exposed in a response — verified server-side only (E4). */
+  pinHash: string | null;
   /** When the rider (or the default) settled the reservation. */
   confirmedAt: Date | null;
   createdAt: Date;
@@ -49,6 +52,8 @@ export interface ReservationResponse {
   direction: ReservationDirection;
   /** true → reserve the seat; false → decline it. */
   travelling: boolean;
+  /** Keyed PIN hash to store on confirm (null when declining). */
+  pinHash?: string | null;
 }
 
 /** Seed of a `pending` reservation (the ask-dispatch creates these; #18). */
@@ -136,6 +141,13 @@ export interface ReservationRepository {
    * @returns the trip's reservations (any status).
    */
   listForTrip(tripId: string): Promise<Reservation[]>;
+  /**
+   * Look up a reservation by id — used to board it via the daily PIN (E4).
+   *
+   * @param id - the reservation id.
+   * @returns the reservation, or null.
+   */
+  findById(id: string): Promise<Reservation | null>;
 }
 
 /** In-memory {@link ReservationRepository} for dev and unit tests. */
@@ -163,6 +175,7 @@ export class InMemoryReservationRepository implements ReservationRepository {
         tripId: input.tripId ?? this.rows[i]!.tripId,
         status,
         source: 'confirmation',
+        pinHash: input.pinHash ?? null,
         confirmedAt: now,
         updatedAt: now,
       };
@@ -177,6 +190,7 @@ export class InMemoryReservationRepository implements ReservationRepository {
       direction: input.direction,
       status,
       source: 'confirmation',
+      pinHash: input.pinHash ?? null,
       confirmedAt: now,
       createdAt: now,
       updatedAt: now,
@@ -197,6 +211,7 @@ export class InMemoryReservationRepository implements ReservationRepository {
       direction: input.direction,
       status: 'pending',
       source: 'confirmation',
+      pinHash: null,
       confirmedAt: null,
       createdAt: now,
       updatedAt: now,
@@ -260,5 +275,9 @@ export class InMemoryReservationRepository implements ReservationRepository {
     return this.rows
       .filter((r) => r.tripId === tripId)
       .sort((a, b) => (a.direction < b.direction ? -1 : 1));
+  }
+
+  async findById(id: string): Promise<Reservation | null> {
+    return this.rows.find((r) => r.id === id) ?? null;
   }
 }

--- a/services/api/src/modules/reservations/reservation.repository.ts
+++ b/services/api/src/modules/reservations/reservation.repository.ts
@@ -272,9 +272,12 @@ export class InMemoryReservationRepository implements ReservationRepository {
   }
 
   async listForTrip(tripId: string): Promise<Reservation[]> {
+    // Morning before evening — explicit rank (NOT alphabetical: 'evening' <
+    // 'morning'), matching the Pg CASE ordering and findBoardable above.
+    const rank = (d: ReservationDirection): number => (d === 'morning' ? 0 : 1);
     return this.rows
       .filter((r) => r.tripId === tripId)
-      .sort((a, b) => (a.direction < b.direction ? -1 : 1));
+      .sort((a, b) => rank(a.direction) - rank(b.direction));
   }
 
   async findById(id: string): Promise<Reservation | null> {

--- a/services/api/src/modules/reservations/reservations.routes.ts
+++ b/services/api/src/modules/reservations/reservations.routes.ts
@@ -8,6 +8,7 @@ import type { ZodTypeProvider } from 'fastify-type-provider-zod';
 import { errorResponseSchema } from '../../lib/schemas';
 import type { RateLimitConfig } from '../ratelimit/ratelimit.plugin';
 import type { Reservation, ReservationRepository } from './reservation.repository';
+import { generatePin, hashPin } from './pin';
 import {
   listReservationsQuerySchema,
   reservationListResponseSchema,
@@ -15,14 +16,19 @@ import {
   respondBodySchema,
 } from './reservations.schema';
 
-// Map a stored reservation to its public (client-facing) shape.
-function toResponse(r: Reservation): {
+// Map a stored reservation to its public (client-facing) shape. Never includes
+// the PIN hash; `pin` (plaintext) is added only on the confirming response.
+function toResponse(
+  r: Reservation,
+  pin?: string,
+): {
   id: string;
   tripId: string | null;
   travelDate: string;
   direction: Reservation['direction'];
   status: Reservation['status'];
   source: Reservation['source'];
+  pin?: string;
 } {
   return {
     id: r.id,
@@ -31,6 +37,7 @@ function toResponse(r: Reservation): {
     direction: r.direction,
     status: r.status,
     source: r.source,
+    ...(pin ? { pin } : {}),
   };
 }
 
@@ -40,11 +47,12 @@ function toResponse(r: Reservation): {
  * @param app - the Fastify instance to register on.
  * @param opts - route dependencies.
  * @param opts.reservations - the reservation repository (503 when absent).
+ * @param opts.secret - server key for hashing the daily boarding PIN.
  * @param opts.rateLimit - rate-limit config (applied per user).
  */
 export async function reservationRoutes(
   app: FastifyInstance,
-  opts: { reservations?: ReservationRepository; rateLimit: RateLimitConfig },
+  opts: { reservations?: ReservationRepository; secret: string; rateLimit: RateLimitConfig },
 ): Promise<void> {
   const r = app.withTypeProvider<ZodTypeProvider>();
   const UNAVAILABLE = { error: 'unavailable', message: 'Reservations are not configured' };
@@ -68,14 +76,18 @@ export async function reservationRoutes(
     },
     async (request, reply) => {
       if (!opts.reservations) return reply.code(503).send(UNAVAILABLE);
+      // Confirming issues a fresh daily PIN; only the hash is stored, the
+      // plaintext is returned once here for the rider to show at boarding.
+      const pin = request.body.travelling ? generatePin() : undefined;
       const reservation = await opts.reservations.respond({
         userId: request.user!.id,
         tripId: request.body.tripId ?? null,
         travelDate: request.body.travelDate,
         direction: request.body.direction,
         travelling: request.body.travelling,
+        pinHash: pin ? hashPin(pin, opts.secret) : null,
       });
-      return toResponse(reservation);
+      return toResponse(reservation, pin);
     },
   );
 
@@ -101,7 +113,7 @@ export async function reservationRoutes(
       const rows = await opts.reservations.listForUser(request.user!.id, {
         fromDate: request.query.from,
       });
-      return { reservations: rows.map(toResponse) };
+      return { reservations: rows.map((row) => toResponse(row)) };
     },
   );
 }

--- a/services/api/src/modules/reservations/reservations.schema.ts
+++ b/services/api/src/modules/reservations/reservations.schema.ts
@@ -35,6 +35,9 @@ export const reservationResponseSchema = z.object({
     'operator_cancelled',
   ]),
   source: z.enum(['confirmation', 'default', 'standby']),
+  /** The daily 4-digit boarding PIN — returned ONLY when confirming (travelling
+   * true); the rider shows it if the QR can't be scanned. Absent otherwise. */
+  pin: z.string().optional(),
 });
 
 export const reservationListResponseSchema = z.object({

--- a/services/api/tests/boarding.manifest.test.ts
+++ b/services/api/tests/boarding.manifest.test.ts
@@ -108,6 +108,33 @@ describe('GET /boarding/manifest', () => {
     expect(body.riders[0]).toMatchObject({ userId: yes.id, boarded: true });
   });
 
+  it('orders morning before evening (not alphabetical)', async () => {
+    const { app, users, reservations, driverToken } = await setup();
+    const m = await users.create({ displayName: 'Morning Rider' });
+    const e = await users.create({ displayName: 'Evening Rider' });
+    // insert evening first so a stable/alphabetical sort would keep it first
+    await reservations.respond({
+      userId: e.id,
+      tripId: TRIP,
+      travelDate: DATE,
+      direction: 'evening',
+      travelling: true,
+    });
+    await reservations.respond({
+      userId: m.id,
+      tripId: TRIP,
+      travelDate: DATE,
+      direction: 'morning',
+      travelling: true,
+    });
+
+    const riders = (await manifest(app, driverToken)).json().riders;
+    expect(riders.map((row: { direction: string }) => row.direction)).toEqual([
+      'morning',
+      'evening',
+    ]);
+  });
+
   it('empty manifest for a trip with no reservations', async () => {
     const { app, driverToken } = await setup();
     const body = (await manifest(app, driverToken)).json();

--- a/services/api/tests/boarding.manifest.test.ts
+++ b/services/api/tests/boarding.manifest.test.ts
@@ -1,0 +1,130 @@
+// Driver manifest (#20, E4) — the photo pass. A trip's confirmed riders with
+// name + signed avatar URL + boarded status, driver-role gated.
+
+import { describe, expect, it } from 'vitest';
+import { buildApp } from '../src/app';
+import { InMemoryReservationRepository } from '../src/modules/reservations/reservation.repository';
+import { InMemoryUserRepository } from '../src/modules/users/user.repository';
+import { createJwtService, type AuthConfig } from '../src/modules/auth/jwt';
+
+const auth: AuthConfig = {
+  secret: 'test-secret-at-least-32-characters-long-0000',
+  accessTtl: '15m',
+  issuer: 'trotxi',
+  audience: 'trotxi-api',
+};
+const jwt = createJwtService(auth);
+const bearer = (t: string) => ({ authorization: `Bearer ${t}` });
+const TRIP = crypto.randomUUID();
+const OTHER_TRIP = crypto.randomUUID();
+const DATE = '2026-07-09';
+
+async function setup() {
+  const users = new InMemoryUserRepository();
+  const reservations = new InMemoryReservationRepository();
+  const app = await buildApp({ auth, users, reservations });
+  const driverToken = await jwt.signAccessToken({ userId: 'driver-1', role: 'driver' });
+  return { users, reservations, app, driverToken };
+}
+
+const manifest = (
+  app: Awaited<ReturnType<typeof buildApp>>,
+  token: string,
+  tripId: string = TRIP,
+) =>
+  app.inject({ method: 'GET', url: `/boarding/manifest?tripId=${tripId}`, headers: bearer(token) });
+
+describe('GET /boarding/manifest', () => {
+  it('requires the driver role (commuter → 403)', async () => {
+    const { app } = await setup();
+    const commuter = await jwt.signAccessToken({ userId: 'rider-1', role: 'commuter' });
+    expect((await manifest(app, commuter)).statusCode).toBe(403);
+  });
+
+  it('lists confirmed riders for the trip with name + signed photo', async () => {
+    const { app, users, reservations, driverToken } = await setup();
+    const ama = await users.create({ displayName: 'Ama Mensah' });
+    await users.setAvatarKey(ama.id, `avatars/${ama.id}`);
+    const kofi = await users.create({ displayName: 'Kofi B' }); // no avatar
+
+    await reservations.respond({
+      userId: ama.id,
+      tripId: TRIP,
+      travelDate: DATE,
+      direction: 'morning',
+      travelling: true,
+    });
+    await reservations.respond({
+      userId: kofi.id,
+      tripId: TRIP,
+      travelDate: DATE,
+      direction: 'morning',
+      travelling: true,
+    });
+
+    const res = await manifest(app, driverToken);
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.tripId).toBe(TRIP);
+    expect(body.riders).toHaveLength(2);
+    const amaRow = body.riders.find((r: { userId: string }) => r.userId === ama.id);
+    expect(amaRow).toMatchObject({ name: 'Ama Mensah', boarded: false, direction: 'morning' });
+    expect(amaRow.avatarUrl).toContain('avatars/'); // signed URL of the stored key
+    const kofiRow = body.riders.find((r: { userId: string }) => r.userId === kofi.id);
+    expect(kofiRow).toMatchObject({ name: 'Kofi B', avatarUrl: null });
+  });
+
+  it('excludes declined seats and other trips; shows boarded status', async () => {
+    const { app, users, reservations, driverToken } = await setup();
+    const yes = await users.create({ displayName: 'Yes Rider' });
+    const no = await users.create({ displayName: 'No Rider' });
+    const other = await users.create({ displayName: 'Other Trip' });
+
+    const confirmed = await reservations.respond({
+      userId: yes.id,
+      tripId: TRIP,
+      travelDate: DATE,
+      direction: 'morning',
+      travelling: true,
+    });
+    await reservations.markBoarded(confirmed.id);
+    await reservations.respond({
+      userId: no.id,
+      tripId: TRIP,
+      travelDate: DATE,
+      direction: 'morning',
+      travelling: false, // declined → excluded
+    });
+    await reservations.respond({
+      userId: other.id,
+      tripId: OTHER_TRIP,
+      travelDate: DATE,
+      direction: 'morning',
+      travelling: true, // different trip → excluded
+    });
+
+    const body = (await manifest(app, driverToken)).json();
+    expect(body.riders).toHaveLength(1);
+    expect(body.riders[0]).toMatchObject({ userId: yes.id, boarded: true });
+  });
+
+  it('empty manifest for a trip with no reservations', async () => {
+    const { app, driverToken } = await setup();
+    const body = (await manifest(app, driverToken)).json();
+    expect(body).toEqual({ tripId: TRIP, riders: [] });
+  });
+
+  it('400 when tripId is missing or not a uuid', async () => {
+    const { app, driverToken } = await setup();
+    expect(
+      (
+        await app.inject({
+          method: 'GET',
+          url: '/boarding/manifest',
+          headers: bearer(driverToken),
+        })
+      ).statusCode,
+    ).toBe(400);
+    expect((await manifest(app, driverToken, 'not-a-uuid')).statusCode).toBe(400);
+  });
+});

--- a/services/api/tests/boarding.pin.test.ts
+++ b/services/api/tests/boarding.pin.test.ts
@@ -1,0 +1,146 @@
+// Daily PIN boarding (#20, E4 layer 2). A rider gets a 4-digit PIN on confirm;
+// the driver types it against the manifest to board offline — same debit as the
+// QR scan, idempotent per reservation.
+
+import { describe, expect, it } from 'vitest';
+import { buildApp } from '../src/app';
+import { InMemoryReservationRepository } from '../src/modules/reservations/reservation.repository';
+import { InMemoryEntitlementLedgerRepository } from '../src/modules/entitlements/entitlement-ledger.repository';
+import { hashPin, verifyPin } from '../src/modules/reservations/pin';
+import { createJwtService, type AuthConfig } from '../src/modules/auth/jwt';
+
+const auth: AuthConfig = {
+  secret: 'test-secret-at-least-32-characters-long-0000',
+  accessTtl: '15m',
+  issuer: 'trotxi',
+  audience: 'trotxi-api',
+};
+const jwt = createJwtService(auth);
+const bearer = (t: string) => ({ authorization: `Bearer ${t}` });
+const today = () => new Date().toISOString().slice(0, 10);
+
+async function setup(riderId = 'rider-1') {
+  const reservations = new InMemoryReservationRepository();
+  const entitlements = new InMemoryEntitlementLedgerRepository();
+  await entitlements.record({
+    userId: riderId,
+    deltaRides: 44,
+    reason: 'allocation',
+    idempotencyKey: `alloc-${riderId}`,
+  });
+  const app = await buildApp({ auth, reservations, entitlements });
+  const riderToken = await jwt.signAccessToken({ userId: riderId, role: 'commuter' });
+  const driverToken = await jwt.signAccessToken({ userId: 'driver-1', role: 'driver' });
+  return { app, reservations, entitlements, riderToken, driverToken, riderId };
+}
+
+const confirm = async (app: Awaited<ReturnType<typeof buildApp>>, token: string) =>
+  app.inject({
+    method: 'POST',
+    url: '/me/reservations',
+    headers: bearer(token),
+    payload: { travelDate: today(), direction: 'morning', travelling: true },
+  });
+
+const verify = (
+  app: Awaited<ReturnType<typeof buildApp>>,
+  driverToken: string,
+  reservationId: string,
+  pin: string,
+) =>
+  app.inject({
+    method: 'POST',
+    url: '/boarding/verify-pin',
+    headers: bearer(driverToken),
+    payload: { reservationId, pin },
+  });
+
+const rides = async (app: Awaited<ReturnType<typeof buildApp>>, riderToken: string) =>
+  (await app.inject({ method: 'GET', url: '/me/rides', headers: bearer(riderToken) })).json()
+    .remainingRides;
+
+describe('pin helper', () => {
+  it('hash is keyed + constant-time verify; null hash never matches', () => {
+    const h = hashPin('1234', 'secret');
+    expect(h).not.toBe('1234'); // hashed, not plaintext
+    expect(hashPin('1234', 'other')).not.toBe(h); // keyed by the secret
+    expect(verifyPin('1234', h, 'secret')).toBe(true);
+    expect(verifyPin('9999', h, 'secret')).toBe(false);
+    expect(verifyPin('1234', null, 'secret')).toBe(false);
+  });
+});
+
+describe('POST /me/reservations issues a PIN', () => {
+  it('returns a 4-digit pin on confirm, none on decline, and never stores plaintext', async () => {
+    const { app, reservations, riderToken, riderId } = await setup();
+    const body = (await confirm(app, riderToken)).json();
+    expect(body.pin).toMatch(/^\d{4}$/);
+    // stored value is the hash, not the plaintext
+    const stored = await reservations.find(riderId, today(), 'morning');
+    expect(stored?.pinHash).toBe(hashPin(body.pin, auth.secret));
+
+    const declined = await app.inject({
+      method: 'POST',
+      url: '/me/reservations',
+      headers: bearer(riderToken),
+      payload: { travelDate: today(), direction: 'evening', travelling: false },
+    });
+    expect(declined.json().pin).toBeUndefined();
+  });
+});
+
+describe('POST /boarding/verify-pin', () => {
+  it('requires the driver role (commuter → 403)', async () => {
+    const { app, riderToken } = await setup();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/boarding/verify-pin',
+      headers: bearer(riderToken),
+      payload: { reservationId: crypto.randomUUID(), pin: '1234' },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('the correct PIN boards the seat and debits one ride', async () => {
+    const { app, reservations, riderToken, driverToken, riderId } = await setup();
+    const { id, pin } = (await confirm(app, riderToken)).json();
+
+    const res = await verify(app, driverToken, id, pin);
+    expect(res.json()).toMatchObject({ valid: true, reason: 'ok', deducted: true, riderId });
+    expect(await rides(app, riderToken)).toBe(43);
+    expect((await reservations.findById(id))?.status).toBe('boarded');
+  });
+
+  it('a wrong PIN does not board or debit', async () => {
+    const { app, riderToken, driverToken } = await setup();
+    const { id, pin } = (await confirm(app, riderToken)).json();
+    const wrong = pin === '0000' ? '1111' : '0000';
+
+    const res = await verify(app, driverToken, id, wrong);
+    expect(res.json()).toMatchObject({ valid: false, reason: 'invalid', deducted: false });
+    expect(await rides(app, riderToken)).toBe(44);
+  });
+
+  it('re-verifying an already-boarded seat is idempotent (no second debit)', async () => {
+    const { app, riderToken, driverToken } = await setup();
+    const { id, pin } = (await confirm(app, riderToken)).json();
+    await verify(app, driverToken, id, pin); // boards, -1
+    expect(await rides(app, riderToken)).toBe(43);
+
+    const again = await verify(app, driverToken, id, pin);
+    expect(again.json()).toMatchObject({ valid: true, reason: 'already_boarded', deducted: false });
+    expect(await rides(app, riderToken)).toBe(43); // unchanged
+  });
+
+  it('an unknown reservation id returns not_found', async () => {
+    const { app, driverToken } = await setup();
+    const res = await verify(app, driverToken, crypto.randomUUID(), '1234');
+    expect(res.json()).toMatchObject({ valid: false, reason: 'not_found', deducted: false });
+  });
+
+  it('rejects a non-4-digit PIN (400)', async () => {
+    const { app, driverToken } = await setup();
+    const res = await verify(app, driverToken, crypto.randomUUID(), '12');
+    expect(res.statusCode).toBe(400);
+  });
+});


### PR DESCRIPTION
The **photo-pass** verification layer — `GET /boarding/manifest?tripId=` (driver role) returns a trip's confirmed riders with **name + short-lived signed avatar URL + boarded status**. Fully unblocked by trips (#18), avatars (#24), and reservations (E3) — no stubs.

Per `security.md §7`: the photo comes from the **server**, never the QR, so a faker can't embed their own face; served transiently via a signed R2 URL.

### What
- **`ManifestService`** (reservations + users + objectStore): a trip's reservations → keep `reserved`/`boarded` → enrich with rider name + signed avatar URL (null when no photo). A missing user record degrades to `name: null` rather than dropping the seat.
- **`ReservationRepository.listForTrip(tripId)`** (InMemory + Pg).
- `users` hoisted to a shared instance in `app.ts` so the manifest reads the same users auth writes.

### Deliberately deferred (documented)
- **Restrict to the trip's *assigned* driver** — needs the driver↔user lookup that GPS reporting (#25) also requires; they land together. Today driver-role gated (trusted pilot staff).
- **Per-rider pickup point** — needs a rider↔stop link.

### Tests
5 new: authz (commuter→403), enrichment (signed URL + no-photo rider), excludes declined + other-trip seats, boarded status, empty manifest, 400s. **240 green**, coverage gate passes.

Completes E4's boarding trio: QR scan ✅ · manifest ✅ · PIN (next, rides on the manifest).