### PR TITLE
feat(api): live vehicle position (HTTP pilot) + deterministic ETA (#25)

### DIFF
--- a/docs/features/live-positions.md
+++ b/docs/features/live-positions.md
@@ -1,0 +1,96 @@
+# Live vehicle position (HTTP pilot) + deterministic ETA
+
+**Owner:** Foyade · **Last updated:** 2026-07-07 · **Issue:** #25
+
+Makes trips **live**. The trip's **assigned driver** reports GPS fixes over HTTP;
+riders poll the latest fix and get a **deterministic ETA** to each upcoming stop
+along the route's ordered stops (system-design §7).
+
+> **Scope shipped (HTTP pilot):** driver reporting + rider read + deterministic
+> ETA + latest-fix cache. **Deferred:** the **MQTT/EMQX/Go/WS telemetry path**
+> (ADR-0006) — this HTTP path exists so the product works before that lands. The
+> ETA uses a **fixed assumed speed**; a live speed/traffic model comes with
+> telemetry.
+
+---
+
+## Authorization
+
+- **Report** (`POST`) requires the **`driver`** role **and** that the signed-in
+  user is _the trip's assigned driver_. We resolve `user.id → drivers.user_id`
+  (`driver.findByUserId`) and require it equals `trip.assigned_driver_id`
+  (the field #26 sets). A driver role alone is **not** enough → `403`.
+- **Read** (`GET`) is any signed-in user (rider) — like `GET /trips`.
+- Both throttle **before** the role check (house convention, cf. boarding/admin).
+
+## API
+
+#### `POST /trips/:id/position`
+
+Report a GPS fix for a trip you are assigned to.
+
+- **Auth:** `Bearer` (driver, assigned). **Rate limit:** per user.
+- **Body:** `{ "latitude": <-90..90>, "longitude": <-180..180> }`
+- **200:** `{ tripId, position: { latitude, longitude, recordedAt } }`
+  (`recordedAt` is server-assigned) · **400** bad coords · **401** · **403** not
+  the assigned driver · **404** unknown trip · **429** · **503**
+
+#### `GET /trips/:id/position`
+
+The trip's latest position with an ETA to each upcoming stop.
+
+- **Auth:** `Bearer`. **Rate limit:** per user.
+- **200:** `{ tripId, position: { latitude, longitude, recordedAt }, etaToStops: [ { stopId, seq, name, distanceMeters, etaSeconds } ] }`
+  · **401** · **404** unknown trip / no fix reported yet · **429** · **503**
+
+## Deterministic ETA (`eta.ts`)
+
+Pure functions — no clock, no I/O, no external routing service, so identical
+inputs always give identical output.
+
+1. The route's ordered stops form a polyline; cumulative distances are computed
+   with **haversine**.
+2. The latest fix is **projected onto the nearest segment** to get "distance
+   travelled along the route" (off-route perpendicular offset is ignored).
+3. For every stop still ahead: `distanceMeters = cumulative(stop) − travelled`,
+   `etaSeconds = round(distanceMeters / ASSUMED_SPEED)`.
+
+`ASSUMED_SPEED_KPH = 20` (urban trotro placeholder). Edge cases: `< 2` stops or
+past the last stop → empty `etaToStops`; before the first stop → the first stop
+still counts as upcoming.
+
+## Data & cache
+
+`trip_positions(id, trip_id → trips ON DELETE CASCADE, location geography(Point,
+4326), recorded_at)` — **append-only** (one row per fix), indexed
+`(trip_id, recorded_at DESC)` so "latest fix" is a cheap lookup. This durable
+store is the **source of truth**; the latest fix is also **written through** to
+the KV store (`trip:position:<tripId>`, TTL 300s) so rider polls hit **Redis when
+available** instead of the DB. `GET` reads the cache, falling back to the store
+(and warming the cache) on a miss.
+
+## Where the code lives
+
+```
+services/api/src/modules/mobility/
+  positions.routes.ts                   # POST/GET /trips/:id/position + authz + cache
+  eta.ts                                # haversine + projection + computeEtas
+  trip-position.repository.ts(.pg)      # record + findLatest (append-only)
+  driver.repository.ts(.pg)             # + findByUserId (assigned-driver authz)
+  mobility.schema.ts                    # report/response schemas
+services/api/src/db/migrations/016_trip_positions.sql
+```
+
+## Deferred (with the telemetry path)
+
+- **MQTT/EMQX → Go ingestor → WebSocket** fan-out (ADR-0006) — replaces HTTP
+  polling; can replay the append-only `trip_positions` log.
+- **Live speed / traffic-aware ETA** — the pilot uses a fixed assumed speed.
+- **Trip-status guard** on reporting (e.g. reject `completed`/`cancelled`).
+- **Retention/pruning** for `trip_positions`.
+
+## Related
+
+- [ADR-0006 — MQTT/EMQX/Go telemetry](../adr/0006-mqtt-emqx-go-telemetry.md) (deferred path)
+- [ADR-0005 — Postgres + PostGIS](../adr/0005-postgres-postgis.md) · [ADR-0010 — KV/Redis](../adr/0010-kv-redis.md)
+- Depends on trips (#18) and the driver↔trip assignment (#26).

--- a/services/api/src/app.ts
+++ b/services/api/src/app.ts
@@ -48,10 +48,15 @@ import {
 import type { RouteStopRepository } from './modules/mobility/route-stop.repository';
 import { mobilityRoutes } from './modules/mobility/mobility.routes';
 import { tripRoutes } from './modules/mobility/trips.routes';
+import { positionRoutes } from './modules/mobility/positions.routes';
 import { adminRoutes } from './modules/admin/admin.routes';
 import type { RouteRepository } from './modules/mobility/route.repository';
 import type { StopRepository } from './modules/mobility/stop.repository';
 import type { TripRepository } from './modules/mobility/trip.repository';
+import {
+  InMemoryTripPositionRepository,
+  type TripPositionRepository,
+} from './modules/mobility/trip-position.repository';
 import type { VehicleRepository } from './modules/mobility/vehicle.repository';
 import type { DriverRepository } from './modules/mobility/driver.repository';
 import type { SubscriptionRepository } from './modules/subscriptions/subscription.repository';
@@ -75,6 +80,8 @@ export interface AppDeps {
   routeStops?: RouteStopRepository;
   /** Trips (scheduled route runs). Reads require auth; routes return 503 when absent. */
   trips?: TripRepository;
+  /** Live trip GPS fixes (#25). Defaults to in-memory; source of truth for positions. */
+  tripPositions?: TripPositionRepository;
   /** Fleet vehicles + drivers. Managed via the admin/ops endpoints (#26). */
   vehicles?: VehicleRepository;
   drivers?: DriverRepository;
@@ -224,6 +231,15 @@ export async function buildApp(deps: AppDeps = {}): Promise<FastifyInstance> {
   });
   await app.register(tripRoutes, {
     trips: deps.trips,
+    rateLimit: deps.rateLimit ?? DEFAULT_RATE_LIMIT,
+  });
+  await app.register(positionRoutes, {
+    trips: deps.trips,
+    drivers: deps.drivers,
+    routeStops: deps.routeStops,
+    stops: deps.stops,
+    tripPositions: deps.tripPositions ?? new InMemoryTripPositionRepository(),
+    kv,
     rateLimit: deps.rateLimit ?? DEFAULT_RATE_LIMIT,
   });
   await app.register(adminRoutes, {

--- a/services/api/src/db/migrations/016_trip_positions.sql
+++ b/services/api/src/db/migrations/016_trip_positions.sql
@@ -1,0 +1,19 @@
+-- 016_trip_positions: live GPS fixes reported by the assigned driver of a trip
+-- (#25, system-design §7). Append-only — one row per reported fix — so the HTTP
+-- pilot keeps a history for free and the deferred MQTT/Go/WS telemetry path
+-- (ADR-0006) can replay it later. The "latest position" a rider reads is the most
+-- recent row for the trip; Redis caches that latest fix when available.
+--
+-- location mirrors stops: geography(Point, 4326), lat/lng via ST_MakePoint
+-- (lng, lat) / ST_X / ST_Y at the adapter boundary. ON DELETE CASCADE so a trip's
+-- fixes die with the trip.
+
+CREATE TABLE IF NOT EXISTS trip_positions (
+  id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  trip_id     uuid NOT NULL REFERENCES trips (id) ON DELETE CASCADE,
+  location    geography(Point, 4326) NOT NULL,
+  recorded_at timestamptz NOT NULL DEFAULT now()
+);
+-- Backs "latest fix for a trip": ORDER BY recorded_at DESC LIMIT 1 within a trip.
+CREATE INDEX IF NOT EXISTS idx_trip_positions_trip_recorded
+  ON trip_positions (trip_id, recorded_at DESC);

--- a/services/api/src/modules/mobility/driver.repository.pg.ts
+++ b/services/api/src/modules/mobility/driver.repository.pg.ts
@@ -39,6 +39,14 @@ export class PgDriverRepository implements DriverRepository {
     return rows[0] ? toDriver(rows[0]) : null;
   }
 
+  async findByUserId(userId: string): Promise<Driver | null> {
+    const { rows } = await this.pool.query<DriverRow>(
+      'SELECT * FROM drivers WHERE user_id = $1 LIMIT 1',
+      [userId],
+    );
+    return rows[0] ? toDriver(rows[0]) : null;
+  }
+
   async findAll(): Promise<Driver[]> {
     const { rows } = await this.pool.query<DriverRow>('SELECT * FROM drivers ORDER BY created_at');
     return rows.map(toDriver);

--- a/services/api/src/modules/mobility/driver.repository.ts
+++ b/services/api/src/modules/mobility/driver.repository.ts
@@ -50,6 +50,15 @@ export interface DriverRepository {
    * @returns the driver, or null if it doesn't exist.
    */
   findById(id: string): Promise<Driver | null>;
+  /**
+   * Look up a driver by the auth principal linked via userId. This resolves a
+   * signed-in user to their driver record — the basis for GPS-reporting authz
+   * (only the assigned driver may report a trip's position, #25).
+   *
+   * @param userId - the auth user id.
+   * @returns the linked driver, or null if none is linked to that user.
+   */
+  findByUserId(userId: string): Promise<Driver | null>;
   /** Returns all drivers. Used by admin ops (#26). */
   findAll(): Promise<Driver[]>;
   /**
@@ -81,6 +90,13 @@ export class InMemoryDriverRepository implements DriverRepository {
 
   async findById(id: string): Promise<Driver | null> {
     return this.drivers.get(id) ?? null;
+  }
+
+  async findByUserId(userId: string): Promise<Driver | null> {
+    for (const driver of this.drivers.values()) {
+      if (driver.userId === userId) return driver;
+    }
+    return null;
   }
 
   async findAll(): Promise<Driver[]> {

--- a/services/api/src/modules/mobility/eta.ts
+++ b/services/api/src/modules/mobility/eta.ts
@@ -1,0 +1,147 @@
+// Deterministic ETA-to-stop (#25, system-design §7). Pure functions — no clock,
+// no I/O, no external routing/traffic service — so the same inputs always yield
+// the same ETAs and the whole thing is trivially unit-testable.
+//
+// Model: the route's ordered stops form a polyline. We project the vehicle's
+// latest fix onto that polyline to get "distance travelled along the route", then
+// for every stop still ahead, remaining distance = cumulative(stop) − travelled,
+// and ETA = remaining / a fixed assumed speed. The assumed speed is a pilot
+// placeholder; a live speed/traffic model arrives with the telemetry path (ADR-0006).
+
+/** Assumed average vehicle speed for the pilot ETA (urban trotro ~20 km/h). */
+export const ASSUMED_SPEED_KPH = 20;
+const ASSUMED_SPEED_MS = (ASSUMED_SPEED_KPH * 1000) / 3600;
+
+const EARTH_RADIUS_M = 6_371_000;
+/** Tolerance (metres) below which a stop counts as "reached", not upcoming. */
+const REACHED_EPS_M = 1e-6;
+
+const toRad = (deg: number): number => (deg * Math.PI) / 180;
+
+/** A geographic point. */
+export interface LatLng {
+  latitude: number;
+  longitude: number;
+}
+
+/** A stop placed on a route, in seq order, with its coordinates. */
+export interface RouteStopPoint extends LatLng {
+  stopId: string;
+  name: string;
+  seq: number;
+}
+
+/** A stop still ahead of the vehicle, with distance + ETA along the route. */
+export interface StopEta {
+  stopId: string;
+  seq: number;
+  name: string;
+  /** Remaining distance along the route to this stop, in metres. */
+  distanceMeters: number;
+  /** ETA to this stop in seconds, at the assumed speed. */
+  etaSeconds: number;
+}
+
+/**
+ * Great-circle distance between two points in metres (haversine).
+ *
+ * @param a - the first point.
+ * @param b - the second point.
+ * @returns the distance between them in metres.
+ */
+export function haversineMeters(a: LatLng, b: LatLng): number {
+  const dLat = toRad(b.latitude - a.latitude);
+  const dLng = toRad(b.longitude - a.longitude);
+  const lat1 = toRad(a.latitude);
+  const lat2 = toRad(b.latitude);
+  const h = Math.sin(dLat / 2) ** 2 + Math.sin(dLng / 2) ** 2 * Math.cos(lat1) * Math.cos(lat2);
+  return 2 * EARTH_RADIUS_M * Math.asin(Math.min(1, Math.sqrt(h)));
+}
+
+/**
+ * Local planar (equirectangular) coordinates of `p` in metres. Good enough for
+ * the short segments between adjacent stops — used only to pick the nearest
+ * segment and its projection fraction, never for reported distances.
+ *
+ * @param p - the point to project.
+ * @param cosLatRef - cosine of the reference latitude that anchors the projection.
+ * @returns the planar `{ x, y }` in metres.
+ */
+function toPlane(p: LatLng, cosLatRef: number): { x: number; y: number } {
+  return {
+    x: EARTH_RADIUS_M * toRad(p.longitude) * cosLatRef,
+    y: EARTH_RADIUS_M * toRad(p.latitude),
+  };
+}
+
+/**
+ * Deterministic ETA from the vehicle's position to every upcoming stop.
+ *
+ * @param position - the vehicle's latest fix.
+ * @param stops - the route's stops in seq order (as returned by the route-stop repo).
+ * @returns upcoming stops in order, each with remaining distance + ETA seconds.
+ *   Empty when there are fewer than two stops or the vehicle is past the last stop.
+ */
+export function computeEtas(position: LatLng, stops: RouteStopPoint[]): StopEta[] {
+  // Need at least one segment to define "progress along the route".
+  if (stops.length < 2) return [];
+
+  // Cumulative haversine distance to each stop (cumulative[0] = 0).
+  const segLen: number[] = [];
+  const cumulative: number[] = [0];
+  for (let i = 0; i < stops.length - 1; i++) {
+    const len = haversineMeters(stops[i]!, stops[i + 1]!);
+    segLen.push(len);
+    cumulative.push(cumulative[i]! + len);
+  }
+
+  // Project the position onto the nearest segment. cosLatRef anchors the planar
+  // approximation at the vehicle's latitude, where the relevant segments sit.
+  const cosLatRef = Math.cos(toRad(position.latitude));
+  const p = toPlane(position, cosLatRef);
+  let bestSeg = 0;
+  let bestTRaw = 0;
+  let bestDist = Infinity;
+  for (let i = 0; i < segLen.length; i++) {
+    const a = toPlane(stops[i]!, cosLatRef);
+    const b = toPlane(stops[i + 1]!, cosLatRef);
+    const abx = b.x - a.x;
+    const aby = b.y - a.y;
+    const abLenSq = abx * abx + aby * aby;
+    // Degenerate (coincident) stops: treat as the segment start.
+    const tRaw = abLenSq === 0 ? 0 : ((p.x - a.x) * abx + (p.y - a.y) * aby) / abLenSq;
+    const tClamped = Math.max(0, Math.min(1, tRaw));
+    const projX = a.x + tClamped * abx;
+    const projY = a.y + tClamped * aby;
+    const dist = Math.hypot(p.x - projX, p.y - projY);
+    if (dist < bestDist) {
+      bestDist = dist;
+      bestSeg = i;
+      bestTRaw = tRaw;
+    }
+  }
+
+  // Distance travelled along the route to the projection point. Allow the vehicle
+  // to sit before the first stop (bestTRaw < 0) or past the last (bestTRaw > 1) so
+  // a rider at the origin still sees the bus approaching, and a finished trip
+  // yields no upcoming stops. Interior segments clamp to [0, 1].
+  const lastSeg = segLen.length - 1;
+  let tEff = Math.max(0, Math.min(1, bestTRaw));
+  if (bestSeg === 0 && bestTRaw < 0) tEff = bestTRaw;
+  if (bestSeg === lastSeg && bestTRaw > 1) tEff = bestTRaw;
+  const travelled = cumulative[bestSeg]! + tEff * segLen[bestSeg]!;
+
+  const etas: StopEta[] = [];
+  for (let j = 0; j < stops.length; j++) {
+    const remaining = cumulative[j]! - travelled;
+    if (remaining <= REACHED_EPS_M) continue; // reached or behind → not upcoming
+    etas.push({
+      stopId: stops[j]!.stopId,
+      seq: stops[j]!.seq,
+      name: stops[j]!.name,
+      distanceMeters: Math.round(remaining),
+      etaSeconds: Math.round(remaining / ASSUMED_SPEED_MS),
+    });
+  }
+  return etas;
+}

--- a/services/api/src/modules/mobility/mobility.schema.ts
+++ b/services/api/src/modules/mobility/mobility.schema.ts
@@ -74,3 +74,42 @@ export const driverResponseSchema = z.object({
   userId: z.string().uuid().nullable(),
   createdAt: z.date(),
 });
+
+// A GPS fix reported by a trip's assigned driver (#25). recordedAt is assigned by
+// the server, so the body carries only coordinates; ranges match WGS84 lat/lng.
+export const reportPositionBodySchema = z.object({
+  latitude: z.number().min(-90).max(90),
+  longitude: z.number().min(-180).max(180),
+});
+
+// Acknowledgement returned to the driver after a fix is recorded — the stored
+// fix, no ETA (the driver knows the route; ETA is for riders via GET).
+export const recordedPositionResponseSchema = z.object({
+  tripId: z.string().uuid(),
+  position: z.object({
+    latitude: z.number(),
+    longitude: z.number(),
+    recordedAt: z.date(),
+  }),
+});
+
+// The trip's latest live position plus a deterministic ETA to each upcoming stop
+// along the route's ordered stops (system-design §7). etaToStops is empty when the
+// route has fewer than two stops or the vehicle is past the last stop.
+export const livePositionResponseSchema = z.object({
+  tripId: z.string().uuid(),
+  position: z.object({
+    latitude: z.number(),
+    longitude: z.number(),
+    recordedAt: z.date(),
+  }),
+  etaToStops: z.array(
+    z.object({
+      stopId: z.string().uuid(),
+      seq: z.number().int(),
+      name: z.string(),
+      distanceMeters: z.number(),
+      etaSeconds: z.number(),
+    }),
+  ),
+});

--- a/services/api/src/modules/mobility/positions.routes.ts
+++ b/services/api/src/modules/mobility/positions.routes.ts
@@ -1,0 +1,234 @@
+// Live vehicle position — HTTP pilot (#25, system-design §7). The MQTT/Go/WS
+// telemetry path (ADR-0006) is deferred; here a driver POSTs GPS fixes over HTTP
+// and riders GET the latest fix with a deterministic ETA to each upcoming stop.
+//
+//   POST /trips/:id/position  driver-only AND must be THE trip's assigned driver.
+//   GET  /trips/:id/position  any signed-in user (rider); returns position + ETA.
+//
+// The durable trip_positions store is the source of truth; the latest fix is also
+// written through to the KV store (Redis when available) so rider polls read a
+// hot cache instead of the DB. ETA is recomputed per read from the route's stops
+// (see eta.ts) — cheap and always reflects the current route configuration.
+
+import type { FastifyInstance } from 'fastify';
+import type { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { z } from 'zod';
+import type { KvStore } from '../../kv/kv.store';
+import { errorResponseSchema } from '../../lib/schemas';
+import type { RateLimitConfig } from '../ratelimit/ratelimit.plugin';
+import type { DriverRepository } from './driver.repository';
+import { computeEtas, type RouteStopPoint } from './eta';
+import {
+  livePositionResponseSchema,
+  recordedPositionResponseSchema,
+  reportPositionBodySchema,
+} from './mobility.schema';
+import type { RouteStopRepository } from './route-stop.repository';
+import type { StopRepository } from './stop.repository';
+import type { TripPositionRepository } from './trip-position.repository';
+import type { TripRepository } from './trip.repository';
+
+/** Latest fix as cached in the KV store (recordedAt is an ISO string over JSON). */
+interface CachedFix {
+  latitude: number;
+  longitude: number;
+  recordedAt: string;
+}
+
+/** How long the KV store keeps a trip's latest fix (refreshed on every report). */
+const POSITION_CACHE_TTL_SECONDS = 300;
+const cacheKey = (tripId: string): string => `trip:position:${tripId}`;
+
+/**
+ * Register the live-position routes (`POST` / `GET /trips/:id/position`).
+ *
+ * @param app - the Fastify instance to register on.
+ * @param opts - route dependencies (503 when the repos they need are unwired).
+ * @param opts.trips - trip lookup (existence + assignedDriverId).
+ * @param opts.drivers - resolves the signed-in user to their driver record (authz).
+ * @param opts.routeStops - the route's ordered stop placements (for ETA).
+ * @param opts.stops - stop coordinates (for ETA).
+ * @param opts.tripPositions - durable fix store (source of truth).
+ * @param opts.kv - latest-fix cache (Redis when available).
+ * @param opts.rateLimit - per-user rate-limit config.
+ */
+export async function positionRoutes(
+  app: FastifyInstance,
+  opts: {
+    trips?: TripRepository;
+    drivers?: DriverRepository;
+    routeStops?: RouteStopRepository;
+    stops?: StopRepository;
+    tripPositions?: TripPositionRepository;
+    kv: KvStore;
+    rateLimit: RateLimitConfig;
+  },
+): Promise<void> {
+  const r = app.withTypeProvider<ZodTypeProvider>();
+  const UNAVAILABLE = { error: 'unavailable', message: 'Live positions are not configured' };
+  const notFound = (message: string) => ({ error: 'not_found', message });
+  const idParam = z.object({ id: z.string().uuid() });
+
+  r.post(
+    '/trips/:id/position',
+    {
+      schema: {
+        tags: ['mobility'],
+        summary: 'Report a GPS fix for a trip (assigned driver only)',
+        security: [{ bearerAuth: [] }],
+        params: idParam,
+        body: reportPositionBodySchema,
+        response: {
+          200: recordedPositionResponseSchema,
+          401: errorResponseSchema,
+          403: errorResponseSchema,
+          404: errorResponseSchema,
+          429: errorResponseSchema,
+          503: errorResponseSchema,
+        },
+      },
+      // Throttle BEFORE the role check (house convention, cf. boarding/admin) so
+      // non-driver tokens can't hammer 403s without being rate limited.
+      preHandler: [
+        app.authenticate,
+        app.rateLimit({ ...opts.rateLimit, by: 'user' }),
+        app.requireRole('driver'),
+      ],
+    },
+    async (request, reply) => {
+      if (!opts.trips || !opts.drivers || !opts.tripPositions) {
+        return reply.code(503).send(UNAVAILABLE);
+      }
+      const trip = await opts.trips.findById(request.params.id);
+      if (!trip) return reply.code(404).send(notFound('Trip not found'));
+
+      // Assigned-driver authz: the signed-in user must be linked to the driver
+      // this trip is assigned to. A driver role alone is not enough.
+      const driver = await opts.drivers.findByUserId(request.user!.id);
+      if (!driver || trip.assignedDriverId !== driver.id) {
+        return reply
+          .code(403)
+          .send({ error: 'forbidden', message: 'Not the assigned driver for this trip' });
+      }
+
+      const fix = await opts.tripPositions.record({
+        tripId: trip.id,
+        latitude: request.body.latitude,
+        longitude: request.body.longitude,
+      });
+
+      // Write-through: warm the latest-fix cache riders read from.
+      const cached: CachedFix = {
+        latitude: fix.latitude,
+        longitude: fix.longitude,
+        recordedAt: fix.recordedAt.toISOString(),
+      };
+      await opts.kv.set(cacheKey(trip.id), JSON.stringify(cached), POSITION_CACHE_TTL_SECONDS);
+
+      return {
+        tripId: trip.id,
+        position: {
+          latitude: fix.latitude,
+          longitude: fix.longitude,
+          recordedAt: fix.recordedAt,
+        },
+      };
+    },
+  );
+
+  r.get(
+    '/trips/:id/position',
+    {
+      schema: {
+        tags: ['mobility'],
+        summary: "Get a trip's latest position with a deterministic ETA to each upcoming stop",
+        security: [{ bearerAuth: [] }],
+        params: idParam,
+        response: {
+          200: livePositionResponseSchema,
+          401: errorResponseSchema,
+          404: errorResponseSchema,
+          429: errorResponseSchema,
+          503: errorResponseSchema,
+        },
+      },
+      preHandler: [app.authenticate, app.rateLimit({ ...opts.rateLimit, by: 'user' })],
+    },
+    async (request, reply) => {
+      if (!opts.trips || !opts.tripPositions || !opts.routeStops || !opts.stops) {
+        return reply.code(503).send(UNAVAILABLE);
+      }
+      const trip = await opts.trips.findById(request.params.id);
+      if (!trip) return reply.code(404).send(notFound('Trip not found'));
+
+      const position = await latestFix(opts.kv, opts.tripPositions, trip.id);
+      if (!position) return reply.code(404).send(notFound('No live position for this trip'));
+
+      // Resolve the route's stops in seq order (route_stops → stops), mirroring
+      // GET /routes/:id. Drop any stop that no longer resolves (defensive).
+      const routeStops = await opts.routeStops.findByRoute(trip.routeId);
+      const stopPoints = (
+        await Promise.all(
+          routeStops.map(async (rs): Promise<RouteStopPoint | null> => {
+            const stop = await opts.stops!.findById(rs.stopId);
+            return stop
+              ? {
+                  stopId: stop.id,
+                  name: stop.name,
+                  seq: rs.seq,
+                  latitude: stop.latitude,
+                  longitude: stop.longitude,
+                }
+              : null;
+          }),
+        )
+      ).filter((s): s is RouteStopPoint => s !== null);
+
+      return {
+        tripId: trip.id,
+        position,
+        etaToStops: computeEtas(position, stopPoints),
+      };
+    },
+  );
+}
+
+/**
+ * Latest fix for a trip: KV cache first, falling back to the durable store and
+ * warming the cache on a miss.
+ *
+ * @param kv - the latest-fix cache.
+ * @param tripPositions - the durable fix store (source of truth).
+ * @param tripId - the trip whose latest fix to read.
+ * @returns the latest position, or null when no fix has ever been reported.
+ */
+async function latestFix(
+  kv: KvStore,
+  tripPositions: TripPositionRepository,
+  tripId: string,
+): Promise<{ latitude: number; longitude: number; recordedAt: Date } | null> {
+  const cached = await kv.get(cacheKey(tripId));
+  if (cached) {
+    const fix = JSON.parse(cached) as CachedFix;
+    return {
+      latitude: fix.latitude,
+      longitude: fix.longitude,
+      recordedAt: new Date(fix.recordedAt),
+    };
+  }
+
+  const stored = await tripPositions.findLatest(tripId);
+  if (!stored) return null;
+
+  const toCache: CachedFix = {
+    latitude: stored.latitude,
+    longitude: stored.longitude,
+    recordedAt: stored.recordedAt.toISOString(),
+  };
+  await kv.set(cacheKey(tripId), JSON.stringify(toCache), POSITION_CACHE_TTL_SECONDS);
+  return {
+    latitude: stored.latitude,
+    longitude: stored.longitude,
+    recordedAt: stored.recordedAt,
+  };
+}

--- a/services/api/src/modules/mobility/trip-position.repository.pg.ts
+++ b/services/api/src/modules/mobility/trip-position.repository.pg.ts
@@ -1,0 +1,59 @@
+// Postgres trip-position adapter (#25). Fixes are stored as PostGIS
+// geography(Point, 4326); the domain model exposes plain lat/lng numbers, so
+// ST_MakePoint / ST_X / ST_Y convert at the boundary (same as stops).
+// Note: ST_MakePoint takes (longitude, latitude) — X is longitude, Y is latitude.
+
+import type { Pool } from 'pg';
+import type {
+  NewTripPosition,
+  TripPosition,
+  TripPositionRepository,
+} from './trip-position.repository';
+
+interface TripPositionRow {
+  id: string;
+  trip_id: string;
+  latitude: number;
+  longitude: number;
+  recorded_at: Date;
+}
+
+function toTripPosition(row: TripPositionRow): TripPosition {
+  return {
+    id: row.id,
+    tripId: row.trip_id,
+    latitude: row.latitude,
+    longitude: row.longitude,
+    recordedAt: row.recorded_at,
+  };
+}
+
+export class PgTripPositionRepository implements TripPositionRepository {
+  constructor(private readonly pool: Pool) {}
+
+  async record(input: NewTripPosition): Promise<TripPosition> {
+    const { rows } = await this.pool.query<TripPositionRow>(
+      `INSERT INTO trip_positions (trip_id, location)
+       VALUES ($1, ST_SetSRID(ST_MakePoint($2, $3), 4326)::geography)
+       RETURNING id, trip_id, recorded_at,
+         ST_Y(location::geometry) AS latitude,
+         ST_X(location::geometry) AS longitude`,
+      [input.tripId, input.longitude, input.latitude],
+    );
+    return toTripPosition(rows[0]!);
+  }
+
+  async findLatest(tripId: string): Promise<TripPosition | null> {
+    const { rows } = await this.pool.query<TripPositionRow>(
+      `SELECT id, trip_id, recorded_at,
+         ST_Y(location::geometry) AS latitude,
+         ST_X(location::geometry) AS longitude
+       FROM trip_positions
+       WHERE trip_id = $1
+       ORDER BY recorded_at DESC
+       LIMIT 1`,
+      [tripId],
+    );
+    return rows[0] ? toTripPosition(rows[0]) : null;
+  }
+}

--- a/services/api/src/modules/mobility/trip-position.repository.ts
+++ b/services/api/src/modules/mobility/trip-position.repository.ts
@@ -1,0 +1,68 @@
+// TripPosition repository — live GPS fixes for a trip (#25, system-design §7).
+// Append-only: `record` inserts one fix, `findLatest` returns the most recent for
+// a trip (the position a rider reads). The assigned driver reports fixes over
+// HTTP for the pilot; the durable store is the source of truth and Redis caches
+// the latest fix (see positions.routes.ts). Two implementations: InMemory for
+// dev/tests, Postgres (trip-position.repository.pg.ts) for real runs.
+
+/** One reported GPS fix for a trip. recordedAt is server-assigned at record time. */
+export interface TripPosition {
+  id: string;
+  tripId: string;
+  latitude: number;
+  longitude: number;
+  recordedAt: Date;
+}
+
+/** Fields needed to record a {@link TripPosition}. recordedAt is set by the store. */
+export interface NewTripPosition {
+  tripId: string;
+  latitude: number;
+  longitude: number;
+}
+
+/** Persistence for trip position fixes (Postgres in prod, in-memory in dev/tests). */
+export interface TripPositionRepository {
+  /**
+   * Append a GPS fix for a trip.
+   *
+   * @param input - the trip and its coordinates.
+   * @returns the recorded fix (with its server-assigned id + recordedAt).
+   */
+  record(input: NewTripPosition): Promise<TripPosition>;
+  /**
+   * The most recent fix for a trip — the trip's current live position.
+   *
+   * @param tripId - the trip id.
+   * @returns the latest fix, or null if none has been reported.
+   */
+  findLatest(tripId: string): Promise<TripPosition | null>;
+}
+
+/** In-memory {@link TripPositionRepository} for dev and unit tests. */
+export class InMemoryTripPositionRepository implements TripPositionRepository {
+  private readonly positions: TripPosition[] = [];
+
+  async record(input: NewTripPosition): Promise<TripPosition> {
+    const position: TripPosition = {
+      id: crypto.randomUUID(),
+      tripId: input.tripId,
+      latitude: input.latitude,
+      longitude: input.longitude,
+      recordedAt: new Date(),
+    };
+    this.positions.push(position);
+    return position;
+  }
+
+  async findLatest(tripId: string): Promise<TripPosition | null> {
+    // Latest = highest recordedAt for the trip; ties broken by insertion order
+    // (later push wins), matching the Postgres ORDER BY recorded_at DESC.
+    let latest: TripPosition | null = null;
+    for (const p of this.positions) {
+      if (p.tripId !== tripId) continue;
+      if (!latest || p.recordedAt.getTime() >= latest.recordedAt.getTime()) latest = p;
+    }
+    return latest;
+  }
+}

--- a/services/api/src/modules/mobility/trips.routes.ts
+++ b/services/api/src/modules/mobility/trips.routes.ts
@@ -3,7 +3,7 @@
 // public route browsing): schedules are app-facing data for signed-in commuters
 // and drivers, and this is the guard the issue calls out as a dependency. Write
 // paths (create/assign) live in the admin/ops module (#26). GPS position
-// reporting authorized by assignedDriverId is #25.
+// reporting authorized by assignedDriverId lives in positions.routes.ts (#25).
 
 import type { FastifyInstance } from 'fastify';
 import type { ZodTypeProvider } from 'fastify-type-provider-zod';

--- a/services/api/src/server.ts
+++ b/services/api/src/server.ts
@@ -37,6 +37,11 @@ import { PgStopRepository } from './modules/mobility/stop.repository.pg';
 import { InMemoryTripRepository, type TripRepository } from './modules/mobility/trip.repository';
 import { PgTripRepository } from './modules/mobility/trip.repository.pg';
 import {
+  InMemoryTripPositionRepository,
+  type TripPositionRepository,
+} from './modules/mobility/trip-position.repository';
+import { PgTripPositionRepository } from './modules/mobility/trip-position.repository.pg';
+import {
   InMemoryVehicleRepository,
   type VehicleRepository,
 } from './modules/mobility/vehicle.repository';
@@ -137,6 +142,7 @@ async function main(): Promise<void> {
   let stops: StopRepository;
   let routeStops: RouteStopRepository;
   let trips: TripRepository;
+  let tripPositions: TripPositionRepository;
   let vehicles: VehicleRepository;
   let drivers: DriverRepository;
   let sessions: SessionRepository;
@@ -155,6 +161,7 @@ async function main(): Promise<void> {
     stops = new PgStopRepository(pool);
     routeStops = new PgRouteStopRepository(pool);
     trips = new PgTripRepository(pool);
+    tripPositions = new PgTripPositionRepository(pool);
     vehicles = new PgVehicleRepository(pool);
     drivers = new PgDriverRepository(pool);
     sessions = new PgSessionRepository(pool);
@@ -173,6 +180,7 @@ async function main(): Promise<void> {
     stops = new InMemoryStopRepository();
     routeStops = new InMemoryRouteStopRepository();
     trips = new InMemoryTripRepository();
+    tripPositions = new InMemoryTripPositionRepository();
     vehicles = new InMemoryVehicleRepository();
     drivers = new InMemoryDriverRepository();
     sessions = new InMemorySessionRepository();
@@ -266,6 +274,7 @@ async function main(): Promise<void> {
     stops,
     routeStops,
     trips,
+    tripPositions,
     vehicles,
     drivers,
     deviceTokens,

--- a/services/api/tests/eta.test.ts
+++ b/services/api/tests/eta.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ASSUMED_SPEED_KPH,
+  computeEtas,
+  haversineMeters,
+  type RouteStopPoint,
+} from '../src/modules/mobility/eta';
+
+// A straight south→north route along the prime meridian. One degree of latitude
+// is ~111.2 km, so each 0.01° hop between adjacent stops is ~1112 m — round,
+// easy-to-reason-about distances for asserting deterministic ETAs.
+const METRES_PER_HOP = 1112; // ~ 6371000 * 0.01 * pi/180
+const stopAt = (seq: number, latitude: number): RouteStopPoint => ({
+  stopId: `00000000-0000-0000-0000-00000000000${seq}`,
+  name: `Stop ${seq}`,
+  seq,
+  latitude,
+  longitude: 0,
+});
+const ROUTE: RouteStopPoint[] = [stopAt(1, 0), stopAt(2, 0.01), stopAt(3, 0.02), stopAt(4, 0.03)];
+
+// Expected ETA seconds for a given remaining distance at the assumed speed.
+const etaFor = (metres: number): number => Math.round(metres / ((ASSUMED_SPEED_KPH * 1000) / 3600));
+
+describe('haversineMeters', () => {
+  it('is zero for the same point', () => {
+    expect(
+      haversineMeters({ latitude: 5.6, longitude: -0.2 }, { latitude: 5.6, longitude: -0.2 }),
+    ).toBe(0);
+  });
+
+  it('measures ~111.2 km for one degree of latitude', () => {
+    const d = haversineMeters({ latitude: 0, longitude: 0 }, { latitude: 1, longitude: 0 });
+    expect(d).toBeGreaterThan(111_000);
+    expect(d).toBeLessThan(111_400);
+  });
+
+  it('measures ~111.2 km for one degree of longitude at the equator', () => {
+    const d = haversineMeters({ latitude: 0, longitude: 0 }, { latitude: 0, longitude: 1 });
+    expect(d).toBeGreaterThan(111_000);
+    expect(d).toBeLessThan(111_400);
+  });
+});
+
+describe('computeEtas', () => {
+  it('returns no ETAs for fewer than two stops', () => {
+    expect(computeEtas({ latitude: 0, longitude: 0 }, [])).toEqual([]);
+    expect(computeEtas({ latitude: 0, longitude: 0 }, [stopAt(1, 0)])).toEqual([]);
+  });
+
+  it('at the first stop, lists every stop ahead with increasing distance + ETA', () => {
+    const etas = computeEtas({ latitude: 0, longitude: 0 }, ROUTE);
+    expect(etas.map((e) => e.seq)).toEqual([2, 3, 4]); // stop 1 (current) excluded
+
+    expect(etas[0]!.distanceMeters).toBeCloseTo(METRES_PER_HOP, -1);
+    expect(etas[1]!.distanceMeters).toBeCloseTo(2 * METRES_PER_HOP, -1);
+    expect(etas[2]!.distanceMeters).toBeCloseTo(3 * METRES_PER_HOP, -1);
+
+    // Strictly increasing distance and ETA, and ETA tracks distance/speed.
+    expect(etas[0]!.distanceMeters).toBeLessThan(etas[1]!.distanceMeters);
+    expect(etas[1]!.distanceMeters).toBeLessThan(etas[2]!.distanceMeters);
+    expect(etas[0]!.etaSeconds).toBe(etaFor(etas[0]!.distanceMeters));
+  });
+
+  it('projects a mid-segment position onto the route (distance measured from the projection)', () => {
+    // Halfway between stop 1 and stop 2.
+    const etas = computeEtas({ latitude: 0.005, longitude: 0 }, ROUTE);
+    expect(etas.map((e) => e.seq)).toEqual([2, 3, 4]);
+    expect(etas[0]!.distanceMeters).toBeCloseTo(METRES_PER_HOP / 2, -1);
+  });
+
+  it('drops stops already passed', () => {
+    // Just past stop 3 (lat 0.02) → only stop 4 remains ahead.
+    const etas = computeEtas({ latitude: 0.021, longitude: 0 }, ROUTE);
+    expect(etas.map((e) => e.seq)).toEqual([4]);
+  });
+
+  it('returns no ETAs once past the last stop', () => {
+    expect(computeEtas({ latitude: 0.05, longitude: 0 }, ROUTE)).toEqual([]);
+  });
+
+  it('still counts the first stop as upcoming when the vehicle is before the route start', () => {
+    const etas = computeEtas({ latitude: -0.005, longitude: 0 }, ROUTE);
+    expect(etas.map((e) => e.seq)).toEqual([1, 2, 3, 4]);
+    expect(etas[0]!.distanceMeters).toBeCloseTo(METRES_PER_HOP / 2, -1);
+  });
+
+  it('ignores perpendicular (off-route) offset — only along-route distance counts', () => {
+    // Same along-route position as the mid-segment case, but offset ~1 km east.
+    const onRoute = computeEtas({ latitude: 0.005, longitude: 0 }, ROUTE);
+    const offRoute = computeEtas({ latitude: 0.005, longitude: 0.01 }, ROUTE);
+    expect(offRoute.map((e) => e.seq)).toEqual([2, 3, 4]);
+    expect(offRoute[0]!.distanceMeters).toBeCloseTo(onRoute[0]!.distanceMeters, -1);
+  });
+});

--- a/services/api/tests/positions.routes.test.ts
+++ b/services/api/tests/positions.routes.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it } from 'vitest';
+import { buildApp } from '../src/app';
+import { createJwtService, type AuthConfig } from '../src/modules/auth/jwt';
+import { InMemoryKvStore } from '../src/kv/kv.store';
+import { InMemoryDriverRepository } from '../src/modules/mobility/driver.repository';
+import { InMemoryRouteStopRepository } from '../src/modules/mobility/route-stop.repository';
+import { InMemoryRouteRepository } from '../src/modules/mobility/route.repository';
+import { InMemoryStopRepository } from '../src/modules/mobility/stop.repository';
+import { InMemoryTripPositionRepository } from '../src/modules/mobility/trip-position.repository';
+import { InMemoryTripRepository } from '../src/modules/mobility/trip.repository';
+
+const auth: AuthConfig = {
+  secret: 'test-secret-at-least-32-characters-long-0000',
+  accessTtl: '15m',
+  issuer: 'trotxi',
+  audience: 'trotxi-api',
+};
+const jwt = createJwtService(auth);
+const bearer = (t: string) => ({ authorization: `Bearer ${t}` });
+const access = (userId: string, role: 'commuter' | 'driver' | 'admin' = 'commuter') =>
+  jwt.signAccessToken({ userId, role });
+
+const UNKNOWN_TRIP = '00000000-0000-0000-0000-0000000000ff';
+const DRIVER_USER = 'user-of-assigned-driver';
+
+// A route of three stops on the prime meridian (~1.1 km apart) with a trip
+// assigned to a driver linked to DRIVER_USER. Returns the app + seeded ids.
+async function seed() {
+  const routes = new InMemoryRouteRepository();
+  const stops = new InMemoryStopRepository();
+  const routeStops = new InMemoryRouteStopRepository();
+  const trips = new InMemoryTripRepository();
+  const drivers = new InMemoryDriverRepository();
+  const tripPositions = new InMemoryTripPositionRepository();
+  const kv = new InMemoryKvStore();
+
+  const route = await routes.create({ name: 'Circle → Kaneshie', description: null });
+  const s1 = await stops.create({ name: 'Circle', latitude: 0, longitude: 0 });
+  const s2 = await stops.create({ name: 'Kwame Nkrumah', latitude: 0.01, longitude: 0 });
+  const s3 = await stops.create({ name: 'Kaneshie', latitude: 0.02, longitude: 0 });
+  await routeStops.create({ routeId: route.id, stopId: s1.id, seq: 1 });
+  await routeStops.create({ routeId: route.id, stopId: s2.id, seq: 2 });
+  await routeStops.create({ routeId: route.id, stopId: s3.id, seq: 3 });
+
+  const driver = await drivers.create({ fullName: 'Kwame Mensah', userId: DRIVER_USER });
+  const trip = await trips.create({
+    routeId: route.id,
+    assignedDriverId: driver.id,
+    status: 'active',
+    scheduledAt: new Date('2026-07-08T06:00:00Z'),
+  });
+
+  const app = await buildApp({
+    auth,
+    routes,
+    stops,
+    routeStops,
+    trips,
+    drivers,
+    tripPositions,
+    kv,
+  });
+  return { app, trips, drivers, tripPositions, trip, driver };
+}
+
+const report = async (
+  app: Awaited<ReturnType<typeof buildApp>>,
+  tripId: string,
+  token: string,
+  body: Record<string, number> = { latitude: 0, longitude: 0 },
+) =>
+  app.inject({
+    method: 'POST',
+    url: `/trips/${tripId}/position`,
+    headers: bearer(token),
+    payload: body,
+  });
+
+describe('POST /trips/:id/position (report a fix)', () => {
+  it('requires authentication', async () => {
+    const { app, trip } = await seed();
+    const res = await app.inject({
+      method: 'POST',
+      url: `/trips/${trip.id}/position`,
+      payload: { latitude: 0, longitude: 0 },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('rejects a non-driver role with 403', async () => {
+    const { app, trip } = await seed();
+    const res = await report(app, trip.id, await access('rider-1', 'commuter'));
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('rejects a driver who is not the assigned driver with 403', async () => {
+    const { app, trip, drivers } = await seed();
+    // A real driver, linked to a user, but assigned to no trip.
+    await drivers.create({ fullName: 'Ama Owusu', userId: 'other-driver-user' });
+    const res = await report(app, trip.id, await access('other-driver-user', 'driver'));
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('rejects a driver-role token with no linked driver record with 403', async () => {
+    const { app, trip } = await seed();
+    const res = await report(app, trip.id, await access('unlinked-user', 'driver'));
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('records a fix for the assigned driver (200) and persists it', async () => {
+    const { app, trip, tripPositions } = await seed();
+    const res = await report(app, trip.id, await access(DRIVER_USER, 'driver'), {
+      latitude: 0.005,
+      longitude: 0.001,
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({
+      tripId: trip.id,
+      position: { latitude: 0.005, longitude: 0.001 },
+    });
+    expect(res.json().position.recordedAt).toBeTruthy();
+
+    const stored = await tripPositions.findLatest(trip.id);
+    expect(stored).toMatchObject({ latitude: 0.005, longitude: 0.001 });
+  });
+
+  it('returns 404 for an unknown trip (even for a driver)', async () => {
+    const { app } = await seed();
+    const res = await report(app, UNKNOWN_TRIP, await access(DRIVER_USER, 'driver'));
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('validates coordinate ranges (400)', async () => {
+    const { app, trip } = await seed();
+    const res = await report(app, trip.id, await access(DRIVER_USER, 'driver'), {
+      latitude: 200,
+      longitude: 0,
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 503 when the repositories are unwired', async () => {
+    const app = await buildApp({ auth });
+    const res = await report(app, UNKNOWN_TRIP, await access(DRIVER_USER, 'driver'));
+    expect(res.statusCode).toBe(503);
+  });
+});
+
+describe('GET /trips/:id/position (latest position + ETA)', () => {
+  it('requires authentication', async () => {
+    const { app, trip } = await seed();
+    const res = await app.inject({ method: 'GET', url: `/trips/${trip.id}/position` });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('returns 404 for an unknown trip', async () => {
+    const { app } = await seed();
+    const res = await app.inject({
+      method: 'GET',
+      url: `/trips/${UNKNOWN_TRIP}/position`,
+      headers: bearer(await access('rider-1')),
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('returns 404 when no fix has been reported yet', async () => {
+    const { app, trip } = await seed();
+    const res = await app.inject({
+      method: 'GET',
+      url: `/trips/${trip.id}/position`,
+      headers: bearer(await access('rider-1')),
+    });
+    expect(res.statusCode).toBe(404);
+    expect(res.json()).toMatchObject({ error: 'not_found' });
+  });
+
+  it('returns the latest fix with deterministic ETAs to upcoming stops', async () => {
+    const { app, trip } = await seed();
+    // Driver reports the bus at the first stop (Circle).
+    await report(app, trip.id, await access(DRIVER_USER, 'driver'), { latitude: 0, longitude: 0 });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/trips/${trip.id}/position`,
+      headers: bearer(await access('rider-1')),
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body).toMatchObject({ tripId: trip.id, position: { latitude: 0, longitude: 0 } });
+
+    // At stop 1 → stops 2 and 3 are upcoming, in order, with increasing ETA.
+    expect(body.etaToStops.map((e: { seq: number }) => e.seq)).toEqual([2, 3]);
+    expect(body.etaToStops[0].distanceMeters).toBeGreaterThan(0);
+    expect(body.etaToStops[0].etaSeconds).toBeGreaterThan(0);
+    expect(body.etaToStops[1].distanceMeters).toBeGreaterThan(body.etaToStops[0].distanceMeters);
+  });
+
+  it('falls back to the durable store when the fix is not cached', async () => {
+    const { app, trip, tripPositions } = await seed();
+    // Seed the store directly (bypassing POST) so the KV cache is cold.
+    await tripPositions.record({ tripId: trip.id, latitude: 0.02, longitude: 0 });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/trips/${trip.id}/position`,
+      headers: bearer(await access('rider-1')),
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().position).toMatchObject({ latitude: 0.02, longitude: 0 });
+    // At the last stop → nothing upcoming.
+    expect(res.json().etaToStops).toEqual([]);
+  });
+
+  it('returns 503 when the repositories are unwired', async () => {
+    const app = await buildApp({ auth });
+    const res = await app.inject({
+      method: 'GET',
+      url: `/trips/${UNKNOWN_TRIP}/position`,
+      headers: bearer(await access('rider-1')),
+    });
+    expect(res.statusCode).toBe(503);
+  });
+});

--- a/services/api/tests/trip-position.repository.test.ts
+++ b/services/api/tests/trip-position.repository.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { InMemoryTripPositionRepository } from '../src/modules/mobility/trip-position.repository';
+
+const TRIP_A = '00000000-0000-0000-0000-0000000000a1';
+const TRIP_B = '00000000-0000-0000-0000-0000000000b2';
+
+describe('InMemoryTripPositionRepository', () => {
+  it('records a fix and returns it as the latest', async () => {
+    const repo = new InMemoryTripPositionRepository();
+    const fix = await repo.record({ tripId: TRIP_A, latitude: 5.6, longitude: -0.19 });
+
+    expect(fix.id).toBeTruthy();
+    expect(fix.recordedAt).toBeInstanceOf(Date);
+    const latest = await repo.findLatest(TRIP_A);
+    expect(latest).toMatchObject({ tripId: TRIP_A, latitude: 5.6, longitude: -0.19 });
+  });
+
+  it('findLatest returns the most recently recorded fix', async () => {
+    const repo = new InMemoryTripPositionRepository();
+    await repo.record({ tripId: TRIP_A, latitude: 1, longitude: 1 });
+    await repo.record({ tripId: TRIP_A, latitude: 2, longitude: 2 });
+    await repo.record({ tripId: TRIP_A, latitude: 3, longitude: 3 });
+
+    const latest = await repo.findLatest(TRIP_A);
+    expect(latest).toMatchObject({ latitude: 3, longitude: 3 });
+  });
+
+  it('isolates fixes by trip', async () => {
+    const repo = new InMemoryTripPositionRepository();
+    await repo.record({ tripId: TRIP_A, latitude: 1, longitude: 1 });
+    await repo.record({ tripId: TRIP_B, latitude: 9, longitude: 9 });
+
+    expect(await repo.findLatest(TRIP_A)).toMatchObject({ latitude: 1 });
+    expect(await repo.findLatest(TRIP_B)).toMatchObject({ latitude: 9 });
+  });
+
+  it('returns null when a trip has no fixes', async () => {
+    const repo = new InMemoryTripPositionRepository();
+    expect(await repo.findLatest(TRIP_A)).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #25. Makes trips **live** for the HTTP pilot: the trip's assigned driver reports GPS fixes over HTTP, riders poll the latest fix and get a deterministic ETA to each upcoming stop along the route's ordered stops (system-design §7). The MQTT/EMQX/Go/WS telemetry path (ADR-0006) stays deferred — this HTTP path exists so the product works before that lands. Builds on trips (#18) and the driver↔trip assignment (#26).

## Endpoints
| Endpoint | Auth | Notes |
|---|---|---|
| `POST /trips/:id/position` | driver **and** the trip's assigned driver | reports a GPS fix `{ latitude, longitude }` |
| `GET /trips/:id/position` | any signed-in user (rider) | latest fix + deterministic `etaToStops` |

## Design notes
- **Assigned-driver authz** (the point of the issue): `requireRole('driver')` is not enough — the handler resolves `user.id → drivers.user_id` via new `driver.findByUserId` and requires it equals `trip.assigned_driver_id` (the field #26 sets). Otherwise **403**. Throttle runs **before** the role check (house convention, cf. boarding/admin).
- **Deterministic ETA** (`services/api/src/modules/mobility/eta.ts`) — pure functions, no clock/I/O/external routing. Haversine cumulative distances along the stop polyline; project the fix onto the nearest segment for "distance travelled"; `etaSeconds = round(remaining / ASSUMED_SPEED_KPH)` (20 km/h placeholder for the pilot). Handles `<2` stops, past-last-stop, before-start, and off-route offsets.
- **Storage + cache** — append-only `trip_positions` (PostGIS `geography(Point,4326)`, migration `016`) is the source of truth; the latest fix is **written through** to the KV store (`trip:position:<id>`, TTL 300s, Redis when available). `GET` reads cache-first with a DB fallback that re-warms it.
- New `TripPositionRepository` (in-memory + Pg) and `driver.findByUserId` on both driver adapters; `tripPositions` wired into `AppDeps`/`app.ts` and `server.ts` (Pg vs in-memory).

## Acceptance (#25)
- ✅ `POST /trips/:id/position` (driver-only, assigned)
- ✅ `GET /trips/:id/position`
- ✅ deterministic ETA
- ✅ tests + authz tests

## Verification
- `tsc --noEmit` clean · `eslint .` clean (also enforced by the pre-commit hook)
- **New tests: 28** — 14 route (full authz matrix, POST→GET, cache fallback, 404/503/400), 10 ETA math, 4 repository
- Full suite: **263/263** green

## Out of scope (follow-ups)
- MQTT/EMQX/Go/WS telemetry ingestion (ADR-0006) — can replay the append-only log
- Live speed/traffic-aware ETA (pilot uses a fixed assumed speed)
- Trip-status guard on reporting (e.g. reject `completed`/`cancelled`)
- Retention/pruning for `trip_positions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
