### PR TITLE
chore(api): scripted end-to-end demo of the hybrid-model loop

### DIFF
--- a/docs/open-questions.md
+++ b/docs/open-questions.md
@@ -1,0 +1,80 @@
+# Hybrid Model — what's proven, and the open questions
+
+**Owner:** Godfred Awuku · **Date:** 2026-07-08
+
+Context: the whole hybrid-model loop now runs **end to end** — see
+[`services/api/scripts/e2e-demo.sh`](../services/api/scripts/e2e-demo.sh) (in this
+PR). Running it for real surfaced the gaps below. **None are broken code** — they
+are **product/schema decisions** that block the remaining epics. This is the
+agenda for the product/pricing meeting.
+
+---
+
+## ✅ Proven (the demo asserts this every run)
+
+```
+admin → create route/stop/vehicle/trip
+      → promote a user to driver (#116) → assign to trip
+rider → sign in → subscribe → (signed) webhook → 44 rides (E1)
+      → confirm tomorrow's trip → daily PIN (E3/E4)
+driver→ open manifest (name + photo pass) → board by PIN → ride debits 44 → 43 (E4)
+```
+
+Idempotency holds (re-board = `already_boarded`, no second debit) and a wrong PIN
+is rejected. Auth, subscribe→allocate, reservations+PIN, manifest, and boarding
+deduction all work together.
+
+---
+
+## 🔴 The one structural gap: rider ↔ route/trip
+
+The demo has to **hand the rider the `tripId`** to confirm. In production the app
+must answer _"which trip is mine tomorrow?"_ on its own — and **nothing links a
+rider to a route/corridor**.
+
+- **Blocks:** E3 **ask-dispatch** (can't send "travelling tomorrow?" if we don't
+  know who rides what) → the daily confirmation can't be automated.
+- **Decision needed:** are pilot riders **pinned to one corridor** (a
+  `rider_route` record set at subscribe/onboarding)? Chosen per-confirmation from
+  a browse? This is the **next decision to make** — it unblocks the whole
+  confirmation loop.
+
+## 🟡 Numbers not decided (block E5 / E6)
+
+- **Allocation isn't period-guarded.** Each paid webhook allocates 44, keyed by
+  payment reference — so subscribing twice yields **88**, not 44. The
+  "**one allocation per subscription period** + renewal netting" logic is **E5**,
+  and needs the **per-ride credit value** decided (plan price ÷ entitlement? a
+  table?).
+- **Pricing set.** Tiers (standard/premium/corporate/student), plan prices,
+  **standby fare**, and **KYC scope** are all placeholders (44 rides, GHS 20).
+  Blocks **E5** (credit conversion) and **E6** (standby pool).
+
+## 🟢 Deferred polish (known, not blocking the loop)
+
+- **Manifest authz** — a manifest isn't yet restricted to the trip's **assigned
+  driver** (any driver token can view any trip's manifest). Pairs with #25's
+  driver↔user lookup.
+- **QR direction resolution** — a QR scan boards the rider's _earliest open leg
+  today_; the PIN + manifest target an exact reservation. Converges once trips
+  carry a direction.
+- **FCM send** — the backend needs the **Firebase service account** (from
+  adomfosugit) to actually send the daily push. Device-token registration
+  already exists.
+- **Housekeeping** — duplicate migration number `016` (`016_reservation_pin` +
+  `016_trip_positions`); renumber one on the next migration.
+
+---
+
+## Decisions, in priority order
+
+| #   | Decision                                              | Owner         | Unblocks        |
+| --- | ----------------------------------------------------- | ------------- | --------------- |
+| 1   | **rider ↔ route** association model                   | Product + CTO | E3 ask-dispatch |
+| 2   | **Per-ride credit value** + one-allocation-per-period | Product       | E5              |
+| 3   | **Tier differentiation + prices**                     | Product       | E1b, E5         |
+| 4   | **Standby fare + KYC scope**                          | Product       | E6              |
+| 5   | Provide **Firebase service account**                  | adomfosugit   | E3 push send    |
+
+Survey data (current one-way spend, willingness-to-pay) feeds #2–#4 — results not
+yet collected.

--- a/services/api/scripts/e2e-demo.sh
+++ b/services/api/scripts/e2e-demo.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# e2e-demo.sh — drive the whole Trotxi hybrid-model loop against a running API,
+# end to end:
+#
+#   admin bootstrap → create fleet (route/stop/vehicle/trip)
+#   → promote a user to driver → assign driver to trip
+#   → rider signs in → subscribes → (fake) webhook → 44 rides
+#   → rider confirms tomorrow's trip → gets a daily PIN
+#   → driver opens the trip manifest (photo pass)
+#   → driver boards the rider by PIN → one ride is debited (44 → 43)
+#
+# It prints every token + id at the end so you can then poke individual
+# endpoints in Swagger (http://localhost:3000/docs) as admin / driver / rider.
+#
+# Prereqs: the API running locally in DEV mode — JWT_SECRET unset (dev auth
+# secret) and PAYSTACK_SECRET_KEY unset (fake Paystack client):
+#
+#   cd services/api
+#   export PATH="$HOME/.nvm/versions/node/v24.17.0/bin:$PATH"   # Node 24
+#   node node_modules/tsx/dist/cli.mjs src/server.ts &          # start the API
+#   bash scripts/e2e-demo.sh                                     # run the loop
+#
+# Override the base URL:  BASE_URL=http://localhost:3000 bash scripts/e2e-demo.sh
+
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://localhost:3000}"
+# DEV_AUTH_CONFIG.secret (services/api/src/modules/auth/jwt.ts) — used only to
+# mint the bootstrap admin token; there is no other way to get the first admin.
+DEV_SECRET="dev-only-insecure-secret-change-me-0123456789abcdef"
+# FakePaystackClient dev secret (services/api/src/modules/payments/paystack.client.ts).
+PAYSTACK_DEV_SECRET="fake-paystack-secret"
+
+TODAY="$(date -u +%F)"
+TRIP_AT="$(date -u -v+1d +%FT06:30:00Z 2>/dev/null || date -u -d '+1 day' +%FT06:30:00Z)"
+STAMP="$(date +%s)"
+
+for tool in node curl jq; do
+  command -v "$tool" >/dev/null || { echo "missing required tool: $tool"; exit 1; }
+done
+
+green() { printf '\033[1;32m%s\033[0m\n' "$1"; }
+cyan()  { printf '\n\033[1;36m▶ %s\033[0m\n' "$1"; }
+die()   { printf '\033[1;31m✗ %s\033[0m\n' "$1"; exit 1; }
+
+curl -sf "$BASE_URL/healthz" >/dev/null 2>&1 \
+  || die "API not reachable at $BASE_URL — start it first (see the header of this script)."
+
+# mint <userId> <role> → an access token signed with the DEV secret (2h)
+mint() {
+  node --input-type=module -e "
+    import { SignJWT } from 'jose';
+    const t = await new SignJWT({ role: process.argv[2] })
+      .setProtectedHeader({ alg: 'HS256' })
+      .setSubject(process.argv[1]).setIssuedAt()
+      .setIssuer('trotxi').setAudience('trotxi-api').setExpirationTime('2h')
+      .sign(new TextEncoder().encode('$DEV_SECRET'));
+    console.log(t);
+  " "$1" "$2"
+}
+
+# signin <sub> <name> → the sign-in JSON (fake Google verifier: idToken is JSON claims)
+signin() {
+  local claims body
+  claims=$(jq -cn --arg sub "$1" --arg name "$2" '{sub:$sub,name:$name}')
+  body=$(jq -cn --arg t "$claims" '{idToken:$t}')
+  curl -s "$BASE_URL/auth/google" -H 'content-type: application/json' -d "$body"
+}
+
+auth() { echo "authorization: Bearer $1"; }
+post() { curl -s "$BASE_URL$1" -H "$(auth "$2")" -H 'content-type: application/json' -d "$3"; }
+
+# webhook <reference> → sign + deliver a fake Paystack charge.success
+webhook() {
+  local body sig
+  body="{\"event\":\"charge.success\",\"data\":{\"reference\":\"$1\"}}"
+  sig=$(node -e "process.stdout.write(require('crypto').createHmac('sha512','$PAYSTACK_DEV_SECRET').update(process.argv[1]).digest('hex'))" "$body")
+  curl -s "$BASE_URL/webhooks/paystack" -H 'content-type: application/json' \
+    -H "x-paystack-signature: $sig" -d "$body" >/dev/null
+}
+
+# --- 1. admin + fleet ---------------------------------------------------------
+cyan "1. Admin (minted) creates route / stop / vehicle / trip"
+ADMIN=$(mint "admin-$STAMP" admin)
+ROUTE=$(post /admin/routes "$ADMIN" '{"name":"East Legon → Airport"}' | jq -r .id)
+STOP=$(post /admin/stops "$ADMIN" '{"name":"East Legon Stop","latitude":5.63,"longitude":-0.16}' | jq -r .id)
+post "/admin/routes/$ROUTE/stops" "$ADMIN" "$(jq -cn --arg s "$STOP" '{stopId:$s,seq:1}')" >/dev/null
+VEHICLE=$(post /admin/vehicles "$ADMIN" "$(jq -cn --arg r "GR-$STAMP" '{registration:$r,capacity:15}')" | jq -r .id)
+TRIP=$(post /admin/trips "$ADMIN" "$(jq -cn --arg r "$ROUTE" --arg at "$TRIP_AT" '{routeId:$r,scheduledAt:$at}')" | jq -r .id)
+green "✓ route=$ROUTE  trip=$TRIP  vehicle=$VEHICLE"
+
+# --- 2. driver bootstrap ------------------------------------------------------
+cyan "2. Bootstrap a driver: sign in (commuter) → grant 'driver' → re-sign-in"
+DUSER=$(signin "driver-$STAMP" "Kwame Driver" | jq -r .user.id)
+DFLEET=$(post /admin/drivers "$ADMIN" "$(jq -cn --arg u "$DUSER" '{fullName:"Kwame Driver",userId:$u}')" | jq -r .id)
+curl -s -X PUT "$BASE_URL/admin/trips/$TRIP/assignment" -H "$(auth "$ADMIN")" -H 'content-type: application/json' \
+  -d "$(jq -cn --arg v "$VEHICLE" --arg d "$DFLEET" '{vehicleId:$v,assignedDriverId:$d}')" >/dev/null
+curl -s -X PATCH "$BASE_URL/admin/users/$DUSER/role" -H "$(auth "$ADMIN")" -H 'content-type: application/json' \
+  -d '{"role":"driver"}' >/dev/null
+DRIVER=$(signin "driver-$STAMP" "Kwame Driver" | jq -r .accessToken)
+DROLE=$(node -e "console.log(JSON.parse(Buffer.from(process.argv[1].split('.')[1],'base64')).role)" "$DRIVER")
+[ "$DROLE" = "driver" ] || die "role grant failed — token role is '$DROLE'"
+green "✓ driver promoted (token role='$DROLE') and assigned to the trip"
+
+# --- 3. rider subscribes ------------------------------------------------------
+cyan "3. Rider signs in → subscribes → webhook → rides allocated"
+RJSON=$(signin "ama-$STAMP" "Ama Mensah")
+RIDER=$(echo "$RJSON" | jq -r .accessToken)
+REF=$(post /payments/subscribe "$RIDER" '{"plan":"monthly"}' | jq -r .reference)
+webhook "$REF"
+RIDES0=$(curl -s "$BASE_URL/me/rides" -H "$(auth "$RIDER")" | jq .remainingRides)
+green "✓ Ama subscribed → remainingRides=$RIDES0"
+
+# --- 4. rider confirms --------------------------------------------------------
+cyan "4. Rider confirms tomorrow's trip → gets a daily PIN"
+CONF=$(post /me/reservations "$RIDER" "$(jq -cn --arg t "$TRIP" --arg d "$TODAY" '{tripId:$t,travelDate:$d,direction:"morning",travelling:true}')")
+RESV=$(echo "$CONF" | jq -r .id)
+PIN=$(echo "$CONF" | jq -r .pin)
+green "✓ reservation=$RESV  status=$(echo "$CONF" | jq -r .status)  pin=$PIN"
+
+# --- 5. driver manifest -------------------------------------------------------
+cyan "5. Driver opens the trip manifest (photo pass)"
+curl -s "$BASE_URL/boarding/manifest?tripId=$TRIP" -H "$(auth "$DRIVER")" \
+  | jq '{tripId, riders: [.riders[] | {name, direction, boarded}]}'
+
+# --- 6. board by PIN ----------------------------------------------------------
+cyan "6. Driver boards the rider by PIN → one ride is debited"
+VP=$(post /boarding/verify-pin "$DRIVER" "$(jq -cn --arg r "$RESV" --arg p "$PIN" '{reservationId:$r,pin:$p}')")
+echo "verify-pin → $VP"
+RIDES1=$(curl -s "$BASE_URL/me/rides" -H "$(auth "$RIDER")" | jq .remainingRides)
+
+cyan "RESULT"
+echo "rides: $RIDES0 → $RIDES1   (deducted=$(echo "$VP" | jq -r .deducted))"
+if [ "$RIDES1" = "$((RIDES0 - 1))" ] && [ "$(echo "$VP" | jq -r .deducted)" = "true" ]; then
+  green "✓ FULL LOOP PASSED — ride consumed end to end"
+else
+  die "loop did not consume a ride as expected"
+fi
+
+# --- poke it yourself in Swagger ---------------------------------------------
+cyan "Now try it in Swagger — $BASE_URL/docs (Authorize → paste a token, NO quotes)"
+cat <<EOF
+  ADMIN  token : $ADMIN
+  DRIVER token : $DRIVER
+  RIDER  token : $RIDER
+
+  tripId       : $TRIP
+  reservationId: $RESV   pin: $PIN
+EOF


### PR DESCRIPTION
A one-command smoke test of the **whole** driver + commuter loop against a running dev API — so we stop hand-clicking Swagger + pasting tokens.

\`\`\`
cd services/api
export PATH="\$HOME/.nvm/versions/node/v24.17.0/bin:\$PATH"
node node_modules/tsx/dist/cli.mjs src/server.ts &   # start API (dev mode)
bash scripts/e2e-demo.sh
\`\`\`

Runs: admin bootstrap (minted token — the only way to the first admin) → create route/stop/vehicle/trip → **promote a user to driver** (#116) → assign → rider signs in → subscribe → **fake signed webhook** → 44 rides → confirm tomorrow's trip → **daily PIN** → driver **manifest** (photo pass) → **board by PIN** → asserts the ride debits **44 → 43**. Then prints the admin/driver/rider tokens + `tripId`/`reservationId`/`pin` so you can jump into Swagger as any role.

Dev-only: uses the committed `DEV_AUTH_CONFIG` secret (already gitleaks-allowlisted) + the fake Paystack client. No infra, no real secrets.