### PR TITLE
fix(ci): allowlist Firebase client config in gitleaks (unblocks secret-scan repo-wide)

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -7,9 +7,20 @@
 useDefault = true
 
 [allowlist]
-description = "Intentional non-secret placeholders (dev JWT fallback + test fixtures)"
+description = "Intentional non-secret placeholders (dev JWT fallback + test fixtures) + Firebase client config"
 regexes = [
   '''dev-only-insecure-secret-change-me-[0-9a-f]+''',
   '''test-secret-at-least-32-characters-long-[0-9]+''',
   '''a-totally-different-secret-32-chars-min''',
+]
+# Firebase CLIENT config (google-services.json / firebase_options.dart /
+# GoogleService-Info.plist). The "API key" in these is a PUBLIC project
+# identifier that ships in the app — access is controlled by Firebase Security
+# Rules + App Check, not by key secrecy (Google docs). Same class as the
+# committed GOOGLE_CLIENT_ID and Paystack pk_ public key. Path-scoped so a real
+# GCP service-account key committed elsewhere is still caught. (See #88.)
+paths = [
+  '''.*google-services\.json$''',
+  '''.*firebase_options\.dart$''',
+  '''.*GoogleService-Info\.plist$''',
 ]


### PR DESCRIPTION
## Problem
The **Secret scan (gitleaks)** job runs `checkout` with `fetch-depth: 0`, so `gitleaks detect` scans **all fetched branches** — not just the PR. The Firebase branch (#88) commits `google-services.json` + `firebase_options.dart`, whose GCP `AIzaSy…` key trips the `gcp-api-key` rule. Result: **secret-scan fails on every PR** (e.g. #117), even though those files aren't on the PR or on `main`.

## Why it's a false positive
Firebase **client** API keys are **public by design** — they ship in the mobile app; access is controlled by **Firebase Security Rules + App Check**, not key secrecy ([Google docs](https://firebase.google.com/docs/projects/api-keys)). Same class as our committed `GOOGLE_CLIENT_ID` and Paystack `pk_` public key.

## Fix
**Path-scoped** allowlist in `.gitleaks.toml` for the three Firebase client-config filenames. Scoped by path (not by disabling the rule), so a real GCP **service-account** key committed *anywhere else* is still caught. Real secrets remain in env/CI — never committed.

After merge: rebase open PRs (#117, and the Firebase PR) and secret-scan goes green repo-wide.