### PR TITLE
feat(api): feature flags (GET /flags) + min supported version force-update (#27)

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -18,7 +18,7 @@ areas land; it is not authoritative once the code moves.
 | Domain repos | `users/*`, `subscriptions/*` — **repos only, no routes**; `mobility/*` — repos + browse routes (#17)                                                                                                     |
 | Contract     | `lib/schemas.ts`, `user.schema.ts`, `mobility.schema.ts`, OpenAPI via zod type-provider (ADR-0008)                                                                                                       |
 
-**Live HTTP surface:** `/`, `/version`, `/healthz`, `/readyz`, `/me`, `/docs`, `/routes`, `/routes/:id`, `/trips`, `/trips/:id`, `/admin/*` (fleet CRUD + trip assignment, admin-only, #26).
+**Live HTTP surface:** `/`, `/version`, `/healthz`, `/readyz`, `/me`, `/docs`, `/routes`, `/routes/:id`, `/trips`, `/trips/:id`, `/flags` (public feature flags + min supported version, #27), `/admin/*` (fleet CRUD + trip assignment + flags/min-versions, admin-only, #26/#27).
 
 **Cross-cutting (in place):** repository pattern (ADR-0009), KV fallback
 (ADR-0010), readiness pings DB+KV, rate limiting, typed OpenAPI, ~100% unit
@@ -88,7 +88,6 @@ operational layer now has schedules — boarding and live positions are next.
 | QR boarding / passes / scan_events      | #20           | none (CTO)                              |
 | Avatar upload → R2                      | #24           | none                                    |
 | Observability (RED metrics, `/metrics`) | #28           | only default pino logs                  |
-| Feature flags + force-update            | #27           | none                                    |
 | Account deletion                        | #30           | none                                    |
 | Flutter apps                            | #32+          | `apps/` is a README — no scaffold       |
 | Telemetry (MQTT→Go)                     | ADR-0002/0006 | EMQX in compose, no pipeline (deferred) |

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -27,6 +27,7 @@ repo (`system-design.md`, `security.md`). Each doc links to both.
 | Rate limiting (#23)                                                         | [rate-limiting.md](rate-limiting.md)             | ✅ live                                |
 | Boarding — QR scan + manifest + PIN, all deduct (#20, E4)                   | [boarding.md](boarding.md)                       | 🟢 3-layer verification live           |
 | Observability & performance (#28)                                           | [design](../design/observability.md)             | ✅ backend live (metrics/traces/logs)  |
+| Feature flags + force-update — `GET /flags` + admin ops (#27)               | [feature-flags.md](feature-flags.md)             | ✅ live (home-grown, PostHog later)    |
 
 ## Conventions for a feature doc
 

--- a/docs/features/feature-flags.md
+++ b/docs/features/feature-flags.md
@@ -1,0 +1,105 @@
+# Feature flags & force-update (#27)
+
+**Status:** ✅ live — home-grown for the pilot (PostHog later).
+
+## Overview
+
+The "deploy ≠ release" keystone. The apps fetch a single public endpoint,
+`GET /flags`, on launch/session to:
+
+- **gate features** behind flags (a kill-switch + a rollout percentage), and
+- run their **force-update** check against the minimum supported app version.
+
+Flags and minimum versions are stored in Postgres and flipped by operations
+through the admin API — no code change or deploy required to turn a feature off
+or force an update.
+
+## Concepts / model
+
+Two small config tables (migration `018_feature_flags.sql`):
+
+- **`feature_flags`** — one row per flag: `key`, `enabled` (the kill-switch),
+  `rollout_percentage` (0–100), an ops-only `description`, and `updated_at`.
+  `rollout_percentage` is returned as-is; per-user bucketing / cohorts are a
+  later concern (they land with PostHog). "Enabled + rollout" is the shape apps
+  read today.
+- **`app_min_versions`** — one row per platform (`ios` | `android`) holding the
+  lowest app build the API still supports. The version string is opaque to the
+  API; the app compares it against its own build.
+
+## API
+
+### `GET /flags` — public
+
+No auth. Fetched by the apps on launch/session. Returns a **slim** shape (no ops
+metadata) and never fails the launch: if the stores are unwired it returns an
+empty payload.
+
+```json
+{
+  "flags": [{ "key": "live_positions", "enabled": true, "rolloutPercentage": 50 }],
+  "minSupportedVersion": { "ios": "1.2.0", "android": "1.1.0" }
+}
+```
+
+A platform with no configured minimum is `null` (no force-update in effect yet).
+
+### Admin (all `requireRole('admin')`; 401 → 403 → 503 when unwired)
+
+| Method & path                       | Body                                             | Purpose                                         |
+| ----------------------------------- | ------------------------------------------------ | ----------------------------------------------- |
+| `GET /admin/flags`                  | —                                                | List every flag (full rows).                    |
+| `PUT /admin/flags/:key`             | `{ enabled?, rolloutPercentage?, description? }` | Create or update a flag (upsert / kill-switch). |
+| `GET /admin/min-versions`           | —                                                | List the min version per platform.              |
+| `PUT /admin/min-versions/:platform` | `{ version }`                                    | Set the force-update floor (`ios`/`android`).   |
+
+`PUT /admin/flags/:key` is a partial upsert: on create, omitted fields default
+(`enabled=false`, `rolloutPercentage=100`, `description=null`); on update, the
+patch merges over the existing row (omitted = unchanged, explicit `null` clears
+`description`).
+
+## How it works
+
+1. Ops set a flag or bump a min version via `/admin/*`.
+2. On the app's next launch/session it calls `GET /flags`.
+3. The app hides/shows features per `enabled` (+ `rolloutPercentage` when it
+   buckets locally) and force-updates itself if its build is below
+   `minSupportedVersion` for its platform.
+
+Repository pattern (ADR-0009): `InMemory*` repos for zero-infra dev/tests,
+`Pg*` selected in `server.ts` when `DATABASE_URL` is set.
+
+## Configuration
+
+No env vars. Flags and minimum versions are **data**, managed at runtime via the
+admin API (or seeded directly in SQL). Bootstrapping the first admin follows the
+same path as the rest of `/admin/*` (see `admin.routes.ts`).
+
+## Security
+
+- `GET /flags` is intentionally public (like `GET /routes`) — it must answer
+  before sign-in — and returns only `key`/`enabled`/`rolloutPercentage`; the
+  ops-only `description` is never exposed.
+- All writes are admin-role guarded, rate-limited before the role check (house
+  convention), and 503 when the repositories are unwired.
+
+## Local development & testing
+
+Zero infra — the in-memory repositories back the endpoint by default:
+
+```bash
+pnpm api          # then: curl localhost:3000/flags
+pnpm test         # flags.routes.test.ts, feature-flag.repository.test.ts, min-version.repository.test.ts
+```
+
+## Where the code lives
+
+- `services/api/src/modules/flags/` — repositories (`feature-flag.*`,
+  `min-version.*`), `flags.schema.ts`, public `flags.routes.ts`.
+- Admin ops live in `services/api/src/modules/admin/` (schema + routes).
+- `services/api/src/db/migrations/018_feature_flags.sql`.
+
+## Related
+
+- ADR-0008 (zod ↔ OpenAPI contract), ADR-0009 (repository pattern).
+- Wave 2, issue #27 (depends on the data-layer foundation, PR #15).

--- a/services/api/src/app.ts
+++ b/services/api/src/app.ts
@@ -51,6 +51,9 @@ import { mobilityRoutes } from './modules/mobility/mobility.routes';
 import { tripRoutes } from './modules/mobility/trips.routes';
 import { positionRoutes } from './modules/mobility/positions.routes';
 import { adminRoutes } from './modules/admin/admin.routes';
+import { flagsRoutes } from './modules/flags/flags.routes';
+import type { FeatureFlagRepository } from './modules/flags/feature-flag.repository';
+import type { MinVersionRepository } from './modules/flags/min-version.repository';
 import type { RouteRepository } from './modules/mobility/route.repository';
 import type { StopRepository } from './modules/mobility/stop.repository';
 import type { TripRepository } from './modules/mobility/trip.repository';
@@ -96,6 +99,10 @@ export interface AppDeps {
   credits?: CreditLedgerRepository;
   /** Daily reservation store (in-memory vs Postgres). Defaults to in-memory. */
   reservations?: ReservationRepository;
+  /** Feature flags (#27). Read by public GET /flags; ops-managed via /admin/flags. */
+  featureFlags?: FeatureFlagRepository;
+  /** Per-platform min supported version (#27) — the apps' force-update floor. */
+  minVersions?: MinVersionRepository;
   /** Selected by REDIS_URL (in-memory vs Redis). For rate limits, idempotency, cache. */
   kv?: KvStore;
   /** Avatar/media storage (R2 in prod, in-memory Fake in dev/tests). */
@@ -154,6 +161,10 @@ export async function buildApp(deps: AppDeps = {}): Promise<FastifyInstance> {
           description: 'Admin/ops: manage fleet (routes/stops/vehicles/drivers/trips) + assignment',
         },
         { name: 'boarding', description: 'QR boarding passes + scan verification' },
+        {
+          name: 'flags',
+          description: 'Feature flags + minimum supported app version (force-update)',
+        },
       ],
       components: {
         // Protected routes set `security: [{ bearerAuth: [] }]`; clients send
@@ -255,7 +266,13 @@ export async function buildApp(deps: AppDeps = {}): Promise<FastifyInstance> {
     drivers: deps.drivers,
     trips: deps.trips,
     users: deps.users,
+    featureFlags: deps.featureFlags,
+    minVersions: deps.minVersions,
     rateLimit: deps.rateLimit ?? DEFAULT_RATE_LIMIT,
+  });
+  await app.register(flagsRoutes, {
+    featureFlags: deps.featureFlags,
+    minVersions: deps.minVersions,
   });
 
   r.get(

--- a/services/api/src/db/migrations/018_feature_flags.sql
+++ b/services/api/src/db/migrations/018_feature_flags.sql
@@ -1,0 +1,24 @@
+-- 018_feature_flags: the "deploy != release" keystone (#27). Home-grown flags for
+-- the pilot (PostHog later). Two config tables the apps read on launch/session via
+-- the public GET /flags, both ops-managed under /admin/*:
+--   feature_flags   — a flag set, kill-switch (enabled) + %-rollout ready.
+--   app_min_versions — the force-update floor per platform (min_supported_version).
+-- Kept intentionally small: a real evaluator (cohorts, bucketing) lands with PostHog.
+
+CREATE TABLE IF NOT EXISTS feature_flags (
+  key                text PRIMARY KEY,                    -- e.g. "live_positions"
+  enabled            boolean NOT NULL DEFAULT false,      -- the kill-switch
+  -- %-rollout ready: 0–100. Returned as-is; per-user bucketing is a later concern.
+  rollout_percentage integer NOT NULL DEFAULT 100
+                       CHECK (rollout_percentage BETWEEN 0 AND 100),
+  description        text,                                -- ops note (not shown to apps)
+  updated_at         timestamptz NOT NULL DEFAULT now()
+);
+
+-- One row per app platform holding the minimum version the API still supports.
+-- The apps compare their build against this on launch and force an update below it.
+CREATE TABLE IF NOT EXISTS app_min_versions (
+  platform   text PRIMARY KEY CHECK (platform IN ('ios', 'android')),
+  version    text NOT NULL,                               -- semver, e.g. "1.2.0"
+  updated_at timestamptz NOT NULL DEFAULT now()
+);

--- a/services/api/src/modules/admin/admin.routes.ts
+++ b/services/api/src/modules/admin/admin.routes.ts
@@ -18,6 +18,8 @@ import type { StopRepository } from '../mobility/stop.repository';
 import type { TripRepository } from '../mobility/trip.repository';
 import type { VehicleRepository } from '../mobility/vehicle.repository';
 import type { UserRepository } from '../users/user.repository';
+import type { FeatureFlagRepository } from '../flags/feature-flag.repository';
+import { APP_PLATFORMS, type MinVersionRepository } from '../flags/min-version.repository';
 import {
   driverResponseSchema,
   routeResponseSchema,
@@ -25,6 +27,7 @@ import {
   tripResponseSchema,
   vehicleResponseSchema,
 } from '../mobility/mobility.schema';
+import { featureFlagResponseSchema, minVersionResponseSchema } from '../flags/flags.schema';
 import {
   adminUserResponseSchema,
   assignTripBodySchema,
@@ -35,12 +38,14 @@ import {
   createTripBodySchema,
   createVehicleBodySchema,
   listTripsAdminQuerySchema,
+  setMinVersionBodySchema,
   setRoleBodySchema,
   updateDriverBodySchema,
   updateRouteBodySchema,
   updateStopBodySchema,
   updateTripBodySchema,
   updateVehicleBodySchema,
+  upsertFeatureFlagBodySchema,
 } from './admin.schema';
 
 // True when a repository error is a (Postgres-shaped) unique-constraint
@@ -79,6 +84,9 @@ export interface AdminDeps {
   trips?: TripRepository;
   /** For the role grant (PATCH /admin/users/:id/role) + driver user_id checks. */
   users?: UserRepository;
+  /** Feature flags + force-update floor (#27), managed under /admin/flags + /admin/min-versions. */
+  featureFlags?: FeatureFlagRepository;
+  minVersions?: MinVersionRepository;
   rateLimit: RateLimitConfig;
 }
 
@@ -532,6 +540,86 @@ export async function adminRoutes(app: FastifyInstance, opts: AdminDeps): Promis
       const updated = await opts.users.setRole(request.params.id, request.body.role);
       if (!updated) return reply.code(404).send(notFound('User not found'));
       return updated;
+    },
+  );
+
+  // --------------------------------------------------------- feature flags ---
+  // The apps read these (kill-switch + %-rollout) on launch via public GET /flags;
+  // ops flip them here without a deploy — the "deploy != release" keystone (#27).
+  r.get(
+    '/admin/flags',
+    {
+      schema: {
+        tags: ['admin'],
+        summary: 'List all feature flags',
+        security: [{ bearerAuth: [] }],
+        response: { 200: z.array(featureFlagResponseSchema), ...authErrors },
+      },
+      preHandler: adminOnly,
+    },
+    async (_request, reply) => {
+      if (!opts.featureFlags) return reply.code(503).send(UNAVAILABLE);
+      return opts.featureFlags.findAll();
+    },
+  );
+
+  // Upsert (create or update) a flag by key. Idempotent — the kill-switch: PUT
+  // { enabled: false } instantly hides a feature on the apps' next fetch.
+  r.put(
+    '/admin/flags/:key',
+    {
+      schema: {
+        tags: ['admin'],
+        summary: 'Create or update a feature flag',
+        security: [{ bearerAuth: [] }],
+        params: z.object({ key: z.string().min(1) }),
+        body: upsertFeatureFlagBodySchema,
+        response: { 200: featureFlagResponseSchema, ...authErrors },
+      },
+      preHandler: adminOnly,
+    },
+    async (request, reply) => {
+      if (!opts.featureFlags) return reply.code(503).send(UNAVAILABLE);
+      return opts.featureFlags.upsert(request.params.key, request.body);
+    },
+  );
+
+  // ------------------------------------------------------- min app versions ---
+  // The force-update floor per platform: bumping it forces older builds to update
+  // on their next launch (they read it via public GET /flags).
+  r.get(
+    '/admin/min-versions',
+    {
+      schema: {
+        tags: ['admin'],
+        summary: 'List the minimum supported app version per platform',
+        security: [{ bearerAuth: [] }],
+        response: { 200: z.array(minVersionResponseSchema), ...authErrors },
+      },
+      preHandler: adminOnly,
+    },
+    async (_request, reply) => {
+      if (!opts.minVersions) return reply.code(503).send(UNAVAILABLE);
+      return opts.minVersions.findAll();
+    },
+  );
+
+  r.put(
+    '/admin/min-versions/:platform',
+    {
+      schema: {
+        tags: ['admin'],
+        summary: 'Set the minimum supported app version for a platform',
+        security: [{ bearerAuth: [] }],
+        params: z.object({ platform: z.enum(APP_PLATFORMS) }),
+        body: setMinVersionBodySchema,
+        response: { 200: minVersionResponseSchema, ...authErrors },
+      },
+      preHandler: adminOnly,
+    },
+    async (request, reply) => {
+      if (!opts.minVersions) return reply.code(503).send(UNAVAILABLE);
+      return opts.minVersions.set(request.params.platform, request.body.version);
     },
   );
 }

--- a/services/api/src/modules/admin/admin.schema.ts
+++ b/services/api/src/modules/admin/admin.schema.ts
@@ -113,3 +113,18 @@ export const assignTripBodySchema = z.object({
   vehicleId: z.string().uuid().nullable().optional(),
   assignedDriverId: z.string().uuid().nullable().optional(),
 });
+
+// --- feature flags (#27) ---
+// The flag key is the path param; the body carries the editable fields. Every
+// field is optional so PUT /admin/flags/:key both creates (defaults applied) and
+// updates (patch merged over the existing row). See flags/feature-flag.repository.
+export const upsertFeatureFlagBodySchema = z.object({
+  enabled: z.boolean().optional(),
+  rolloutPercentage: z.number().int().min(0).max(100).optional(),
+  description: z.string().nullable().optional(),
+});
+
+// Set the minimum supported app version for a platform (the force-update floor).
+export const setMinVersionBodySchema = z.object({
+  version: z.string().min(1),
+});

--- a/services/api/src/modules/flags/feature-flag.repository.pg.ts
+++ b/services/api/src/modules/flags/feature-flag.repository.pg.ts
@@ -1,0 +1,69 @@
+import type { Pool } from 'pg';
+import { applyPatch } from '../../lib/patch';
+import type {
+  FeatureFlag,
+  FeatureFlagRepository,
+  FeatureFlagUpsert,
+} from './feature-flag.repository';
+
+interface FeatureFlagRow {
+  key: string;
+  enabled: boolean;
+  rollout_percentage: number;
+  description: string | null;
+  updated_at: Date;
+}
+
+function toFlag(row: FeatureFlagRow): FeatureFlag {
+  return {
+    key: row.key,
+    enabled: row.enabled,
+    rolloutPercentage: row.rollout_percentage,
+    description: row.description,
+    updatedAt: row.updated_at,
+  };
+}
+
+export class PgFeatureFlagRepository implements FeatureFlagRepository {
+  constructor(private readonly pool: Pool) {}
+
+  async findAll(): Promise<FeatureFlag[]> {
+    const { rows } = await this.pool.query<FeatureFlagRow>(
+      'SELECT * FROM feature_flags ORDER BY key',
+    );
+    return rows.map(toFlag);
+  }
+
+  async findByKey(key: string): Promise<FeatureFlag | null> {
+    const { rows } = await this.pool.query<FeatureFlagRow>(
+      'SELECT * FROM feature_flags WHERE key = $1',
+      [key],
+    );
+    return rows[0] ? toFlag(rows[0]) : null;
+  }
+
+  async upsert(key: string, input: FeatureFlagUpsert): Promise<FeatureFlag> {
+    // Merge the patch over the existing row (or the create defaults) so an
+    // omitted field is left unchanged rather than reset to NULL/default.
+    const existing = await this.findByKey(key);
+    const next = existing
+      ? applyPatch(existing, input)
+      : {
+          enabled: input.enabled ?? false,
+          rolloutPercentage: input.rolloutPercentage ?? 100,
+          description: input.description ?? null,
+        };
+    const { rows } = await this.pool.query<FeatureFlagRow>(
+      `INSERT INTO feature_flags (key, enabled, rollout_percentage, description, updated_at)
+       VALUES ($1, $2, $3, $4, now())
+       ON CONFLICT (key) DO UPDATE
+         SET enabled = EXCLUDED.enabled,
+             rollout_percentage = EXCLUDED.rollout_percentage,
+             description = EXCLUDED.description,
+             updated_at = now()
+       RETURNING *`,
+      [key, next.enabled, next.rolloutPercentage, next.description],
+    );
+    return toFlag(rows[0]!);
+  }
+}

--- a/services/api/src/modules/flags/feature-flag.repository.ts
+++ b/services/api/src/modules/flags/feature-flag.repository.ts
@@ -1,0 +1,92 @@
+// Feature-flag repository (#27) — the "deploy != release" keystone for the pilot.
+// A flag is a keyed switch the apps read on launch via GET /flags: `enabled` is
+// the kill-switch and `rolloutPercentage` is %-rollout-ready (returned as-is; a
+// real cohort/bucketing evaluator lands with PostHog). Repository pattern
+// (ADR-0009): interface + InMemory here, Postgres in *.pg.ts.
+
+import { applyPatch } from '../../lib/patch';
+
+/** A feature flag: a keyed kill-switch with a rollout percentage. */
+export interface FeatureFlag {
+  /** Stable identifier the apps gate on, e.g. "live_positions". */
+  key: string;
+  /** The kill-switch — false hides the feature regardless of rollout. */
+  enabled: boolean;
+  /** 0–100. Returned as-is; per-user bucketing is a later (PostHog) concern. */
+  rolloutPercentage: number;
+  /** Ops note; not surfaced to the apps. */
+  description: string | null;
+  updatedAt: Date;
+}
+
+/**
+ * Editable flag fields for an upsert (admin, #27). All optional — on create,
+ * omitted fields fall back to defaults (disabled, 100% rollout, no description);
+ * on update, the patch merges over the existing row (omitted = unchanged).
+ */
+export interface FeatureFlagUpsert {
+  enabled?: boolean;
+  rolloutPercentage?: number;
+  description?: string | null;
+}
+
+/** Persistence for feature flags (Postgres in prod, in-memory in dev/tests). */
+export interface FeatureFlagRepository {
+  /** Returns every flag, ordered by key. Read by GET /flags and admin ops. */
+  findAll(): Promise<FeatureFlag[]>;
+  /**
+   * Look up a single flag by key.
+   *
+   * @param key - the flag key.
+   * @returns the flag, or null if it doesn't exist.
+   */
+  findByKey(key: string): Promise<FeatureFlag | null>;
+  /**
+   * Create or update a flag by key (idempotent — the app's kill-switch).
+   *
+   * @param key - the flag key.
+   * @param input - the fields to set; omitted fields default (create) or are
+   *   left unchanged (update).
+   * @returns the persisted flag.
+   */
+  upsert(key: string, input: FeatureFlagUpsert): Promise<FeatureFlag>;
+}
+
+/**
+ * Build a fresh flag row from an upsert input, applying the create defaults.
+ *
+ * @param key - the flag key.
+ * @param input - the fields provided on create; omitted fields default.
+ * @returns the new flag row.
+ */
+function newFlag(key: string, input: FeatureFlagUpsert): FeatureFlag {
+  return {
+    key,
+    enabled: input.enabled ?? false,
+    rolloutPercentage: input.rolloutPercentage ?? 100,
+    description: input.description ?? null,
+    updatedAt: new Date(),
+  };
+}
+
+/** In-memory {@link FeatureFlagRepository} for dev and unit tests. */
+export class InMemoryFeatureFlagRepository implements FeatureFlagRepository {
+  private readonly flags = new Map<string, FeatureFlag>();
+
+  async findAll(): Promise<FeatureFlag[]> {
+    return [...this.flags.values()].sort((a, b) => a.key.localeCompare(b.key));
+  }
+
+  async findByKey(key: string): Promise<FeatureFlag | null> {
+    return this.flags.get(key) ?? null;
+  }
+
+  async upsert(key: string, input: FeatureFlagUpsert): Promise<FeatureFlag> {
+    const existing = this.flags.get(key);
+    const flag: FeatureFlag = existing
+      ? { ...applyPatch(existing, input), updatedAt: new Date() }
+      : newFlag(key, input);
+    this.flags.set(key, flag);
+    return flag;
+  }
+}

--- a/services/api/src/modules/flags/flags.routes.ts
+++ b/services/api/src/modules/flags/flags.routes.ts
@@ -1,0 +1,57 @@
+// Public feature-flags endpoint (#27) — the "deploy != release" keystone. The
+// apps fetch GET /flags on launch/session to gate features (kill-switch +
+// %-rollout) and to run their force-update check (min_supported_version per
+// platform). Intentionally public and un-throttled, like GET /routes: it must
+// answer before a user signs in, and it degrades gracefully (empty set) when the
+// stores are unwired so the app can always boot.
+
+import type { FastifyInstance } from 'fastify';
+import type { ZodTypeProvider } from 'fastify-type-provider-zod';
+import type { FeatureFlagRepository } from './feature-flag.repository';
+import type { MinVersionRepository } from './min-version.repository';
+import { flagsResponseSchema } from './flags.schema';
+
+/**
+ * Register the public flags route (`GET /flags`).
+ *
+ * @param app - the Fastify instance to register on.
+ * @param opts - route dependencies (both optional; absent -> empty payload).
+ * @param opts.featureFlags - the feature-flag repository.
+ * @param opts.minVersions - the minimum-supported-version repository.
+ */
+export async function flagsRoutes(
+  app: FastifyInstance,
+  opts: { featureFlags?: FeatureFlagRepository; minVersions?: MinVersionRepository },
+): Promise<void> {
+  app.withTypeProvider<ZodTypeProvider>().get(
+    '/flags',
+    {
+      schema: {
+        tags: ['flags'],
+        summary: 'Feature flags + minimum supported app version (fetched on launch)',
+        response: { 200: flagsResponseSchema },
+      },
+    },
+    async () => {
+      const flags = opts.featureFlags ? await opts.featureFlags.findAll() : [];
+      const versions = opts.minVersions ? await opts.minVersions.findAll() : [];
+
+      const minSupportedVersion: { ios: string | null; android: string | null } = {
+        ios: null,
+        android: null,
+      };
+      for (const v of versions) {
+        minSupportedVersion[v.platform] = v.version;
+      }
+
+      return {
+        flags: flags.map((f) => ({
+          key: f.key,
+          enabled: f.enabled,
+          rolloutPercentage: f.rolloutPercentage,
+        })),
+        minSupportedVersion,
+      };
+    },
+  );
+}

--- a/services/api/src/modules/flags/flags.schema.ts
+++ b/services/api/src/modules/flags/flags.schema.ts
@@ -1,0 +1,45 @@
+// Contract schemas for feature flags + minimum supported version (#27), rendered
+// into the OpenAPI spec via the zod type provider (ADR-0008). The public GET
+// /flags returns a slim shape (no ops-only fields); admin ops reuse the full row.
+
+import { z } from 'zod';
+import { APP_PLATFORMS } from './min-version.repository';
+
+// --- public (GET /flags) ---
+
+/** A single flag as the apps see it — no ops metadata (description/timestamps). */
+export const publicFlagSchema = z.object({
+  key: z.string(),
+  enabled: z.boolean(),
+  rolloutPercentage: z.number().int(),
+});
+
+/**
+ * The launch/session payload: the flag set plus the per-platform force-update
+ * floor. A platform with no configured minimum is `null` (no force-update yet).
+ */
+export const flagsResponseSchema = z.object({
+  flags: z.array(publicFlagSchema),
+  minSupportedVersion: z.object({
+    ios: z.string().nullable(),
+    android: z.string().nullable(),
+  }),
+});
+
+// --- admin (full rows) ---
+
+/** The full flag row returned by admin ops. */
+export const featureFlagResponseSchema = z.object({
+  key: z.string(),
+  enabled: z.boolean(),
+  rolloutPercentage: z.number().int(),
+  description: z.string().nullable(),
+  updatedAt: z.date(),
+});
+
+/** A per-platform minimum version row returned by admin ops. */
+export const minVersionResponseSchema = z.object({
+  platform: z.enum(APP_PLATFORMS),
+  version: z.string(),
+  updatedAt: z.date(),
+});

--- a/services/api/src/modules/flags/min-version.repository.pg.ts
+++ b/services/api/src/modules/flags/min-version.repository.pg.ts
@@ -1,0 +1,47 @@
+import type { Pool } from 'pg';
+import type { AppPlatform, MinVersion, MinVersionRepository } from './min-version.repository';
+
+interface MinVersionRow {
+  platform: AppPlatform;
+  version: string;
+  updated_at: Date;
+}
+
+function toMinVersion(row: MinVersionRow): MinVersion {
+  return {
+    platform: row.platform,
+    version: row.version,
+    updatedAt: row.updated_at,
+  };
+}
+
+export class PgMinVersionRepository implements MinVersionRepository {
+  constructor(private readonly pool: Pool) {}
+
+  async findAll(): Promise<MinVersion[]> {
+    const { rows } = await this.pool.query<MinVersionRow>(
+      'SELECT * FROM app_min_versions ORDER BY platform',
+    );
+    return rows.map(toMinVersion);
+  }
+
+  async get(platform: AppPlatform): Promise<MinVersion | null> {
+    const { rows } = await this.pool.query<MinVersionRow>(
+      'SELECT * FROM app_min_versions WHERE platform = $1',
+      [platform],
+    );
+    return rows[0] ? toMinVersion(rows[0]) : null;
+  }
+
+  async set(platform: AppPlatform, version: string): Promise<MinVersion> {
+    const { rows } = await this.pool.query<MinVersionRow>(
+      `INSERT INTO app_min_versions (platform, version, updated_at)
+       VALUES ($1, $2, now())
+       ON CONFLICT (platform) DO UPDATE
+         SET version = EXCLUDED.version, updated_at = now()
+       RETURNING *`,
+      [platform, version],
+    );
+    return toMinVersion(rows[0]!);
+  }
+}

--- a/services/api/src/modules/flags/min-version.repository.ts
+++ b/services/api/src/modules/flags/min-version.repository.ts
@@ -1,0 +1,57 @@
+// Minimum-supported-version repository (#27) — the apps' force-update floor.
+// One row per platform holding the lowest app build the API still supports; the
+// apps compare their version against it on launch (via GET /flags) and force an
+// update below it. Repository pattern (ADR-0009): interface + InMemory here,
+// Postgres in *.pg.ts.
+
+/** App platforms that carry a minimum supported version. */
+export const APP_PLATFORMS = ['ios', 'android'] as const;
+export type AppPlatform = (typeof APP_PLATFORMS)[number];
+
+/** The minimum supported app version for one platform. */
+export interface MinVersion {
+  platform: AppPlatform;
+  /** Semver string, e.g. "1.2.0". Opaque to the API — the apps compare it. */
+  version: string;
+  updatedAt: Date;
+}
+
+/** Persistence for per-platform minimum versions (Postgres in prod, in-memory in dev/tests). */
+export interface MinVersionRepository {
+  /** Returns the minimum version for every configured platform. */
+  findAll(): Promise<MinVersion[]>;
+  /**
+   * Look up the minimum version for a platform.
+   *
+   * @param platform - the app platform.
+   * @returns the row, or null if none is configured yet.
+   */
+  get(platform: AppPlatform): Promise<MinVersion | null>;
+  /**
+   * Set (create or replace) the minimum version for a platform.
+   *
+   * @param platform - the app platform.
+   * @param version - the new minimum version.
+   * @returns the persisted row.
+   */
+  set(platform: AppPlatform, version: string): Promise<MinVersion>;
+}
+
+/** In-memory {@link MinVersionRepository} for dev and unit tests. */
+export class InMemoryMinVersionRepository implements MinVersionRepository {
+  private readonly versions = new Map<AppPlatform, MinVersion>();
+
+  async findAll(): Promise<MinVersion[]> {
+    return [...this.versions.values()].sort((a, b) => a.platform.localeCompare(b.platform));
+  }
+
+  async get(platform: AppPlatform): Promise<MinVersion | null> {
+    return this.versions.get(platform) ?? null;
+  }
+
+  async set(platform: AppPlatform, version: string): Promise<MinVersion> {
+    const row: MinVersion = { platform, version, updatedAt: new Date() };
+    this.versions.set(platform, row);
+    return row;
+  }
+}

--- a/services/api/src/server.ts
+++ b/services/api/src/server.ts
@@ -96,6 +96,16 @@ import {
 import { PgReservationRepository } from './modules/reservations/reservation.repository.pg';
 import { InMemoryUserRepository, type UserRepository } from './modules/users/user.repository';
 import { PgUserRepository } from './modules/users/user.repository.pg';
+import {
+  InMemoryFeatureFlagRepository,
+  type FeatureFlagRepository,
+} from './modules/flags/feature-flag.repository';
+import { PgFeatureFlagRepository } from './modules/flags/feature-flag.repository.pg';
+import {
+  InMemoryMinVersionRepository,
+  type MinVersionRepository,
+} from './modules/flags/min-version.repository';
+import { PgMinVersionRepository } from './modules/flags/min-version.repository.pg';
 
 async function main(): Promise<void> {
   loadDotenv();
@@ -153,6 +163,8 @@ async function main(): Promise<void> {
   let entitlements: EntitlementLedgerRepository;
   let credits: CreditLedgerRepository;
   let reservations: ReservationRepository;
+  let featureFlags: FeatureFlagRepository;
+  let minVersions: MinVersionRepository;
   if (env.DATABASE_URL) {
     pool = createPool(env.DATABASE_URL);
     users = new PgUserRepository(pool);
@@ -172,6 +184,8 @@ async function main(): Promise<void> {
     entitlements = new PgEntitlementLedgerRepository(pool);
     credits = new PgCreditLedgerRepository(pool);
     reservations = new PgReservationRepository(pool);
+    featureFlags = new PgFeatureFlagRepository(pool);
+    minVersions = new PgMinVersionRepository(pool);
     console.log('Using Postgres repositories');
   } else {
     users = new InMemoryUserRepository();
@@ -191,6 +205,8 @@ async function main(): Promise<void> {
     entitlements = new InMemoryEntitlementLedgerRepository();
     credits = new InMemoryCreditLedgerRepository();
     reservations = new InMemoryReservationRepository();
+    featureFlags = new InMemoryFeatureFlagRepository();
+    minVersions = new InMemoryMinVersionRepository();
     console.log('Using in-memory repositories (no DATABASE_URL set)');
   }
 
@@ -284,6 +300,8 @@ async function main(): Promise<void> {
     entitlements,
     credits,
     reservations,
+    featureFlags,
+    minVersions,
     kv,
     objectStore,
     isReady,

--- a/services/api/tests/feature-flag.repository.test.ts
+++ b/services/api/tests/feature-flag.repository.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { InMemoryFeatureFlagRepository } from '../src/modules/flags/feature-flag.repository';
+
+describe('InMemoryFeatureFlagRepository', () => {
+  it('creates a flag with defaults (disabled, 100% rollout, no description)', async () => {
+    const repo = new InMemoryFeatureFlagRepository();
+    const flag = await repo.upsert('live_positions', {});
+    expect(flag).toMatchObject({
+      key: 'live_positions',
+      enabled: false,
+      rolloutPercentage: 100,
+      description: null,
+    });
+    expect(flag.updatedAt).toBeInstanceOf(Date);
+  });
+
+  it('creates a flag with the provided values', async () => {
+    const repo = new InMemoryFeatureFlagRepository();
+    const flag = await repo.upsert('beta_ui', {
+      enabled: true,
+      rolloutPercentage: 25,
+      description: 'gradual UI rollout',
+    });
+    expect(flag).toMatchObject({
+      key: 'beta_ui',
+      enabled: true,
+      rolloutPercentage: 25,
+      description: 'gradual UI rollout',
+    });
+  });
+
+  it('upsert merges a partial patch over an existing flag', async () => {
+    const repo = new InMemoryFeatureFlagRepository();
+    await repo.upsert('beta_ui', { enabled: true, rolloutPercentage: 25 });
+    const updated = await repo.upsert('beta_ui', { enabled: false });
+    // enabled changes; rolloutPercentage is left unchanged.
+    expect(updated).toMatchObject({ key: 'beta_ui', enabled: false, rolloutPercentage: 25 });
+  });
+
+  it('findByKey returns null for an unknown key', async () => {
+    const repo = new InMemoryFeatureFlagRepository();
+    expect(await repo.findByKey('nope')).toBeNull();
+  });
+
+  it('findAll returns every flag ordered by key', async () => {
+    const repo = new InMemoryFeatureFlagRepository();
+    await repo.upsert('zebra', {});
+    await repo.upsert('alpha', {});
+    const keys = (await repo.findAll()).map((f) => f.key);
+    expect(keys).toEqual(['alpha', 'zebra']);
+  });
+});

--- a/services/api/tests/flags.routes.test.ts
+++ b/services/api/tests/flags.routes.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest';
+import { buildApp } from '../src/app';
+import { createJwtService, type AuthConfig } from '../src/modules/auth/jwt';
+import { InMemoryFeatureFlagRepository } from '../src/modules/flags/feature-flag.repository';
+import { InMemoryMinVersionRepository } from '../src/modules/flags/min-version.repository';
+
+const auth: AuthConfig = {
+  secret: 'test-secret-at-least-32-characters-long-0000',
+  accessTtl: '15m',
+  issuer: 'trotxi',
+  audience: 'trotxi-api',
+};
+const jwt = createJwtService(auth);
+const bearer = (t: string) => ({ authorization: `Bearer ${t}` });
+const adminToken = () => jwt.signAccessToken({ userId: 'admin-1', role: 'admin' });
+const commuterToken = () => jwt.signAccessToken({ userId: 'rider-1', role: 'commuter' });
+
+async function flagsApp() {
+  const featureFlags = new InMemoryFeatureFlagRepository();
+  const minVersions = new InMemoryMinVersionRepository();
+  const app = await buildApp({ auth, featureFlags, minVersions });
+  return { app, featureFlags, minVersions };
+}
+
+describe('GET /flags (public)', () => {
+  it('is public and returns an empty payload when nothing is configured', async () => {
+    const { app } = await flagsApp();
+    const res = await app.inject({ method: 'GET', url: '/flags' });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({
+      flags: [],
+      minSupportedVersion: { ios: null, android: null },
+    });
+  });
+
+  it('degrades gracefully (empty payload) when the stores are unwired', async () => {
+    const app = await buildApp({ auth });
+    const res = await app.inject({ method: 'GET', url: '/flags' });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({
+      flags: [],
+      minSupportedVersion: { ios: null, android: null },
+    });
+  });
+
+  it('returns the flag set (slim shape) and per-platform min versions', async () => {
+    const { app, featureFlags, minVersions } = await flagsApp();
+    await featureFlags.upsert('live_positions', {
+      enabled: true,
+      rolloutPercentage: 50,
+      description: 'ops note not shown to apps',
+    });
+    await minVersions.set('ios', '1.2.0');
+    await minVersions.set('android', '1.1.0');
+
+    const res = await app.inject({ method: 'GET', url: '/flags' });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.minSupportedVersion).toEqual({ ios: '1.2.0', android: '1.1.0' });
+    expect(body.flags).toEqual([{ key: 'live_positions', enabled: true, rolloutPercentage: 50 }]);
+    // Ops metadata is not leaked to the public payload.
+    expect(body.flags[0]).not.toHaveProperty('description');
+  });
+});
+
+describe('admin flags + min-versions', () => {
+  it('401 without a token, 403 for a non-admin', async () => {
+    const { app } = await flagsApp();
+    expect((await app.inject({ method: 'GET', url: '/admin/flags' })).statusCode).toBe(401);
+    const forbidden = await app.inject({
+      method: 'GET',
+      url: '/admin/flags',
+      headers: bearer(await commuterToken()),
+    });
+    expect(forbidden.statusCode).toBe(403);
+  });
+
+  it('503 when the flag store is unwired', async () => {
+    const app = await buildApp({ auth });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/admin/flags',
+      headers: bearer(await adminToken()),
+    });
+    expect(res.statusCode).toBe(503);
+  });
+
+  it('upserts a flag and lists it', async () => {
+    const { app } = await flagsApp();
+    const token = await adminToken();
+
+    const created = await app.inject({
+      method: 'PUT',
+      url: '/admin/flags/beta_ui',
+      headers: bearer(token),
+      payload: { enabled: true, rolloutPercentage: 25 },
+    });
+    expect(created.statusCode).toBe(200);
+    expect(created.json()).toMatchObject({ key: 'beta_ui', enabled: true, rolloutPercentage: 25 });
+
+    // Kill-switch: flip enabled, leave rollout unchanged.
+    const flipped = await app.inject({
+      method: 'PUT',
+      url: '/admin/flags/beta_ui',
+      headers: bearer(token),
+      payload: { enabled: false },
+    });
+    expect(flipped.json()).toMatchObject({ enabled: false, rolloutPercentage: 25 });
+
+    const list = await app.inject({
+      method: 'GET',
+      url: '/admin/flags',
+      headers: bearer(token),
+    });
+    expect(list.json()).toHaveLength(1);
+  });
+
+  it('sets a platform minimum version and lists it', async () => {
+    const { app } = await flagsApp();
+    const token = await adminToken();
+
+    const set = await app.inject({
+      method: 'PUT',
+      url: '/admin/min-versions/ios',
+      headers: bearer(token),
+      payload: { version: '2.0.0' },
+    });
+    expect(set.statusCode).toBe(200);
+    expect(set.json()).toMatchObject({ platform: 'ios', version: '2.0.0' });
+
+    const list = await app.inject({
+      method: 'GET',
+      url: '/admin/min-versions',
+      headers: bearer(token),
+    });
+    expect(list.json()).toEqual([expect.objectContaining({ platform: 'ios', version: '2.0.0' })]);
+  });
+
+  it('rejects an unknown platform (422 from the enum schema)', async () => {
+    const { app } = await flagsApp();
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/admin/min-versions/windows',
+      headers: bearer(await adminToken()),
+      payload: { version: '1.0.0' },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+});

--- a/services/api/tests/min-version.repository.test.ts
+++ b/services/api/tests/min-version.repository.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { InMemoryMinVersionRepository } from '../src/modules/flags/min-version.repository';
+
+describe('InMemoryMinVersionRepository', () => {
+  it('sets and gets a platform minimum version', async () => {
+    const repo = new InMemoryMinVersionRepository();
+    const row = await repo.set('ios', '1.2.0');
+    expect(row).toMatchObject({ platform: 'ios', version: '1.2.0' });
+    expect(row.updatedAt).toBeInstanceOf(Date);
+    expect(await repo.get('ios')).toMatchObject({ version: '1.2.0' });
+  });
+
+  it('set replaces the existing version for a platform', async () => {
+    const repo = new InMemoryMinVersionRepository();
+    await repo.set('android', '1.0.0');
+    await repo.set('android', '1.5.0');
+    expect(await repo.get('android')).toMatchObject({ version: '1.5.0' });
+    expect(await repo.findAll()).toHaveLength(1);
+  });
+
+  it('get returns null for an unconfigured platform', async () => {
+    const repo = new InMemoryMinVersionRepository();
+    expect(await repo.get('ios')).toBeNull();
+  });
+
+  it('findAll returns every configured platform ordered by name', async () => {
+    const repo = new InMemoryMinVersionRepository();
+    await repo.set('ios', '2.0.0');
+    await repo.set('android', '1.0.0');
+    expect((await repo.findAll()).map((v) => v.platform)).toEqual(['android', 'ios']);
+  });
+});


### PR DESCRIPTION
Closes #27. The **"deploy ≠ release"** keystone for the pilot (home-grown; PostHog later). The apps fetch a single **public `GET /flags`** on launch/session to gate features (kill-switch + %-rollout) and run their **force-update** check against the minimum supported app version. Flags and min versions are **Postgres-backed and flipped by ops** via the admin API — no code change or deploy to disable a feature or force an update. Builds on the data-layer foundation (PR #15).

## Endpoints
| Endpoint | Auth | Notes |
|---|---|---|
| `GET /flags` | **public** (un-throttled, like `/routes`) | slim flag set + per-platform `minSupportedVersion`; degrades to an empty payload when unwired so the app always boots |
| `GET /admin/flags` · `PUT /admin/flags/:key` | admin | list / upsert a flag (create defaults or patch merge) |
| `GET /admin/min-versions` · `PUT /admin/min-versions/:platform` | admin | list / set the force-update floor (`ios`/`android`) |

## Design notes
- **Public + graceful.** `GET /flags` must answer before sign-in, so it's public like `GET /routes` and returns only `key`/`enabled`/`rolloutPercentage` — the ops-only `description` never leaks. If the stores are unwired it returns `{ flags: [], minSupportedVersion: { ios: null, android: null } }` rather than a 503, so a launch call can never brick the app.
- **Kill-switch + %-rollout ready.** `feature_flags` carries `enabled` (the switch) and `rollout_percentage` (0–100, returned as-is). Per-user bucketing / cohorts are deliberately deferred to PostHog — this ships the shape the apps read today.
- **Admin writes** are `requireRole('admin')` guarded with **throttle before the role check** (house convention, cf. admin/boarding), and 503 when repos are unwired. `PUT /admin/flags/:key` is a partial upsert: create applies defaults (`enabled=false`, `rolloutPercentage=100`, `description=null`); update merges the patch (omitted = unchanged, explicit `null` clears).
- **Storage.** Migration `018` adds `feature_flags` and `app_min_versions` (platform PK `ios`/`android`). New `FeatureFlagRepository` + `MinVersionRepository`, each in-memory + Pg (ADR-0009), wired into `AppDeps`/`app.ts` and `server.ts` (Pg vs in-memory).

## Acceptance (#27)
- ✅ `GET /flags` returns the flag set (cohort/%-rollout/kill-switch ready)
- ✅ `min_supported_version` configurable (per-platform, admin-managed)
- ✅ tests

## Verification
- `tsc --noEmit` clean · `eslint .` clean (also enforced by the pre-commit hook)
- **New tests: 17** — repository units (flags + min-versions) + public/admin route flows (full authz matrix, kill-switch flip, 503-when-unwired, unknown-platform 400)
- Full suite: **294/294** green

## Out of scope (follow-ups)
- The **app-side** force-update check + flag consumption (Flutter apps — `apps/` is still a README)
- Real per-user cohort/rollout evaluation (lands with PostHog)
- Admin flag **delete** (disable via `enabled=false` is the pilot kill-switch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
