### PR TITLE
E3: scheduled ask-dispatch + rider↔route pinning

### DIFF
--- a/docs/features/reservations.md
+++ b/docs/features/reservations.md
@@ -90,10 +90,14 @@ sends via `firebase-admin` to a rider's registered device tokens (#84), used whe
 `FIREBASE_SERVICE_ACCOUNT` is set (else the recording fake). The service-account
 key is a **secret → Render env only**.
 
+**Cron schedule** is wired in `render.yaml`: four Render cron jobs run
+`dist/cron/ask-dispatch-cron.js` at the windows above (18:00 / 21:00 morning,
+12:00 / 14:00 evening — Ghana is UTC). Each mints a short-lived admin token and
+POSTs the trigger. To activate: apply the blueprint and set `JWT_SECRET` on the
+`trotxi-cron-staging` env group to the **same value** as the web service's.
+
 ## Deferred
 
-- **Cron schedule** — the Render cron that hits `POST /admin/ask-dispatch` at the
-  ask windows and `POST /admin/resolve-defaults` at each cutoff (infra config).
 - **Capacity / release** — seat caps + releasing a declined seat to standby (E6).
 
 ## Where the code lives
@@ -107,7 +111,9 @@ services/api/src/modules/reservations/
 services/api/src/modules/notifications/
   ask-dispatch.service.ts          # dispatchAsks + resolveDefaults (the loop)
   ask-dispatch.routes.ts           # POST /admin/ask-dispatch, /resolve-defaults
-  notification.sender.ts           # NotificationSender + FakeNotificationSender
+  notification.sender.ts(.live)    # NotificationSender + Fake / real FCM
+services/api/src/cron/ask-dispatch-cron.ts   # cron entry (mints token, POSTs)
+render.yaml                        # 4 Render cron jobs (the schedule)
 services/api/src/db/migrations/013_reservations.sql
 services/api/src/db/migrations/019_subscription_route.sql   # rider↔route pin
 ```

--- a/docs/features/reservations.md
+++ b/docs/features/reservations.md
@@ -11,11 +11,10 @@ pool (E6) fills when declined.
 > **Scope shipped (E3):** the reservation lifecycle + the rider's confirm/decline
 > API + the default-yes operation (E3-core), **plus the scheduled _ask-dispatch_**
 > — now that trips (#18) have landed, the loop seeds `pending` rows for tomorrow's
-> route trips and sends the (fake, until FCM) prompt, and a cutoff trigger runs
-> the default-yes. **Still deferred:** the real **FCM push** (needs the Firebase
-> service account, #88–90), seat **capacity / release** to standby (E6), and the
-> **cron schedule** itself (Render infra hits the admin triggers below). So
-> `trip_id` still carries **no FK yet** (same as `scan_events`).
+> route trips and pushes the "travelling?" prompt over **FCM**, and a cutoff
+> trigger runs the default-yes. **Still deferred:** seat **capacity / release** to
+> standby (E6) and the **cron schedule** itself (Render infra hits the admin
+> triggers below). So `trip_id` still carries **no FK yet** (same as `scan_events`).
 
 **Rider ↔ route (the pilot model).** A rider is linked to a corridor by their
 **subscription**: at checkout the chosen `route_id` is threaded through the
@@ -86,11 +85,13 @@ confirmed_at, created_at, updated_at)`, unique `(user_id, travel_date,
 direction)`. `trip_id` has no FK yet (trips are #18). Rider↔route lives on
 `subscriptions.route_id` / `payments.route_id` (migration `019`).
 
+**FCM push** is wired: `FcmNotificationSender` (`notification.sender.live.ts`)
+sends via `firebase-admin` to a rider's registered device tokens (#84), used when
+`FIREBASE_SERVICE_ACCOUNT` is set (else the recording fake). The service-account
+key is a **secret → Render env only**.
+
 ## Deferred
 
-- **FCM push** — swap `FakeNotificationSender` for the Firebase Admin sender —
-  needs the Firebase service account (adomfosugit, #88–90). The `ask-dispatch`
-  loop is built and sends via the fake sender until then.
 - **Cron schedule** — the Render cron that hits `POST /admin/ask-dispatch` at the
   ask windows and `POST /admin/resolve-defaults` at each cutoff (infra config).
 - **Capacity / release** — seat caps + releasing a declined seat to standby (E6).

--- a/docs/features/reservations.md
+++ b/docs/features/reservations.md
@@ -1,6 +1,6 @@
 # Daily ride confirmation (reservations)
 
-**Owner:** Godfred Awuku · **Last updated:** 2026-07-05 · **Issue:** #101 (epic E3)
+**Owner:** Godfred Awuku · **Last updated:** 2026-07-08 · **Issue:** #101 (epic E3)
 
 The **daily confirmation loop** of the Hybrid Subscription Model (ADR-0014). Each
 travel day the rider is asked "travelling tomorrow morning?" / "this evening?";
@@ -8,11 +8,19 @@ they confirm or decline, and a **no-response defaults to travelling** at the
 cutoff. A reservation is what boarding (E4) verifies against and what the standby
 pool (E6) fills when declined.
 
-> **Scope shipped (E3-core):** the reservation lifecycle + the rider's
-> confirm/decline API + the default-yes operation. **Deferred to when trips (#18)
-> land:** the scheduled _ask-dispatch_ (which seeds `pending` rows for tomorrow's
-> trips and sends the FCM push) and seat **capacity / release** to standby. So
-> `trip_id` carries **no FK yet** (same as `scan_events`).
+> **Scope shipped (E3):** the reservation lifecycle + the rider's confirm/decline
+> API + the default-yes operation (E3-core), **plus the scheduled _ask-dispatch_**
+> — now that trips (#18) have landed, the loop seeds `pending` rows for tomorrow's
+> route trips and sends the (fake, until FCM) prompt, and a cutoff trigger runs
+> the default-yes. **Still deferred:** the real **FCM push** (needs the Firebase
+> service account, #88–90), seat **capacity / release** to standby (E6), and the
+> **cron schedule** itself (Render infra hits the admin triggers below). So
+> `trip_id` still carries **no FK yet** (same as `scan_events`).
+
+**Rider ↔ route (the pilot model).** A rider is linked to a corridor by their
+**subscription**: at checkout the chosen `route_id` is threaded through the
+payment and **pins the subscription** on activation (`subscriptions.route_id`).
+Ask-dispatch targets a trip's riders via `findActiveByRoute(trip.routeId)`.
 
 ---
 
@@ -53,22 +61,39 @@ The rider's reservations, newest travel day first.
 
 - **200:** `{ "reservations": [ … ] }`
 
+#### `POST /admin/ask-dispatch` · `POST /admin/resolve-defaults`
+
+The scheduled loop's two triggers — a Render cron hits these with an **admin**
+token: `ask-dispatch` in the ask window, `resolve-defaults` at the cutoff.
+
+- **Auth:** `Bearer` **admin**. **Rate limit:** per user.
+- **Body:** `{ "travelDate": "YYYY-MM-DD", "direction": "morning"|"evening" }`
+- **ask-dispatch → 200:** `{ "trips": <n>, "asked": <n> }` — for each scheduled
+  trip of that day+direction, seed a `pending` reservation for every active
+  subscriber of the trip's route and push the "travelling?" prompt. Idempotent
+  (re-running leaves existing rows untouched). A trip's direction comes from its
+  scheduled time (before noon UTC → morning) — a pilot heuristic, same as the
+  boarding scan.
+- **resolve-defaults → 200:** `{ "defaulted": <n> }` — `markDefaultTravelling`.
+- **401** · **403** (non-admin) · **503** (unwired) · **429**
+
 ---
 
 ## Data
 
 `reservations(id, user_id, trip_id, travel_date, direction, status, source,
 confirmed_at, created_at, updated_at)`, unique `(user_id, travel_date,
-direction)`. `trip_id` has no FK yet (trips are #18).
+direction)`. `trip_id` has no FK yet (trips are #18). Rider↔route lives on
+`subscriptions.route_id` / `payments.route_id` (migration `019`).
 
-## Deferred (with #18)
+## Deferred
 
-- **Ask-dispatch cron** — for each subscribed rider on tomorrow's trips, seed a
-  `pending` row (`createPending`) and send the FCM prompt; run
-  `markDefaultTravelling` at each cutoff. Needs trips + capacity.
-- **FCM push** — the notification sender (Firebase Admin) — needs the Firebase
-  service account (adomfosugit, #88–90).
-- **Deduction** — a confirmed no-show / a boarding consumes a ride (E4).
+- **FCM push** — swap `FakeNotificationSender` for the Firebase Admin sender —
+  needs the Firebase service account (adomfosugit, #88–90). The `ask-dispatch`
+  loop is built and sends via the fake sender until then.
+- **Cron schedule** — the Render cron that hits `POST /admin/ask-dispatch` at the
+  ask windows and `POST /admin/resolve-defaults` at each cutoff (infra config).
+- **Capacity / release** — seat caps + releasing a declined seat to standby (E6).
 
 ## Where the code lives
 
@@ -78,7 +103,12 @@ services/api/src/modules/reservations/
                                    # markDefaultTravelling, listForUser, find
   reservations.routes.ts           # POST /me/reservations, GET /me/reservations
   reservations.schema.ts
+services/api/src/modules/notifications/
+  ask-dispatch.service.ts          # dispatchAsks + resolveDefaults (the loop)
+  ask-dispatch.routes.ts           # POST /admin/ask-dispatch, /resolve-defaults
+  notification.sender.ts           # NotificationSender + FakeNotificationSender
 services/api/src/db/migrations/013_reservations.sql
+services/api/src/db/migrations/019_subscription_route.sql   # rider↔route pin
 ```
 
 ## Related

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,6 +110,9 @@ importers:
       fastify-type-provider-zod:
         specifier: ^4.0.2
         version: 4.0.2(fastify@5.8.5)(zod@3.25.76)
+      firebase-admin:
+        specifier: ^14.1.0
+        version: 14.1.0
       ioredis:
         specifier: ^5.11.1
         version: 5.11.1
@@ -809,6 +812,58 @@ packages:
   '@fastify/swagger@9.7.0':
     resolution: {integrity: sha512-Vp1SC1GC2Hrkd3faFILv86BzUNyFz5N4/xdExqtCgkGASOzn/x+eMe4qXIGq7cdT6wif/P/oa6r1Ruqx19paZA==}
 
+  '@firebase/app-check-interop-types@0.3.4':
+    resolution: {integrity: sha512-zz3i6e13B8BfWiLy8MABtTh8aGIACgKbf9UVnyHcWs+yQzJXgQcl8A46b0zfaiJHdQ+niF0ouAfcpuf+3LMPQg==}
+
+  '@firebase/app-types@0.9.5':
+    resolution: {integrity: sha512-YevqTjvo7Iujsa9Dwowmd6dSoElhzmD63ZSrq6bzjvQ6POjYgNjOFHLmNIgJs48eNO093NCERibuFnxbfOvU7A==}
+
+  '@firebase/auth-interop-types@0.2.5':
+    resolution: {integrity: sha512-1Li/YuBDBAXcKv7BzY4U28gontUmAaw53sYiqbaVOMCFb2lFKK/c3CGMUWqtwe7+TXrl3poWnTCL5umYBg85Eg==}
+
+  '@firebase/component@0.7.3':
+    resolution: {integrity: sha512-wFofIaa2879ogD/WvkjYXJxRmfnL0scen6ORgaC3na1FNOR9ASIUANQdhqQcmWu/h77/pVHY7ch5flewa5Bcew==}
+    engines: {node: '>=20.0.0'}
+
+  '@firebase/database-compat@2.1.4':
+    resolution: {integrity: sha512-3pK35F1MAgmqFJQlf2nhQl44vtAXQO1uaCaQOEUI9kCRtLFqi7N+QRKR7lFZPg+xIZIyubgxQaxY69YgfZRZWg==}
+    engines: {node: '>=20.0.0'}
+
+  '@firebase/database-types@1.0.20':
+    resolution: {integrity: sha512-kegbOk/w8iU64pr0q6k2ItyNGjnQBMHFhwS7ohdWI4W+pc0/zhhdGXTdFj6X1oxItRjPoYOsSQmERgBkn/ihxw==}
+
+  '@firebase/database@1.1.3':
+    resolution: {integrity: sha512-XwWCa+E4TvNGpGwXrycLRNfdogADwFcvuhyow6wDWma9W54roaQIhe+4PM0KiLsIftBdSCGI7OKCXrdSRHbIhw==}
+    engines: {node: '>=20.0.0'}
+
+  '@firebase/logger@0.5.1':
+    resolution: {integrity: sha512-vZKLsqE1ABOy8OjQiE7cUTFn4gvaqlk88yp8N94Pk/sDpq61YqZGqmVFZTvOyflTwuYFcWirBdYGoJgbDaXKYQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@firebase/util@1.15.1':
+    resolution: {integrity: sha512-LUdM4Wg7YM9Pq/49nGYySJA0CSQEKnGffFzWV8+6gXN7mGxn+FL1IqvFbuZUtAQcfZgHYDwCE1wwlK7rB7gl2g==}
+    engines: {node: '>=20.0.0'}
+
+  '@google-cloud/firestore@8.6.0':
+    resolution: {integrity: sha512-TdvZHfwQj5B5CSDEgDqyrhdVqtOSupmBXDQPasMAJiC64tjsGvyMooNiC43fdk1TsUHeklyoZ6/vQ1TjWKVMbg==}
+    engines: {node: '>=18'}
+
+  '@google-cloud/paginator@5.0.2':
+    resolution: {integrity: sha512-DJS3s0OVH4zFDB1PzjxAsHqJT6sKVbRwwML0ZBP9PbU7Yebtu/7SWMRzvO2J3nUi9pRNITCfu4LJeooM2w4pjg==}
+    engines: {node: '>=14.0.0'}
+
+  '@google-cloud/projectify@4.0.0':
+    resolution: {integrity: sha512-MmaX6HeSvyPbWGwFq7mXdo0uQZLGBYCwziiLIGq5JVX+/bdI3SAq6bP98trV5eTWfLuvsMcIC1YJOF2vfteLFA==}
+    engines: {node: '>=14.0.0'}
+
+  '@google-cloud/promisify@4.0.0':
+    resolution: {integrity: sha512-Orxzlfb9c67A15cq2JQEyVc7wEsmFBmHjZWZYQMUyJ1qivXyMwdyNOs9odi79hze+2zqdTtu1E19IM/FtqZ10g==}
+    engines: {node: '>=14'}
+
+  '@google-cloud/storage@7.21.0':
+    resolution: {integrity: sha512-l+IFTkd+6Y5LoAuXyYCKNAKtw/Ci+rAMqgdTB1jv4iZiLhw0rtq+0qjIRbBizXkNzEFmXiXUW0H7sZQQvk1ffA==}
+    engines: {node: '>=14'}
+
   '@grpc/grpc-js@1.14.4':
     resolution: {integrity: sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==}
     engines: {node: '>=12.10.0'}
@@ -1084,6 +1139,9 @@ packages:
         optional: true
       '@nestjs/websockets':
         optional: true
+
+  '@nodable/entities@2.2.0':
+    resolution: {integrity: sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==}
 
   '@nuxtjs/opencollective@0.3.2':
     resolution: {integrity: sha512-um0xL3fO7Mf4fDxcqx9KryrB7zgRM5JSlvGN5AGkP6JLM5XEKyjeAiPbNxdXVXQ16isuAhYpvP88NgL2BGd6aA==}
@@ -1532,11 +1590,24 @@ packages:
   '@tokenizer/token@0.3.0':
     resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
 
+  '@tootallnate/once@2.0.1':
+    resolution: {integrity: sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==}
+    engines: {node: '>= 10'}
+
+  '@types/caseless@0.12.5':
+    resolution: {integrity: sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==}
+
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/jsonwebtoken@9.0.10':
+    resolution: {integrity: sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
   '@types/mute-stream@0.0.4':
     resolution: {integrity: sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==}
@@ -1555,6 +1626,12 @@ packages:
 
   '@types/pg@8.20.0':
     resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
+
+  '@types/request@2.48.13':
+    resolution: {integrity: sha512-FGJ6udDNUCjd19pp0Q3iTiDkwhYup7J8hpMW9c4k53NrccQFFWKRho6hvtPPEhnXWKvukfwAlB6DbDz4yhH5Gg==}
+
+  '@types/tough-cookie@4.0.5':
+    resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
 
   '@types/wrap-ansi@3.0.0':
     resolution: {integrity: sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==}
@@ -1656,6 +1733,10 @@ packages:
   '@vitest/utils@2.1.9':
     resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
 
+  abort-controller@3.0.0:
+    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
+    engines: {node: '>=6.5'}
+
   abstract-logging@2.0.1:
     resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
 
@@ -1677,6 +1758,10 @@ packages:
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
+
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
 
   agent-base@9.0.0:
     resolution: {integrity: sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==}
@@ -1723,12 +1808,19 @@ packages:
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
+  anynum@1.0.1:
+    resolution: {integrity: sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==}
+
   are-docs-informative@0.0.2:
     resolution: {integrity: sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==}
     engines: {node: '>=14'}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  arrify@2.0.1:
+    resolution: {integrity: sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==}
+    engines: {node: '>=8'}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -1737,6 +1829,9 @@ packages:
   ast-types@0.13.4:
     resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
     engines: {node: '>=4'}
+
+  async-retry@1.3.3:
+    resolution: {integrity: sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==}
 
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
@@ -1758,9 +1853,15 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   basic-ftp@5.3.1:
     resolution: {integrity: sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==}
     engines: {node: '>=10.0.0'}
+
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
   bintrees@1.0.2:
     resolution: {integrity: sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==}
@@ -1777,6 +1878,9 @@ packages:
   brace-expansion@5.0.6:
     resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   bundle-require@5.1.0:
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
@@ -1915,6 +2019,10 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
+
   data-uri-to-buffer@8.0.0:
     resolution: {integrity: sha512-6UHfyCux51b8PTGDgveqtz1tvphBku5DrMKKJbFAZAJOI2zsjDpDoYE1+QGj7FOMS4BdTFNJsJiR3zEB0xH0yQ==}
     engines: {node: '>= 20'}
@@ -1968,11 +2076,17 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  duplexify@4.1.3:
+    resolution: {integrity: sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==}
+
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
   easy-table@1.1.0:
     resolution: {integrity: sha512-oq33hWOSSnl2Hoh00tZWaIPi1ievrD9aFG82/IgjlycAnW9hHx5PkJiXpxPsgEE+H7BsbVQXFVFST8TEXS6/pA==}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
@@ -1982,6 +2096,9 @@ packages:
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
@@ -2105,12 +2222,23 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  event-target-shim@5.0.1:
+    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
+    engines: {node: '>=6'}
+
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
   expect-type@1.4.0:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
+  farmhash-modern@1.1.0:
+    resolution: {integrity: sha512-6ypT4XfgqJk/F3Yuv4SX26I3doUjt0GTG4a+JgWxXQpxXzTBq8fPUeGHfcYMMDPHJHm3yPOSjaeBwBGAHWXCdA==}
+    engines: {node: '>=18.0.0'}
 
   fast-decode-uri-component@1.0.1:
     resolution: {integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==}
@@ -2136,6 +2264,13 @@ packages:
   fast-uri@3.1.2:
     resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
+  fast-xml-builder@1.2.1:
+    resolution: {integrity: sha512-tPb5TTWfgfVx5BNSi2xV0eLr89POeXXn0dXIsCJ9m1narrWxeIyx6je9d7Rce/3NyXLbvuQmLkxq+RuxMWejvw==}
+
+  fast-xml-parser@5.9.3:
+    resolution: {integrity: sha512-brCNCeScma/kqa54J4PIDriSSSLssRkuYaUCpvHJulGc3HGI/xxKUCTDcYkAdqJsyb//ydpbxecjC3hB9+tb/g==}
+    hasBin: true
+
   fastify-plugin@5.1.0:
     resolution: {integrity: sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==}
 
@@ -2158,6 +2293,10 @@ packages:
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
+  faye-websocket@0.11.4:
+    resolution: {integrity: sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==}
+    engines: {node: '>=0.8.0'}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -2166,6 +2305,10 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
 
   figures@3.2.0:
     resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
@@ -2186,6 +2329,10 @@ packages:
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
+
+  firebase-admin@14.1.0:
+    resolution: {integrity: sha512-GdHh6vHWm9LVRt+3hINWczaA7fPwnN/l4xZdqzn+wNPYErrLI1x6u1mvAJM/5IGgYI9EqQgLt1EyBG8ok/hWCg==}
+    engines: {node: '>=22'}
 
   fix-dts-default-cjs-exports@1.0.1:
     resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
@@ -2210,9 +2357,17 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
+  form-data@2.5.6:
+    resolution: {integrity: sha512-Ogz/E85h9tlfJzpI6TuFpGcHZFhLrb9Gw8wq9v40CxSCPnv7ahKr6Xgtkn0KYCDQJ8DNn5VoMO8EXr9V5PadyA==}
+    engines: {node: '>= 0.12'}
+
   form-data@4.0.6:
     resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
+
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
 
   forwarded-parse@2.1.2:
     resolution: {integrity: sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==}
@@ -2233,6 +2388,33 @@ packages:
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  functional-red-black-tree@1.0.1:
+    resolution: {integrity: sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==}
+
+  gaxios@6.7.1:
+    resolution: {integrity: sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==}
+    engines: {node: '>=14'}
+
+  gaxios@7.1.3:
+    resolution: {integrity: sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==}
+    engines: {node: '>=18'}
+
+  gaxios@7.1.6:
+    resolution: {integrity: sha512-aIQ0QL8Or8vsUhHyXGA6AohOFRrAAiHhrvsAG6myzcSlfhxSXtnwXA/pRuQTilFgjhLe30swK5rg1d7E1f8Izw==}
+    engines: {node: '>=18'}
+
+  gcp-metadata@6.1.1:
+    resolution: {integrity: sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==}
+    engines: {node: '>=14'}
+
+  gcp-metadata@8.1.2:
+    resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
+    engines: {node: '>=18'}
+
+  gcp-metadata@8.1.3:
+    resolution: {integrity: sha512-ziTrzUhhpL9Zk5k0HHzgP/KIpWDJT0VMBC/ynt/QIBvTW+UUcSivQRl6VlwTf/EilDxtSWklHoRsKy1c4k+59w==}
+    engines: {node: '>=18'}
 
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
@@ -2275,12 +2457,44 @@ packages:
     resolution: {integrity: sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==}
     engines: {node: '>=18'}
 
+  google-auth-library@10.5.0:
+    resolution: {integrity: sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==}
+    engines: {node: '>=18'}
+
+  google-auth-library@10.9.0:
+    resolution: {integrity: sha512-xtvUqvINPhTaBm7nXqlYPcrMHJPm1lCNdSovxnKKhTm+4JsvQ+KGVYJViLoH9Yxu8w+T0Qv5HubzYT9BLrppJg==}
+    engines: {node: '>=18'}
+
+  google-auth-library@9.15.1:
+    resolution: {integrity: sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==}
+    engines: {node: '>=14'}
+
+  google-gax@5.0.7:
+    resolution: {integrity: sha512-EhiqaWWJ+9h7sCcKJTsoo6tMcjokVHhWsbSuWCnZJT4vIBP3y4mAoFLnt9SzgkVZeq24ZsFaArr06nnYYku2yA==}
+    engines: {node: '>=18'}
+
+  google-logging-utils@0.0.2:
+    resolution: {integrity: sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==}
+    engines: {node: '>=14'}
+
+  google-logging-utils@1.1.3:
+    resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
+    engines: {node: '>=14'}
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  gtoken@7.1.0:
+    resolution: {integrity: sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==}
+    engines: {node: '>=14.0.0'}
+
+  gtoken@8.0.0:
+    resolution: {integrity: sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==}
+    engines: {node: '>=18'}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -2308,6 +2522,17 @@ packages:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
 
+  http-parser-js@0.5.10:
+    resolution: {integrity: sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==}
+
+  http-proxy-agent@5.0.0:
+    resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
+    engines: {node: '>= 6'}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
   http-proxy-agent@9.1.0:
     resolution: {integrity: sha512-2NxoveTT58mjYT4n3RPTEfCZGLMbidoO8XEieXfpSYxu+PQJ1qpx4ypwH6N+uF9twBPIvRRgvkvW5HUTYWENig==}
     engines: {node: '>= 20'}
@@ -2315,6 +2540,10 @@ packages:
   https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
     engines: {node: '>= 6'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
 
   https-proxy-agent@9.1.0:
     resolution: {integrity: sha512-ag87y7cJJ9/3+GxFr8Oy4O5faDsGRGnBGsJj/YjOSsSx/5eadKLYTMPlzuR6obgoCDDm0abAAZitXXQkMOPSpA==}
@@ -2383,6 +2612,13 @@ packages:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
+  is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
+
+  is-unsafe@1.0.1:
+    resolution: {integrity: sha512-CLK2+VdgERgD96EYm5lUQssZYlRg2tkZnbsxZoacmSiRxiFJ4Nk4SzjCl+Ur+v3kXIY9dTIdb3IH22y1mZ56LA==}
+
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
@@ -2424,6 +2660,9 @@ packages:
     resolution: {integrity: sha512-dh140MMgjyg3JhJZY/+iEzW+NO5xR2gpbDFKHqotCmexElVntw7GjWjt511+C/Ef02RU5TKYrJo/Xlzk+OLaTw==}
     engines: {node: '>=20.0.0'}
 
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
+
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
@@ -2446,6 +2685,20 @@ packages:
   jsonfile@6.2.1:
     resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
 
+  jsonwebtoken@9.0.3:
+    resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
+    engines: {node: '>=12', npm: '>=6'}
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jwks-rsa@4.1.0:
+    resolution: {integrity: sha512-sbkByqyATKYJP5F4RXj03N5TUNC0QLTjCAZvwTzC4BwJZ8e0/cWxN8YROnyUth2g1/ONWi4eSFHeu6oYalrc3Q==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >= 23.0.0}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -2459,6 +2712,9 @@ packages:
   lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
     engines: {node: '>=14'}
+
+  limiter@1.1.5:
+    resolution: {integrity: sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA==}
 
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
@@ -2487,8 +2743,32 @@ packages:
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
 
+  lodash.clonedeep@4.5.0:
+    resolution: {integrity: sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==}
+
+  lodash.includes@4.3.0:
+    resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
+
+  lodash.isboolean@3.0.3:
+    resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
+
+  lodash.isinteger@4.0.4:
+    resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}
+
+  lodash.isnumber@3.0.3:
+    resolution: {integrity: sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==}
+
+  lodash.isplainobject@4.0.6:
+    resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
+
+  lodash.isstring@4.0.1:
+    resolution: {integrity: sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==}
+
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  lodash.once@4.1.1:
+    resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
 
   log-update@6.1.0:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
@@ -2510,6 +2790,9 @@ packages:
   lru-cache@7.18.3:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
     engines: {node: '>=12'}
+
+  lru-memoizer@3.0.0:
+    resolution: {integrity: sha512-m83w/cYXLdUIboKSPxzPAGfYnk+vqeDYXuoSrQRw1q+yVEd8IXhvMufN8Q5TIPe7e2jyX4SRNrDJI2Skw1yznQ==}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -2585,6 +2868,11 @@ packages:
     resolution: {integrity: sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==}
     engines: {node: '>= 0.4.0'}
 
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
   node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
     engines: {node: 4.x || >=6.0.0}
@@ -2594,6 +2882,10 @@ packages:
       encoding:
         optional: true
 
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -2601,9 +2893,16 @@ packages:
   object-deep-merge@2.0.1:
     resolution: {integrity: sha512-aKttDKcU3pyZqKcCkDhsMn70WmZFG2JGDQLP9EcLyTSIFQRCPWLAmBZRLJnrVUrhPG1jETEEbfdgbNtJf1LyMg==}
 
+  object-hash@3.0.0:
+    resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
+    engines: {node: '>= 6'}
+
   on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
@@ -2650,6 +2949,10 @@ packages:
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
+
+  path-expression-matcher@1.6.1:
+    resolution: {integrity: sha512-h7bxdzhHk8Knyc4Tj+jMaa7fEEoUJy7p1qtbVgkYg1Uhpe5Np5VuGXCRZnkZvU+Q42M1vStt0ifa3ueykRJPmQ==}
+    engines: {node: '>=14.0.0'}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -2801,6 +3104,10 @@ packages:
     resolution: {integrity: sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==}
     engines: {node: ^16 || ^18 || >=20}
 
+  proto3-json-serializer@3.0.4:
+    resolution: {integrity: sha512-E1sbAYg3aEbXrq0n1ojJkRHQJGE1kaE/O6GLA94y8rnJBfgvOPTOd1b9hOceQK1FFZI9qMh1vBERCyO2ifubcw==}
+    engines: {node: '>=18'}
+
   protobufjs@7.6.4:
     resolution: {integrity: sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==}
     engines: {node: '>=12.0.0'}
@@ -2835,6 +3142,10 @@ packages:
   raw-body@3.0.2:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
 
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
@@ -2890,12 +3201,28 @@ packages:
     resolution: {integrity: sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==}
     engines: {node: '>=10'}
 
+  retry-request@7.0.2:
+    resolution: {integrity: sha512-dUOvLMJ0/JJYEn8NrpOaGNE7X3vpI5XlZS/u0ANjqtcZVKnIxP7IgCFwrKTxENw29emmwug53awKtaMm4i9g5w==}
+    engines: {node: '>=14'}
+
+  retry-request@8.0.3:
+    resolution: {integrity: sha512-qqoc4kkGgP9cmQDWELlOpAmfgJOg0Yi7MT82ZjiPWu451ayju4itwomjM4/dBEliify8C1b3tSaeCOldugtwPQ==}
+    engines: {node: '>=18'}
+
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
+
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
+
+  rimraf@5.0.10:
+    resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
+    hasBin: true
 
   rollup@4.62.2:
     resolution: {integrity: sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==}
@@ -2908,6 +3235,9 @@ packages:
 
   rxjs@7.8.2:
     resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
   safe-regex2@5.1.1:
     resolution: {integrity: sha512-mOSBvHGDZMuIEZMdOz/aCEYDCv0E7nfcNsIhUF+/P+xC7Hyf3FkvymqgPbg9D1EdSGu+uKbJgy09K/RKKc7kJA==}
@@ -3026,6 +3356,12 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
+  stream-events@1.0.5:
+    resolution: {integrity: sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==}
+
+  stream-shift@1.0.3:
+    resolution: {integrity: sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==}
+
   string-argv@0.3.2:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
     engines: {node: '>=0.6.19'}
@@ -3046,6 +3382,9 @@ packages:
     resolution: {integrity: sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==}
     engines: {node: '>=20'}
 
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
@@ -3058,9 +3397,15 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
+  strnum@2.4.1:
+    resolution: {integrity: sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==}
+
   strtok3@10.3.5:
     resolution: {integrity: sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==}
     engines: {node: '>=18'}
+
+  stubs@3.0.0:
+    resolution: {integrity: sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==}
 
   sucrase@3.35.1:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
@@ -3077,6 +3422,14 @@ packages:
 
   tdigest@0.1.2:
     resolution: {integrity: sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==}
+
+  teeny-request@10.1.3:
+    resolution: {integrity: sha512-5yDliI1uWkYPo7W+Zvrxg6YmoWuj5iC5EydewqrRTvc68nyMTZhlPPlLg6cptUGfbQAb+N9XDPDPzF6N081lug==}
+    engines: {node: '>=18'}
+
+  teeny-request@9.0.0:
+    resolution: {integrity: sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g==}
+    engines: {node: '>=14'}
 
   test-exclude@7.0.2:
     resolution: {integrity: sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==}
@@ -3226,6 +3579,14 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  uuid@9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    hasBin: true
+
   vite-node@2.1.9:
     resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -3290,8 +3651,20 @@ packages:
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
 
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
+
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  websocket-driver@0.7.5:
+    resolution: {integrity: sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==}
+    engines: {node: '>=0.8.0'}
+
+  websocket-extensions@0.1.4:
+    resolution: {integrity: sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==}
+    engines: {node: '>=0.8.0'}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -3329,6 +3702,13 @@ packages:
   wrap-ansi@9.0.2:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  xml-naming@0.1.0:
+    resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
+    engines: {node: '>=16.0.0'}
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -3927,6 +4307,95 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@firebase/app-check-interop-types@0.3.4': {}
+
+  '@firebase/app-types@0.9.5':
+    dependencies:
+      '@firebase/logger': 0.5.1
+
+  '@firebase/auth-interop-types@0.2.5': {}
+
+  '@firebase/component@0.7.3':
+    dependencies:
+      '@firebase/util': 1.15.1
+      tslib: 2.8.1
+
+  '@firebase/database-compat@2.1.4':
+    dependencies:
+      '@firebase/component': 0.7.3
+      '@firebase/database': 1.1.3
+      '@firebase/database-types': 1.0.20
+      '@firebase/logger': 0.5.1
+      '@firebase/util': 1.15.1
+      tslib: 2.8.1
+
+  '@firebase/database-types@1.0.20':
+    dependencies:
+      '@firebase/app-types': 0.9.5
+      '@firebase/util': 1.15.1
+
+  '@firebase/database@1.1.3':
+    dependencies:
+      '@firebase/app-check-interop-types': 0.3.4
+      '@firebase/auth-interop-types': 0.2.5
+      '@firebase/component': 0.7.3
+      '@firebase/logger': 0.5.1
+      '@firebase/util': 1.15.1
+      faye-websocket: 0.11.4
+      tslib: 2.8.1
+
+  '@firebase/logger@0.5.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@firebase/util@1.15.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@google-cloud/firestore@8.6.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      fast-deep-equal: 3.1.3
+      functional-red-black-tree: 1.0.1
+      google-gax: 5.0.7
+      protobufjs: 7.6.4
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  '@google-cloud/paginator@5.0.2':
+    dependencies:
+      arrify: 2.0.1
+      extend: 3.0.2
+    optional: true
+
+  '@google-cloud/projectify@4.0.0':
+    optional: true
+
+  '@google-cloud/promisify@4.0.0':
+    optional: true
+
+  '@google-cloud/storage@7.21.0':
+    dependencies:
+      '@google-cloud/paginator': 5.0.2
+      '@google-cloud/projectify': 4.0.0
+      '@google-cloud/promisify': 4.0.0
+      abort-controller: 3.0.0
+      async-retry: 1.3.3
+      duplexify: 4.1.3
+      fast-xml-parser: 5.9.3
+      gaxios: 6.7.1
+      google-auth-library: 9.15.1
+      html-entities: 2.6.0
+      mime: 3.0.0
+      p-limit: 3.1.0
+      retry-request: 7.0.2
+      teeny-request: 9.0.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    optional: true
+
   '@grpc/grpc-js@1.14.4':
     dependencies:
       '@grpc/proto-loader': 0.8.1
@@ -4151,6 +4620,9 @@ snapshots:
       rxjs: 7.8.2
       tslib: 2.8.1
       uid: 2.0.2
+
+  '@nodable/entities@2.2.0':
+    optional: true
 
   '@nuxtjs/opencollective@0.3.2':
     dependencies:
@@ -4654,9 +5126,22 @@ snapshots:
 
   '@tokenizer/token@0.3.0': {}
 
+  '@tootallnate/once@2.0.1':
+    optional: true
+
+  '@types/caseless@0.12.5':
+    optional: true
+
   '@types/estree@1.0.9': {}
 
   '@types/json-schema@7.0.15': {}
+
+  '@types/jsonwebtoken@9.0.10':
+    dependencies:
+      '@types/ms': 2.1.0
+      '@types/node': 26.0.1
+
+  '@types/ms@2.1.0': {}
 
   '@types/mute-stream@0.0.4':
     dependencies:
@@ -4685,6 +5170,17 @@ snapshots:
       '@types/node': 26.0.1
       pg-protocol: 1.15.0
       pg-types: 2.2.0
+
+  '@types/request@2.48.13':
+    dependencies:
+      '@types/caseless': 0.12.5
+      '@types/node': 26.0.1
+      '@types/tough-cookie': 4.0.5
+      form-data: 2.5.6
+    optional: true
+
+  '@types/tough-cookie@4.0.5':
+    optional: true
 
   '@types/wrap-ansi@3.0.0': {}
 
@@ -4837,6 +5333,11 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 1.2.0
 
+  abort-controller@3.0.0:
+    dependencies:
+      event-target-shim: 5.0.1
+    optional: true
+
   abstract-logging@2.0.1: {}
 
   acorn-import-attributes@1.9.5(acorn@8.17.0):
@@ -4854,6 +5355,8 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  agent-base@7.1.4: {}
 
   agent-base@9.0.0: {}
 
@@ -4895,15 +5398,26 @@ snapshots:
 
   any-promise@1.3.0: {}
 
+  anynum@1.0.1:
+    optional: true
+
   are-docs-informative@0.0.2: {}
 
   argparse@2.0.1: {}
+
+  arrify@2.0.1:
+    optional: true
 
   assertion-error@2.0.1: {}
 
   ast-types@0.13.4:
     dependencies:
       tslib: 2.8.1
+
+  async-retry@1.3.3:
+    dependencies:
+      retry: 0.13.1
+    optional: true
 
   asynckit@0.4.0: {}
 
@@ -4928,7 +5442,11 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
+  base64-js@1.5.1: {}
+
   basic-ftp@5.3.1: {}
+
+  bignumber.js@9.3.1: {}
 
   bintrees@1.0.2: {}
 
@@ -4946,6 +5464,8 @@ snapshots:
   brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
+
+  buffer-equal-constant-time@1.0.1: {}
 
   bundle-require@5.1.0(esbuild@0.27.7):
     dependencies:
@@ -5065,6 +5585,8 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  data-uri-to-buffer@4.0.1: {}
+
   data-uri-to-buffer@8.0.0: {}
 
   debug@4.4.3:
@@ -5103,17 +5625,34 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  duplexify@4.1.3:
+    dependencies:
+      end-of-stream: 1.4.5
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+      stream-shift: 1.0.3
+    optional: true
+
   eastasianwidth@0.2.0: {}
 
   easy-table@1.1.0:
     optionalDependencies:
       wcwidth: 1.0.1
 
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
+
   emoji-regex@10.6.0: {}
 
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
+    optional: true
 
   environment@1.1.0: {}
 
@@ -5334,9 +5873,16 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  event-target-shim@5.0.1:
+    optional: true
+
   eventemitter3@5.0.4: {}
 
   expect-type@1.4.0: {}
+
+  extend@3.0.2: {}
+
+  farmhash-modern@1.1.0: {}
 
   fast-decode-uri-component@1.0.1: {}
 
@@ -5362,6 +5908,22 @@ snapshots:
   fast-safe-stringify@2.1.1: {}
 
   fast-uri@3.1.2: {}
+
+  fast-xml-builder@1.2.1:
+    dependencies:
+      path-expression-matcher: 1.6.1
+      xml-naming: 0.1.0
+    optional: true
+
+  fast-xml-parser@5.9.3:
+    dependencies:
+      '@nodable/entities': 2.2.0
+      fast-xml-builder: 1.2.1
+      is-unsafe: 1.0.1
+      path-expression-matcher: 1.6.1
+      strnum: 2.4.1
+      xml-naming: 0.1.0
+    optional: true
 
   fastify-plugin@5.1.0: {}
 
@@ -5402,9 +5964,18 @@ snapshots:
     dependencies:
       reusify: 1.1.0
 
+  faye-websocket@0.11.4:
+    dependencies:
+      websocket-driver: 0.7.5
+
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
 
   figures@3.2.0:
     dependencies:
@@ -5434,6 +6005,23 @@ snapshots:
       locate-path: 6.0.0
       path-exists: 4.0.0
 
+  firebase-admin@14.1.0:
+    dependencies:
+      '@fastify/busboy': 3.2.0
+      '@firebase/database-compat': 2.1.4
+      '@firebase/database-types': 1.0.20
+      farmhash-modern: 1.1.0
+      fast-deep-equal: 3.1.3
+      google-auth-library: 10.9.0
+      jsonwebtoken: 9.0.3
+      jwks-rsa: 4.1.0
+    optionalDependencies:
+      '@google-cloud/firestore': 8.6.0
+      '@google-cloud/storage': 7.21.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
   fix-dts-default-cjs-exports@1.0.1:
     dependencies:
       magic-string: 0.30.21
@@ -5454,6 +6042,16 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
+  form-data@2.5.6:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.4
+      mime-types: 2.1.35
+      safe-buffer: 5.2.1
+    optional: true
+
   form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
@@ -5461,6 +6059,10 @@ snapshots:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.4
       mime-types: 2.1.35
+
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
 
   forwarded-parse@2.1.2: {}
 
@@ -5477,6 +6079,66 @@ snapshots:
     optional: true
 
   function-bind@1.1.2: {}
+
+  functional-red-black-tree@1.0.1:
+    optional: true
+
+  gaxios@6.7.1:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      is-stream: 2.0.1
+      node-fetch: 2.7.0
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    optional: true
+
+  gaxios@7.1.3:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+      rimraf: 5.0.10
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  gaxios@7.1.6:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - supports-color
+
+  gcp-metadata@6.1.1:
+    dependencies:
+      gaxios: 6.7.1
+      google-logging-utils: 0.0.2
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    optional: true
+
+  gcp-metadata@8.1.2:
+    dependencies:
+      gaxios: 7.1.6
+      google-logging-utils: 1.1.3
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  gcp-metadata@8.1.3:
+    dependencies:
+      gaxios: 7.1.3
+      google-logging-utils: 1.1.3
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
 
   get-caller-file@2.0.5: {}
 
@@ -5531,9 +6193,85 @@ snapshots:
 
   globals@15.15.0: {}
 
+  google-auth-library@10.5.0:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.1.6
+      gcp-metadata: 8.1.3
+      google-logging-utils: 1.1.3
+      gtoken: 8.0.0
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  google-auth-library@10.9.0:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.1.6
+      gcp-metadata: 8.1.2
+      google-logging-utils: 1.1.3
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  google-auth-library@9.15.1:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 6.7.1
+      gcp-metadata: 6.1.1
+      gtoken: 7.1.0
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    optional: true
+
+  google-gax@5.0.7:
+    dependencies:
+      '@grpc/grpc-js': 1.14.4
+      '@grpc/proto-loader': 0.8.1
+      duplexify: 4.1.3
+      google-auth-library: 10.5.0
+      google-logging-utils: 1.1.3
+      node-fetch: 3.3.2
+      object-hash: 3.0.0
+      proto3-json-serializer: 3.0.4
+      protobufjs: 7.6.4
+      retry-request: 8.0.3
+      rimraf: 5.0.10
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  google-logging-utils@0.0.2:
+    optional: true
+
+  google-logging-utils@1.1.3: {}
+
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
+
+  gtoken@7.1.0:
+    dependencies:
+      gaxios: 6.7.1
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    optional: true
+
+  gtoken@8.0.0:
+    dependencies:
+      gaxios: 7.1.6
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
 
   has-flag@4.0.0: {}
 
@@ -5559,6 +6297,25 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
+  http-parser-js@0.5.10: {}
+
+  http-proxy-agent@5.0.0:
+    dependencies:
+      '@tootallnate/once': 2.0.1
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   http-proxy-agent@9.1.0:
     dependencies:
       agent-base: 9.0.0
@@ -5571,6 +6328,13 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
@@ -5640,6 +6404,12 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
+  is-stream@2.0.1:
+    optional: true
+
+  is-unsafe@1.0.1:
+    optional: true
+
   isexe@2.0.0: {}
 
   istanbul-lib-coverage@3.2.2: {}
@@ -5681,6 +6451,10 @@ snapshots:
 
   jsdoc-type-pratt-parser@7.2.0: {}
 
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.1
+
   json-buffer@3.0.1: {}
 
   json-schema-ref-resolver@3.0.0:
@@ -5707,6 +6481,41 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
+  jsonwebtoken@9.0.3:
+    dependencies:
+      jws: 4.0.1
+      lodash.includes: 4.3.0
+      lodash.isboolean: 3.0.3
+      lodash.isinteger: 4.0.4
+      lodash.isnumber: 3.0.3
+      lodash.isplainobject: 4.0.6
+      lodash.isstring: 4.0.1
+      lodash.once: 4.1.1
+      ms: 2.1.3
+      semver: 7.8.5
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jwks-rsa@4.1.0:
+    dependencies:
+      '@types/jsonwebtoken': 9.0.10
+      debug: 4.4.3
+      jose: 6.2.3
+      limiter: 1.1.5
+      lru-cache: 11.5.1
+      lru-memoizer: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -5723,6 +6532,8 @@ snapshots:
       set-cookie-parser: 2.7.2
 
   lilconfig@3.1.3: {}
+
+  limiter@1.1.5: {}
 
   lines-and-columns@1.2.4: {}
 
@@ -5753,7 +6564,23 @@ snapshots:
 
   lodash.camelcase@4.3.0: {}
 
+  lodash.clonedeep@4.5.0: {}
+
+  lodash.includes@4.3.0: {}
+
+  lodash.isboolean@3.0.3: {}
+
+  lodash.isinteger@4.0.4: {}
+
+  lodash.isnumber@3.0.3: {}
+
+  lodash.isplainobject@4.0.6: {}
+
+  lodash.isstring@4.0.1: {}
+
   lodash.merge@4.6.2: {}
+
+  lodash.once@4.1.1: {}
 
   log-update@6.1.0:
     dependencies:
@@ -5772,6 +6599,11 @@ snapshots:
   lru-cache@11.5.1: {}
 
   lru-cache@7.18.3: {}
+
+  lru-memoizer@3.0.0:
+    dependencies:
+      lodash.clonedeep: 4.5.0
+      lru-cache: 11.5.1
 
   magic-string@0.30.21:
     dependencies:
@@ -5838,15 +6670,31 @@ snapshots:
 
   netmask@2.1.1: {}
 
+  node-domexception@1.0.0: {}
+
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
 
   object-assign@4.1.1: {}
 
   object-deep-merge@2.0.1: {}
 
+  object-hash@3.0.0:
+    optional: true
+
   on-exit-leak-free@2.1.2: {}
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+    optional: true
 
   onetime@7.0.0:
     dependencies:
@@ -5904,6 +6752,9 @@ snapshots:
   parse-statements@1.0.11: {}
 
   path-exists@4.0.0: {}
+
+  path-expression-matcher@1.6.1:
+    optional: true
 
   path-key@3.1.1: {}
 
@@ -6037,6 +6888,11 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       tdigest: 0.1.2
 
+  proto3-json-serializer@3.0.4:
+    dependencies:
+      protobufjs: 7.6.4
+    optional: true
+
   protobufjs@7.6.4:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
@@ -6082,6 +6938,13 @@ snapshots:
       iconv-lite: 0.7.2
       unpipe: 1.0.0
 
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+    optional: true
+
   readdirp@4.1.2: {}
 
   real-require@0.2.0: {}
@@ -6120,9 +6983,35 @@ snapshots:
 
   ret@0.5.0: {}
 
+  retry-request@7.0.2:
+    dependencies:
+      '@types/request': 2.48.13
+      extend: 3.0.2
+      teeny-request: 9.0.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    optional: true
+
+  retry-request@8.0.3:
+    dependencies:
+      extend: 3.0.2
+      teeny-request: 10.1.3
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  retry@0.13.1:
+    optional: true
+
   reusify@1.1.0: {}
 
   rfdc@1.4.1: {}
+
+  rimraf@5.0.10:
+    dependencies:
+      glob: 10.5.0
+    optional: true
 
   rollup@4.62.2:
     dependencies:
@@ -6160,6 +7049,8 @@ snapshots:
   rxjs@7.8.2:
     dependencies:
       tslib: 2.8.1
+
+  safe-buffer@5.2.1: {}
 
   safe-regex2@5.1.1:
     dependencies:
@@ -6279,6 +7170,14 @@ snapshots:
 
   std-env@3.10.0: {}
 
+  stream-events@1.0.5:
+    dependencies:
+      stubs: 3.0.0
+    optional: true
+
+  stream-shift@1.0.3:
+    optional: true
+
   string-argv@0.3.2: {}
 
   string-width@4.2.3:
@@ -6304,6 +7203,11 @@ snapshots:
       get-east-asian-width: 1.6.0
       strip-ansi: 7.2.0
 
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+    optional: true
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -6314,9 +7218,17 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  strnum@2.4.1:
+    dependencies:
+      anynum: 1.0.1
+    optional: true
+
   strtok3@10.3.5:
     dependencies:
       '@tokenizer/token': 0.3.0
+
+  stubs@3.0.0:
+    optional: true
 
   sucrase@3.35.1:
     dependencies:
@@ -6337,6 +7249,28 @@ snapshots:
   tdigest@0.1.2:
     dependencies:
       bintrees: 1.0.2
+
+  teeny-request@10.1.3:
+    dependencies:
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+      stream-events: 1.0.5
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  teeny-request@9.0.0:
+    dependencies:
+      http-proxy-agent: 5.0.0
+      https-proxy-agent: 5.0.1
+      node-fetch: 2.7.0
+      stream-events: 1.0.5
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    optional: true
 
   test-exclude@7.0.2:
     dependencies:
@@ -6473,6 +7407,12 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  util-deprecate@1.0.2:
+    optional: true
+
+  uuid@9.0.1:
+    optional: true
+
   vite-node@2.1.9(@types/node@26.0.1):
     dependencies:
       cac: 6.7.14
@@ -6540,7 +7480,17 @@ snapshots:
       defaults: 1.0.4
     optional: true
 
+  web-streams-polyfill@3.3.3: {}
+
   webidl-conversions@3.0.1: {}
+
+  websocket-driver@0.7.5:
+    dependencies:
+      http-parser-js: 0.5.10
+      safe-buffer: 5.2.1
+      websocket-extensions: 0.1.4
+
+  websocket-extensions@0.1.4: {}
 
   whatwg-url@5.0.0:
     dependencies:
@@ -6587,6 +7537,12 @@ snapshots:
       ansi-styles: 6.2.3
       string-width: 7.2.0
       strip-ansi: 7.2.0
+
+  wrappy@1.0.2:
+    optional: true
+
+  xml-naming@0.1.0:
+    optional: true
 
   xtend@4.0.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,9 @@ packages:
 # pnpm blocks dependency build scripts by default (supply-chain safety).
 # esbuild (used by tsup + vitest) needs its postinstall to fetch its binary.
 allowBuilds:
+  # firebase-admin (FCM push, E3) works from its prebuilt dist; @firebase/util's
+  # postinstall build script is not needed at runtime.
+  '@firebase/util': false
   '@openapitools/openapi-generator-cli': true
   esbuild: true
   # protobufjs (via the OTLP protobuf exporter) works at runtime from its

--- a/render.yaml
+++ b/render.yaml
@@ -11,6 +11,18 @@ databases:
     plan: free # NB: free Postgres expires ~30 days after creation
     region: frankfurt # closest Render region to Ghana
 
+# Shared config for the ask-dispatch cron jobs (E3). The cron mints a short-lived
+# admin token, so its JWT_SECRET MUST equal the web service's JWT_SECRET — set it
+# once here in the dashboard and all four crons inherit it. API_BASE_URL is the
+# public staging URL (not a secret).
+envVarGroups:
+  - name: trotxi-cron-staging
+    envVars:
+      - key: JWT_SECRET
+        sync: false # set in dashboard; MUST match trotxi-api-staging's JWT_SECRET
+      - key: API_BASE_URL
+        value: https://trotxi-api-staging.onrender.com
+
 services:
   - type: web
     name: trotxi-api-staging
@@ -66,6 +78,70 @@ services:
         sync: false
       - key: R2_BUCKET
         sync: false
+
+  # ---- Ask-dispatch cron jobs (E3) — the daily confirmation loop ----
+  # Each mints an admin token and POSTs a trigger on the deployed API. Windows are
+  # from docs/features/reservations.md; Ghana is UTC (GMT+0) so schedules are plain
+  # UTC. autoDeploy off — they redeploy with the API (GitHub Actions / manual).
+  # NB: on Render, cron jobs may require a paid instance type; bump `plan` if so.
+  # The free web service also sleeps when idle — the first trigger warms it (a
+  # slow cold start), which is fine for the pilot.
+  - type: cron
+    name: trotxi-ask-morning-staging
+    runtime: docker
+    repo: https://github.com/TROTXI/mobility-core
+    branch: main
+    dockerfilePath: services/api/Dockerfile
+    dockerContext: .
+    plan: free
+    region: frankfurt
+    autoDeploy: false
+    schedule: '0 18 * * *' # 18:00 — ask tomorrow-morning riders
+    dockerCommand: node dist/cron/ask-dispatch-cron.js ask morning
+    envVars:
+      - fromGroup: trotxi-cron-staging
+  - type: cron
+    name: trotxi-resolve-morning-staging
+    runtime: docker
+    repo: https://github.com/TROTXI/mobility-core
+    branch: main
+    dockerfilePath: services/api/Dockerfile
+    dockerContext: .
+    plan: free
+    region: frankfurt
+    autoDeploy: false
+    schedule: '0 21 * * *' # 21:00 cutoff — default-yes the still-pending (morning)
+    dockerCommand: node dist/cron/ask-dispatch-cron.js resolve morning
+    envVars:
+      - fromGroup: trotxi-cron-staging
+  - type: cron
+    name: trotxi-ask-evening-staging
+    runtime: docker
+    repo: https://github.com/TROTXI/mobility-core
+    branch: main
+    dockerfilePath: services/api/Dockerfile
+    dockerContext: .
+    plan: free
+    region: frankfurt
+    autoDeploy: false
+    schedule: '0 12 * * *' # 12:00 — ask this-evening riders
+    dockerCommand: node dist/cron/ask-dispatch-cron.js ask evening
+    envVars:
+      - fromGroup: trotxi-cron-staging
+  - type: cron
+    name: trotxi-resolve-evening-staging
+    runtime: docker
+    repo: https://github.com/TROTXI/mobility-core
+    branch: main
+    dockerfilePath: services/api/Dockerfile
+    dockerContext: .
+    plan: free
+    region: frankfurt
+    autoDeploy: false
+    schedule: '0 14 * * *' # 14:00 cutoff — default-yes the still-pending (evening)
+    dockerCommand: node dist/cron/ask-dispatch-cron.js resolve evening
+    envVars:
+      - fromGroup: trotxi-cron-staging
 
   # ---- Production (uncomment when going live) ----
   # Needs a paid Postgres plan so data doesn't expire. After applying, set the

--- a/render.yaml
+++ b/render.yaml
@@ -47,6 +47,11 @@ services:
       # Render dashboard; never commit it. Generate: openssl rand -base64 48
       - key: JWT_SECRET
         sync: false
+      # Firebase service-account key JSON (FCM push, E3). A SECRET → paste the
+      # whole JSON as the value in the dashboard, never commit. Unset -> the
+      # recording fake sender runs (no real push).
+      - key: FIREBASE_SERVICE_ACCOUNT
+        sync: false
       # Google "Web" OAuth client ID — the audience verified on sign-in. This is
       # PUBLIC (a Web client ID ships in clients; only a client *secret* would be
       # sensitive, and we don't use one), so it lives in the blueprint, not the

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "dev": "tsx watch src/server.ts",
     "start": "node --import ./dist/observability/tracing.live.js dist/server.js",
-    "build": "tsup src/server.ts src/observability/tracing.live.ts --format esm --clean",
+    "build": "tsup src/server.ts src/observability/tracing.live.ts src/cron/ask-dispatch-cron.ts --format esm --clean",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -42,6 +42,7 @@
     "fastify-plugin": "^6.0.0",
     "fastify-raw-body": "^5.0.0",
     "fastify-type-provider-zod": "^4.0.2",
+    "firebase-admin": "^14.1.0",
     "ioredis": "^5.11.1",
     "jose": "^6.2.3",
     "pg": "^8.13.1",

--- a/services/api/src/app.ts
+++ b/services/api/src/app.ts
@@ -35,6 +35,12 @@ import {
   InMemoryReservationRepository,
   type ReservationRepository,
 } from './modules/reservations/reservation.repository';
+import { askDispatchRoutes } from './modules/notifications/ask-dispatch.routes';
+import { AskDispatchService } from './modules/notifications/ask-dispatch.service';
+import {
+  FakeNotificationSender,
+  type NotificationSender,
+} from './modules/notifications/notification.sender';
 import { paymentRoutes } from './modules/payments/payments.routes';
 import type { PaymentsService } from './modules/payments/payments.service';
 import { authPlugin } from './modules/auth/auth.plugin';
@@ -99,6 +105,8 @@ export interface AppDeps {
   credits?: CreditLedgerRepository;
   /** Daily reservation store (in-memory vs Postgres). Defaults to in-memory. */
   reservations?: ReservationRepository;
+  /** Push notification sender (FCM in prod, recording fake in dev/tests). */
+  notifier?: NotificationSender;
   /** Feature flags (#27). Read by public GET /flags; ops-managed via /admin/flags. */
   featureFlags?: FeatureFlagRepository;
   /** Per-platform min supported version (#27) — the apps' force-update floor. */
@@ -224,6 +232,22 @@ export async function buildApp(deps: AppDeps = {}): Promise<FastifyInstance> {
   await app.register(reservationRoutes, {
     reservations,
     secret: authConfig.secret,
+    rateLimit: deps.rateLimit ?? DEFAULT_RATE_LIMIT,
+  });
+  // Ask-dispatch (E3): only wired when trips + subscriptions are available (the
+  // route 503s otherwise). The notifier defaults to the recording fake until the
+  // Firebase service account lands.
+  const notifier = deps.notifier ?? new FakeNotificationSender();
+  await app.register(askDispatchRoutes, {
+    askDispatch:
+      deps.trips && deps.subscriptions
+        ? new AskDispatchService({
+            trips: deps.trips,
+            subscriptions: deps.subscriptions,
+            reservations,
+            notifier,
+          })
+        : undefined,
     rateLimit: deps.rateLimit ?? DEFAULT_RATE_LIMIT,
   });
   await app.register(boardingRoutes, {

--- a/services/api/src/config/env.ts
+++ b/services/api/src/config/env.ts
@@ -22,6 +22,10 @@ const envSchema = z
     // Paystack SECRET key (sk_...). Used for the API + webhook signature check.
     // Set -> real payments; unset -> dev fake client (non-prod) / 503 (prod).
     PAYSTACK_SECRET_KEY: z.string().optional(),
+    // Firebase Cloud Messaging (push, E3). The service-account key JSON (owned by
+    // the FE lane, #88-90). Set -> real FCM sender; unset -> recording fake
+    // (dev/tests). A secret -> Render dashboard only, never committed.
+    FIREBASE_SERVICE_ACCOUNT: z.string().optional(),
     // Cloudflare R2 (avatars, #24). All four set -> real R2; any unset ->
     // in-memory Fake object store (dev/tests). Secrets -> Render dashboard only.
     R2_ACCOUNT_ID: z.string().optional(),

--- a/services/api/src/cron/ask-dispatch-cron.ts
+++ b/services/api/src/cron/ask-dispatch-cron.ts
@@ -1,0 +1,77 @@
+// Ask-dispatch cron entrypoint (E3). A Render cron job runs this at each
+// confirmation window: it mints a short-lived admin token from JWT_SECRET (auth
+// is stateless — no user row needed) and POSTs the deployed API's admin trigger.
+// Two actions x two directions (schedules live in render.yaml):
+//   ask morning  (18:00) -> prompt tomorrow-morning riders   cutoff resolve 21:00
+//   ask evening  (12:00) -> prompt this-evening riders        cutoff resolve 14:00
+// Ghana runs on UTC (GMT+0), so the cron schedules are plain UTC, no offset.
+
+import { createJwtService, type AuthConfig } from '../modules/auth/jwt';
+
+type Action = 'ask' | 'resolve';
+type Direction = 'morning' | 'evening';
+
+const PATH_FOR: Record<Action, string> = {
+  ask: '/admin/ask-dispatch',
+  resolve: '/admin/resolve-defaults',
+};
+
+// Morning is asked (and defaulted) the evening BEFORE, for tomorrow; evening is
+// asked midday, for today. So the target travel day is tomorrow for morning and
+// today for evening — the trip's own scheduled time still decides its direction.
+function travelDateFor(direction: Direction, now: Date): string {
+  const d = new Date(now);
+  if (direction === 'morning') d.setUTCDate(d.getUTCDate() + 1);
+  return d.toISOString().slice(0, 10);
+}
+
+function parseArgs(argv: readonly string[]): { action: Action; direction: Direction } {
+  const [action, direction] = argv;
+  if (
+    (action !== 'ask' && action !== 'resolve') ||
+    (direction !== 'morning' && direction !== 'evening')
+  ) {
+    throw new Error(
+      `usage: ask-dispatch-cron <ask|resolve> <morning|evening> (got: "${argv.join(' ')}")`,
+    );
+  }
+  return { action, direction };
+}
+
+async function main(): Promise<void> {
+  const { action, direction } = parseArgs(process.argv.slice(2));
+
+  const secret = process.env.JWT_SECRET;
+  const baseUrl = process.env.API_BASE_URL;
+  if (!secret) throw new Error('JWT_SECRET is required');
+  if (!baseUrl) throw new Error('API_BASE_URL is required');
+
+  const auth: AuthConfig = {
+    secret,
+    accessTtl: '5m',
+    issuer: process.env.JWT_ISSUER ?? 'trotxi',
+    audience: process.env.JWT_AUDIENCE ?? 'trotxi-api',
+  };
+  const token = await createJwtService(auth).signAccessToken({
+    userId: 'cron-ask-dispatch',
+    role: 'admin',
+  });
+
+  const travelDate = travelDateFor(direction, new Date());
+  const url = `${baseUrl.replace(/\/$/, '')}${PATH_FOR[action]}`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+    body: JSON.stringify({ travelDate, direction }),
+  });
+  const body = await res.text();
+  if (!res.ok) {
+    throw new Error(`${action} ${direction} ${travelDate} -> HTTP ${res.status}: ${body}`);
+  }
+  console.log(`ask-dispatch cron: ${action} ${direction} ${travelDate} -> ${res.status} ${body}`);
+}
+
+main().catch((err: unknown) => {
+  console.error('ask-dispatch cron failed:', err);
+  process.exit(1);
+});

--- a/services/api/src/db/migrations/019_subscription_route.sql
+++ b/services/api/src/db/migrations/019_subscription_route.sql
@@ -1,0 +1,9 @@
+-- 019_subscription_route: pin a subscription to a route/corridor (ADR-0014, E3).
+-- The rider picks their corridor at subscribe; the daily ask-dispatch prompts
+-- every active subscriber of tomorrow's trip's route. route_id rides through the
+-- payment (set at checkout) and is applied to the subscription on activation.
+-- Nullable: pre-E3 subscriptions have none, and the ask-dispatch simply skips
+-- routeless subscribers.
+ALTER TABLE subscriptions ADD COLUMN IF NOT EXISTS route_id uuid REFERENCES routes (id) ON DELETE SET NULL;
+ALTER TABLE payments ADD COLUMN IF NOT EXISTS route_id uuid;
+CREATE INDEX IF NOT EXISTS idx_subscriptions_route ON subscriptions (route_id) WHERE status = 'active';

--- a/services/api/src/modules/notifications/ask-dispatch.routes.ts
+++ b/services/api/src/modules/notifications/ask-dispatch.routes.ts
@@ -1,0 +1,84 @@
+// Ask-dispatch trigger endpoints (E3). A scheduled Render cron hits these with
+// an admin token at the confirmation windows: `ask-dispatch` in the ask window
+// (evening for tomorrow morning; midday for the evening) and `resolve-defaults`
+// at the cutoff. Admin-role gated, like the rest of the ops surface (#26).
+
+import type { FastifyInstance } from 'fastify';
+import type { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { errorResponseSchema } from '../../lib/schemas';
+import type { RateLimitConfig } from '../ratelimit/ratelimit.plugin';
+import type { AskDispatchService } from './ask-dispatch.service';
+import {
+  askDispatchBodySchema,
+  askDispatchResponseSchema,
+  resolveDefaultsBodySchema,
+  resolveDefaultsResponseSchema,
+} from './ask-dispatch.schema';
+
+/**
+ * Register the ask-dispatch triggers: `POST /admin/ask-dispatch` and
+ * `POST /admin/resolve-defaults`.
+ *
+ * @param app - the Fastify instance to register on.
+ * @param opts - route dependencies.
+ * @param opts.askDispatch - the ask-dispatch service (503 when unwired).
+ * @param opts.rateLimit - rate-limit config (per user).
+ */
+export async function askDispatchRoutes(
+  app: FastifyInstance,
+  opts: { askDispatch?: AskDispatchService; rateLimit: RateLimitConfig },
+): Promise<void> {
+  const r = app.withTypeProvider<ZodTypeProvider>();
+  const UNAVAILABLE = { error: 'unavailable', message: 'Ask-dispatch is not configured' };
+  const adminOnly = [
+    app.authenticate,
+    app.rateLimit({ ...opts.rateLimit, by: 'user' }),
+    app.requireRole('admin'),
+  ];
+
+  r.post(
+    '/admin/ask-dispatch',
+    {
+      schema: {
+        tags: ['admin'],
+        summary: "Prompt a day's route subscribers to confirm (seed pending + push)",
+        security: [{ bearerAuth: [] }],
+        body: askDispatchBodySchema,
+        response: {
+          200: askDispatchResponseSchema,
+          401: errorResponseSchema,
+          403: errorResponseSchema,
+          503: errorResponseSchema,
+        },
+      },
+      preHandler: adminOnly,
+    },
+    async (request, reply) => {
+      if (!opts.askDispatch) return reply.code(503).send(UNAVAILABLE);
+      return opts.askDispatch.dispatchAsks(request.body.travelDate, request.body.direction);
+    },
+  );
+
+  r.post(
+    '/admin/resolve-defaults',
+    {
+      schema: {
+        tags: ['admin'],
+        summary: 'Cutoff default-yes: flip still-pending reservations to reserved',
+        security: [{ bearerAuth: [] }],
+        body: resolveDefaultsBodySchema,
+        response: {
+          200: resolveDefaultsResponseSchema,
+          401: errorResponseSchema,
+          403: errorResponseSchema,
+          503: errorResponseSchema,
+        },
+      },
+      preHandler: adminOnly,
+    },
+    async (request, reply) => {
+      if (!opts.askDispatch) return reply.code(503).send(UNAVAILABLE);
+      return opts.askDispatch.resolveDefaults(request.body.travelDate, request.body.direction);
+    },
+  );
+}

--- a/services/api/src/modules/notifications/ask-dispatch.schema.ts
+++ b/services/api/src/modules/notifications/ask-dispatch.schema.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod';
+
+const dateAndDirection = {
+  travelDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'expected YYYY-MM-DD'),
+  direction: z.enum(['morning', 'evening']),
+};
+
+export const askDispatchBodySchema = z.object(dateAndDirection);
+export const resolveDefaultsBodySchema = z.object(dateAndDirection);
+
+export const askDispatchResponseSchema = z.object({
+  trips: z.number().int(),
+  asked: z.number().int(),
+});
+
+export const resolveDefaultsResponseSchema = z.object({
+  defaulted: z.number().int(),
+});

--- a/services/api/src/modules/notifications/ask-dispatch.service.ts
+++ b/services/api/src/modules/notifications/ask-dispatch.service.ts
@@ -1,0 +1,100 @@
+// Daily ask-dispatch (E3) — the scheduled heart of the confirmation loop. For a
+// travel day + direction, it finds tomorrow's trips, seeds a `pending`
+// reservation for every active subscriber of each trip's route, and pushes the
+// "travelling?" prompt. At the cutoff, resolveDefaults flips the still-`pending`
+// rows to reserved (default-yes). These are the operations a Render cron invokes
+// (via the admin endpoints); the cron schedule itself is infra.
+//
+// A rider is linked to a route by their subscription (ADR-0014 / the pilot
+// rider↔route model): confirm at subscribe → the route pins the subscription →
+// this targets those subscribers.
+
+import type { TripRepository } from '../mobility/trip.repository';
+import type {
+  ReservationDirection,
+  ReservationRepository,
+} from '../reservations/reservation.repository';
+import type { SubscriptionRepository } from '../subscriptions/subscription.repository';
+import type { NotificationSender } from './notification.sender';
+
+/** Collaborators for {@link AskDispatchService}. */
+export interface AskDispatchDeps {
+  trips: TripRepository;
+  subscriptions: SubscriptionRepository;
+  reservations: ReservationRepository;
+  notifier: NotificationSender;
+}
+
+/** How many riders were prompted, across how many trips. */
+export interface AskDispatchResult {
+  trips: number;
+  asked: number;
+}
+
+// A trip's direction from its scheduled time — morning before noon, else evening
+// (UTC). Pilot heuristic, consistent with the boarding scan; converges when
+// trips carry an explicit direction.
+function directionOf(scheduledAt: Date): ReservationDirection {
+  return scheduledAt.getUTCHours() < 12 ? 'morning' : 'evening';
+}
+
+/** The daily ask-dispatch + cutoff default-yes (see the file header). */
+export class AskDispatchService {
+  /** @param deps - the trip, subscription, reservation stores + the notifier. */
+  constructor(private readonly deps: AskDispatchDeps) {}
+
+  /**
+   * Prompt every active subscriber of each of the day's trips (for the given
+   * direction): seed a `pending` reservation and push the "travelling?" ask.
+   * Idempotent — re-running leaves existing reservations untouched (createPending
+   * no-ops a duplicate day+direction).
+   *
+   * @param travelDate - the travel day (`YYYY-MM-DD`).
+   * @param direction - morning or evening (matches the trip's scheduled time).
+   * @returns how many trips were dispatched and riders prompted.
+   */
+  async dispatchAsks(
+    travelDate: string,
+    direction: ReservationDirection,
+  ): Promise<AskDispatchResult> {
+    const trips = (await this.deps.trips.findAll({ date: travelDate, status: 'scheduled' })).filter(
+      (t) => directionOf(t.scheduledAt) === direction,
+    );
+    const label = direction === 'morning' ? 'tomorrow morning' : 'this evening';
+    let asked = 0;
+    for (const trip of trips) {
+      const subs = await this.deps.subscriptions.findActiveByRoute(trip.routeId);
+      for (const sub of subs) {
+        await this.deps.reservations.createPending({
+          userId: sub.userId,
+          tripId: trip.id,
+          travelDate,
+          direction,
+        });
+        await this.deps.notifier.send({
+          userId: sub.userId,
+          title: `Travelling ${label}?`,
+          body: 'Tap to confirm your seat, or decline to release it.',
+          data: { tripId: trip.id, travelDate, direction },
+        });
+        asked++;
+      }
+    }
+    return { trips: trips.length, asked };
+  }
+
+  /**
+   * Cutoff default-yes: flip every still-`pending` reservation for the
+   * day+direction to `reserved` (a no-response is treated as travelling).
+   *
+   * @param travelDate - the travel day (`YYYY-MM-DD`).
+   * @param direction - morning or evening.
+   * @returns how many reservations were defaulted.
+   */
+  async resolveDefaults(
+    travelDate: string,
+    direction: ReservationDirection,
+  ): Promise<{ defaulted: number }> {
+    return { defaulted: await this.deps.reservations.markDefaultTravelling(travelDate, direction) };
+  }
+}

--- a/services/api/src/modules/notifications/notification.sender.live.ts
+++ b/services/api/src/modules/notifications/notification.sender.live.ts
@@ -1,0 +1,72 @@
+// Firebase Cloud Messaging sender — the real backend behind NotificationSender.
+// Looks up a user's registered device tokens (#84) and delivers a multicast
+// push, pruning tokens FCM reports as permanently dead. Wired only when
+// FIREBASE_SERVICE_ACCOUNT is set (server.ts); dev/tests use the fake. Excluded
+// from unit coverage (needs a real Firebase project), like the other *.live/.pg
+// integrations.
+
+import { cert, getApps, initializeApp, type App } from 'firebase-admin/app';
+import { getMessaging, type Messaging } from 'firebase-admin/messaging';
+import type { DeviceTokenRepository } from '../devices/device-token.repository';
+import type { Notification, NotificationSender } from './notification.sender';
+
+// FCM error codes that mean the token is gone for good (app uninstalled, token
+// rotated) — prune these so we stop delivering to them.
+const DEAD_TOKEN_CODES = new Set([
+  'messaging/registration-token-not-registered',
+  'messaging/invalid-registration-token',
+  'messaging/invalid-argument',
+]);
+
+/** {@link NotificationSender} backed by Firebase Cloud Messaging. */
+export class FcmNotificationSender implements NotificationSender {
+  constructor(
+    private readonly deviceTokens: DeviceTokenRepository,
+    private readonly messaging: Messaging,
+  ) {}
+
+  async send(notification: Notification): Promise<void> {
+    const tokens = (await this.deviceTokens.listForUser(notification.userId)).map(
+      (t) => t.fcmToken,
+    );
+    if (tokens.length === 0) return;
+    try {
+      const res = await this.messaging.sendEachForMulticast({
+        tokens,
+        notification: { title: notification.title, body: notification.body },
+        data: notification.data,
+      });
+      await Promise.all(
+        res.responses.map(async (r, i) => {
+          const token = tokens[i];
+          if (r.success || token === undefined) return;
+          if (r.error && DEAD_TOKEN_CODES.has(r.error.code)) {
+            await this.deviceTokens.removeByToken(token);
+          }
+        }),
+      );
+    } catch (err) {
+      // Best-effort (per the interface): a transport/auth failure must not abort
+      // the ask-dispatch loop — the seeded reservation is the durable unit.
+      console.warn(`[notify] FCM send to ${notification.userId} failed:`, err);
+    }
+  }
+}
+
+/**
+ * Build an FCM sender from a service-account JSON string (the
+ * `FIREBASE_SERVICE_ACCOUNT` Render secret). Initializes the Firebase Admin app
+ * once and reuses it on subsequent calls.
+ *
+ * @param serviceAccountJson - the service-account key JSON (a secret).
+ * @param deviceTokens - the device-token registry to fan out to.
+ * @returns an FCM-backed {@link NotificationSender}.
+ */
+export function createFcmSender(
+  serviceAccountJson: string,
+  deviceTokens: DeviceTokenRepository,
+): FcmNotificationSender {
+  const app: App =
+    getApps()[0] ?? initializeApp({ credential: cert(JSON.parse(serviceAccountJson)) });
+  return new FcmNotificationSender(deviceTokens, getMessaging(app));
+}

--- a/services/api/src/modules/notifications/notification.sender.ts
+++ b/services/api/src/modules/notifications/notification.sender.ts
@@ -1,8 +1,8 @@
 // Push notifications (E3). A seam over the delivery channel: the daily
-// ask-dispatch calls send(); the real backend is Firebase Cloud Messaging, which
-// needs the Firebase service account (owned by the FE lane, #88–90) — not wired
-// yet. Until then the Fake records + logs, so the ask-dispatch flow is fully
-// exercisable and the real sender drops in behind this interface later.
+// ask-dispatch calls send(). The real backend is Firebase Cloud Messaging
+// (notification.sender.live.ts), wired when FIREBASE_SERVICE_ACCOUNT is set; the
+// Fake below records + logs for dev/tests so the ask-dispatch flow is fully
+// exercisable without a network.
 
 /** A push to one user (fanned out to their registered devices by the sender). */
 export interface Notification {

--- a/services/api/src/modules/notifications/notification.sender.ts
+++ b/services/api/src/modules/notifications/notification.sender.ts
@@ -1,0 +1,36 @@
+// Push notifications (E3). A seam over the delivery channel: the daily
+// ask-dispatch calls send(); the real backend is Firebase Cloud Messaging, which
+// needs the Firebase service account (owned by the FE lane, #88–90) — not wired
+// yet. Until then the Fake records + logs, so the ask-dispatch flow is fully
+// exercisable and the real sender drops in behind this interface later.
+
+/** A push to one user (fanned out to their registered devices by the sender). */
+export interface Notification {
+  userId: string;
+  title: string;
+  body: string;
+  /** Small key/value payload the app reads on tap (e.g. tripId, travelDate). */
+  data?: Record<string, string>;
+}
+
+/** Delivers push notifications (FCM in prod, a recording fake in dev/tests). */
+export interface NotificationSender {
+  /**
+   * Send a push to a user's devices. Best-effort: implementations must not throw
+   * on a delivery failure (a dead token can't fail the ask-dispatch).
+   *
+   * @param notification - who to notify and what to say.
+   */
+  send(notification: Notification): Promise<void>;
+}
+
+/** Recording {@link NotificationSender} for dev and unit tests (no network). */
+export class FakeNotificationSender implements NotificationSender {
+  /** Everything "sent", for assertions and dev inspection. */
+  readonly sent: Notification[] = [];
+
+  async send(notification: Notification): Promise<void> {
+    this.sent.push(notification);
+    console.log(`[notify] → ${notification.userId}: ${notification.title}`);
+  }
+}

--- a/services/api/src/modules/payments/payment.repository.pg.ts
+++ b/services/api/src/modules/payments/payment.repository.pg.ts
@@ -14,6 +14,7 @@ interface PaymentRow {
   reference: string;
   purpose: PaymentPurpose;
   plan: SubscriptionPlan | null;
+  route_id: string | null;
   amount: number;
   currency: string;
   status: PaymentStatus;
@@ -28,6 +29,7 @@ function toPayment(row: PaymentRow): Payment {
     reference: row.reference,
     purpose: row.purpose,
     plan: row.plan,
+    routeId: row.route_id,
     amount: row.amount,
     currency: row.currency,
     status: row.status,
@@ -41,10 +43,18 @@ export class PgPaymentRepository implements PaymentRepository {
 
   async create(input: NewPayment): Promise<Payment> {
     const { rows } = await this.pool.query<PaymentRow>(
-      `INSERT INTO payments (user_id, reference, purpose, plan, amount, currency)
-       VALUES ($1, $2, $3, $4, $5, $6)
+      `INSERT INTO payments (user_id, reference, purpose, plan, route_id, amount, currency)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)
        RETURNING *`,
-      [input.userId, input.reference, input.purpose, input.plan, input.amount, input.currency],
+      [
+        input.userId,
+        input.reference,
+        input.purpose,
+        input.plan,
+        input.routeId ?? null,
+        input.amount,
+        input.currency,
+      ],
     );
     return toPayment(rows[0]!);
   }

--- a/services/api/src/modules/payments/payment.repository.ts
+++ b/services/api/src/modules/payments/payment.repository.ts
@@ -22,6 +22,8 @@ export interface Payment {
   purpose: PaymentPurpose;
   /** Set for subscription payments; null for top-ups. */
   plan: SubscriptionPlan | null;
+  /** The route the rider is subscribing to (E3); carried to the subscription on activation. */
+  routeId: string | null;
   /** Amount in pesewas (1 GHS = 100 pesewas). */
   amount: number;
   /** ISO 4217 currency code (currently always `GHS`). */
@@ -38,6 +40,7 @@ export interface NewPayment {
   reference: string;
   purpose: PaymentPurpose;
   plan: SubscriptionPlan | null;
+  routeId?: string | null;
   /** Amount in pesewas (1 GHS = 100 pesewas). */
   amount: number;
   currency: string;
@@ -79,6 +82,7 @@ export class InMemoryPaymentRepository implements PaymentRepository {
       reference: input.reference,
       purpose: input.purpose,
       plan: input.plan,
+      routeId: input.routeId ?? null,
       amount: input.amount,
       currency: input.currency,
       status: 'pending',

--- a/services/api/src/modules/payments/payments.routes.ts
+++ b/services/api/src/modules/payments/payments.routes.ts
@@ -64,6 +64,7 @@ export async function paymentRoutes(
         return await opts.paymentsService.initializeSubscription(
           request.user!.id,
           request.body.plan,
+          request.body.routeId,
         );
       } catch (err) {
         if (err instanceof PaymentsNotConfiguredError) return reply.code(503).send(UNAVAILABLE);

--- a/services/api/src/modules/payments/payments.schema.ts
+++ b/services/api/src/modules/payments/payments.schema.ts
@@ -7,6 +7,9 @@ const PLANS = ['monthly', 'annual'] as const satisfies readonly SubscriptionPlan
 
 export const subscribeBodySchema = z.object({
   plan: z.enum(PLANS),
+  /** The route/corridor the rider commutes (E3); pins the subscription so the
+   * daily ask-dispatch knows which riders to prompt. Optional for now. */
+  routeId: z.string().uuid().optional(),
 });
 
 export const checkoutResponseSchema = z.object({

--- a/services/api/src/modules/payments/payments.service.ts
+++ b/services/api/src/modules/payments/payments.service.ts
@@ -105,14 +105,21 @@ export class PaymentsService {
    *
    * @param userId - the authenticated user subscribing.
    * @param plan - membership tier (`monthly` | `annual`); selects the fee.
+   * @param routeId - the rider's pinned route/corridor (E3), carried to the
+   *   subscription on activation.
    * @returns the Paystack `authorizationUrl` and our payment `reference`.
    * @throws PaymentsNotConfiguredError when no Paystack client is wired.
    */
-  async initializeSubscription(userId: string, plan: SubscriptionPlan): Promise<CheckoutResult> {
+  async initializeSubscription(
+    userId: string,
+    plan: SubscriptionPlan,
+    routeId?: string | null,
+  ): Promise<CheckoutResult> {
     return this.startCheckout({
       userId,
       purpose: 'subscription',
       plan,
+      routeId: routeId ?? null,
       amount: this.deps.subscriptionFees[plan],
       currency: 'GHS',
     });
@@ -170,9 +177,9 @@ export class PaymentsService {
     if (!payment) return; // unknown reference — not ours
 
     if (payment.purpose === 'subscription' && payment.plan) {
-      // Membership fee paid — activate the subscription and allocate the
-      // period's rides. Both are idempotent, so a replayed webhook is a no-op.
-      await this.activateSubscription(payment.userId, payment.plan);
+      // Membership fee paid — activate the subscription (pinned to the paid
+      // route) and allocate the period's rides. Both idempotent → replay-safe.
+      await this.activateSubscription(payment.userId, payment.plan, payment.routeId);
       await this.allocateEntitlement(payment.userId, reference);
     }
     // Legacy 'topup' payments (pre-ADR-0014 staging data) are ignored.
@@ -204,10 +211,15 @@ export class PaymentsService {
    *
    * @param userId - the subscriber.
    * @param plan - the membership tier to activate.
+   * @param routeId - the rider's pinned route/corridor (E3).
    */
-  private async activateSubscription(userId: string, plan: SubscriptionPlan): Promise<void> {
+  private async activateSubscription(
+    userId: string,
+    plan: SubscriptionPlan,
+    routeId: string | null,
+  ): Promise<void> {
     try {
-      await this.deps.subscriptions.create({ userId, plan });
+      await this.deps.subscriptions.create({ userId, plan, routeId });
     } catch (err) {
       // one-active-per-user index fired — already activated, treat as done.
       if (!isUniqueViolation(err)) throw err;

--- a/services/api/src/modules/subscriptions/subscription.repository.pg.ts
+++ b/services/api/src/modules/subscriptions/subscription.repository.pg.ts
@@ -12,6 +12,7 @@ interface SubscriptionRow {
   user_id: string;
   plan: SubscriptionPlan;
   status: SubscriptionStatus;
+  route_id: string | null;
   created_at: Date;
 }
 
@@ -21,6 +22,7 @@ function toSubscription(row: SubscriptionRow): Subscription {
     userId: row.user_id,
     plan: row.plan,
     status: row.status,
+    routeId: row.route_id,
     createdAt: row.created_at,
   };
 }
@@ -28,13 +30,13 @@ function toSubscription(row: SubscriptionRow): Subscription {
 export class PgSubscriptionRepository implements SubscriptionRepository {
   constructor(private readonly pool: Pool) {}
 
-  /** Creates a new subscription for a user with the given plan. Status defaults to 'active'. */
+  /** Creates a new subscription for a user with the given plan + route. Status defaults to 'active'. */
   async create(input: NewSubscription): Promise<Subscription> {
     const { rows } = await this.pool.query<SubscriptionRow>(
-      `INSERT INTO subscriptions (user_id, plan)
-       VALUES ($1, $2)
+      `INSERT INTO subscriptions (user_id, plan, route_id)
+       VALUES ($1, $2, $3)
        RETURNING *`,
-      [input.userId, input.plan],
+      [input.userId, input.plan, input.routeId ?? null],
     );
     return toSubscription(rows[0]!);
   }
@@ -46,5 +48,14 @@ export class PgSubscriptionRepository implements SubscriptionRepository {
       [userId],
     );
     return rows[0] ? toSubscription(rows[0]) : null;
+  }
+
+  /** Active subscriptions pinned to a route (E3 ask-dispatch targets). */
+  async findActiveByRoute(routeId: string): Promise<Subscription[]> {
+    const { rows } = await this.pool.query<SubscriptionRow>(
+      `SELECT * FROM subscriptions WHERE route_id = $1 AND status = 'active'`,
+      [routeId],
+    );
+    return rows.map(toSubscription);
   }
 }

--- a/services/api/src/modules/subscriptions/subscription.repository.ts
+++ b/services/api/src/modules/subscriptions/subscription.repository.ts
@@ -7,6 +7,8 @@ export interface Subscription {
   userId: string;
   plan: SubscriptionPlan;
   status: SubscriptionStatus;
+  /** The rider's pinned route/corridor (E3); null for pre-E3 subscriptions. */
+  routeId: string | null;
   createdAt: Date;
 }
 
@@ -14,6 +16,7 @@ export interface Subscription {
 export interface NewSubscription {
   userId: string;
   plan: SubscriptionPlan;
+  routeId?: string | null;
 }
 
 /** Persistence for memberships; one active subscription per user. */
@@ -21,7 +24,7 @@ export interface SubscriptionRepository {
   /**
    * Create a subscription (active).
    *
-   * @param input - the user and plan to subscribe.
+   * @param input - the user, plan, and pinned route.
    * @returns the persisted subscription.
    * @throws on a unique-violation if the user already has an active subscription.
    */
@@ -33,6 +36,14 @@ export interface SubscriptionRepository {
    * @returns the active subscription, or null.
    */
   findActiveByUser(userId: string): Promise<Subscription | null>;
+  /**
+   * Active subscriptions pinned to a route — who the ask-dispatch prompts for
+   * that route's trips (E3).
+   *
+   * @param routeId - the route/corridor.
+   * @returns the active subscriptions on that route.
+   */
+  findActiveByRoute(routeId: string): Promise<Subscription[]>;
 }
 
 /** In-memory {@link SubscriptionRepository} for dev and unit tests. */
@@ -45,6 +56,7 @@ export class InMemorySubscriptionRepository implements SubscriptionRepository {
       userId: input.userId,
       plan: input.plan,
       status: 'active',
+      routeId: input.routeId ?? null,
       createdAt: new Date(),
     };
     this.subscriptions.set(subscription.id, subscription);
@@ -58,5 +70,11 @@ export class InMemorySubscriptionRepository implements SubscriptionRepository {
       }
     }
     return null;
+  }
+
+  async findActiveByRoute(routeId: string): Promise<Subscription[]> {
+    return Array.from(this.subscriptions.values()).filter(
+      (s) => s.status === 'active' && s.routeId === routeId,
+    );
   }
 }

--- a/services/api/src/server.ts
+++ b/services/api/src/server.ts
@@ -61,6 +61,11 @@ import {
   type DeviceTokenRepository,
 } from './modules/devices/device-token.repository';
 import { PgDeviceTokenRepository } from './modules/devices/device-token.repository.pg';
+import {
+  FakeNotificationSender,
+  type NotificationSender,
+} from './modules/notifications/notification.sender';
+import { createFcmSender } from './modules/notifications/notification.sender.live';
 import { BoardingService } from './modules/boarding/boarding.service';
 import {
   InMemoryScanEventRepository,
@@ -266,6 +271,17 @@ async function main(): Promise<void> {
     ridesPerPeriod: PLACEHOLDER_RIDES_PER_PERIOD,
   });
 
+  // Push notifications (E3): real FCM when the service account is set, else the
+  // recording fake (harmless — logs; the ask-dispatch reservation is durable).
+  let notifier: NotificationSender;
+  if (env.FIREBASE_SERVICE_ACCOUNT) {
+    notifier = createFcmSender(env.FIREBASE_SERVICE_ACCOUNT, deviceTokens);
+    console.log('Using Firebase Cloud Messaging sender');
+  } else {
+    notifier = new FakeNotificationSender();
+    console.warn('FIREBASE_SERVICE_ACCOUNT not set — using recording fake notifier (no push).');
+  }
+
   // Readiness pings every configured backing service (DB + KV).
   const isReady = async (): Promise<boolean> => {
     if (pool) {
@@ -294,6 +310,7 @@ async function main(): Promise<void> {
     vehicles,
     drivers,
     deviceTokens,
+    notifier,
     boardingService,
     authService,
     paymentsService,

--- a/services/api/tests/ask-dispatch.test.ts
+++ b/services/api/tests/ask-dispatch.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest';
+import { buildApp } from '../src/app';
+import { AskDispatchService } from '../src/modules/notifications/ask-dispatch.service';
+import { FakeNotificationSender } from '../src/modules/notifications/notification.sender';
+import { InMemoryReservationRepository } from '../src/modules/reservations/reservation.repository';
+import { InMemorySubscriptionRepository } from '../src/modules/subscriptions/subscription.repository';
+import { InMemoryTripRepository } from '../src/modules/mobility/trip.repository';
+import { createJwtService, type AuthConfig } from '../src/modules/auth/jwt';
+
+const auth: AuthConfig = {
+  secret: 'test-secret-at-least-32-characters-long-0000',
+  accessTtl: '15m',
+  issuer: 'trotxi',
+  audience: 'trotxi-api',
+};
+const jwt = createJwtService(auth);
+const bearer = (t: string) => ({ authorization: `Bearer ${t}` });
+const ROUTE_A = crypto.randomUUID();
+const ROUTE_B = crypto.randomUUID();
+const TOMORROW = new Date(Date.now() + 86_400_000).toISOString().slice(0, 10);
+const at = (hhmm: string) => new Date(`${TOMORROW}T${hhmm}:00Z`);
+
+/** trips + subs + reservations wired to an ask-dispatch service. */
+function make() {
+  const trips = new InMemoryTripRepository();
+  const subscriptions = new InMemorySubscriptionRepository();
+  const reservations = new InMemoryReservationRepository();
+  const notifier = new FakeNotificationSender();
+  const svc = new AskDispatchService({ trips, subscriptions, reservations, notifier });
+  return { trips, subscriptions, reservations, notifier, svc };
+}
+
+describe('AskDispatchService.dispatchAsks', () => {
+  it('prompts every active subscriber of the day’s route trips (seed pending + notify)', async () => {
+    const { trips, subscriptions, reservations, notifier, svc } = make();
+    await trips.create({ routeId: ROUTE_A, scheduledAt: at('06:30') }); // morning trip on A
+    await subscriptions.create({ userId: 'ama', plan: 'monthly', routeId: ROUTE_A });
+    await subscriptions.create({ userId: 'kofi', plan: 'monthly', routeId: ROUTE_A });
+    await subscriptions.create({ userId: 'other', plan: 'monthly', routeId: ROUTE_B }); // different route
+
+    const res = await svc.dispatchAsks(TOMORROW, 'morning');
+    expect(res).toEqual({ trips: 1, asked: 2 });
+    expect(notifier.sent.map((n) => n.userId).sort()).toEqual(['ama', 'kofi']);
+    // each got a pending reservation tied to the trip
+    expect((await reservations.find('ama', TOMORROW, 'morning'))?.status).toBe('pending');
+    expect(await reservations.find('other', TOMORROW, 'morning')).toBeNull();
+  });
+
+  it('only dispatches trips matching the direction (morning vs evening)', async () => {
+    const { trips, subscriptions, svc, notifier } = make();
+    await trips.create({ routeId: ROUTE_A, scheduledAt: at('17:00') }); // evening trip
+    await subscriptions.create({ userId: 'ama', plan: 'monthly', routeId: ROUTE_A });
+
+    expect(await svc.dispatchAsks(TOMORROW, 'morning')).toEqual({ trips: 0, asked: 0 });
+    expect(await svc.dispatchAsks(TOMORROW, 'evening')).toEqual({ trips: 1, asked: 1 });
+    expect(notifier.sent).toHaveLength(1);
+  });
+
+  it('is idempotent — re-running does not double-seed or double-notify a rider', async () => {
+    const { trips, subscriptions, reservations, notifier, svc } = make();
+    await trips.create({ routeId: ROUTE_A, scheduledAt: at('06:30') });
+    await subscriptions.create({ userId: 'ama', plan: 'monthly', routeId: ROUTE_A });
+
+    await svc.dispatchAsks(TOMORROW, 'morning');
+    await svc.dispatchAsks(TOMORROW, 'morning'); // again
+    expect(await reservations.listForUser('ama')).toHaveLength(1); // one pending, not two
+    // (the notification best-effort re-sends; the reservation is the idempotent unit)
+    expect(notifier.sent.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('resolveDefaults flips still-pending reservations to reserved', async () => {
+    const { trips, subscriptions, reservations, svc } = make();
+    await trips.create({ routeId: ROUTE_A, scheduledAt: at('06:30') });
+    await subscriptions.create({ userId: 'ama', plan: 'monthly', routeId: ROUTE_A });
+    await svc.dispatchAsks(TOMORROW, 'morning'); // ama is pending
+
+    expect(await svc.resolveDefaults(TOMORROW, 'morning')).toEqual({ defaulted: 1 });
+    expect(await reservations.find('ama', TOMORROW, 'morning')).toMatchObject({
+      status: 'reserved',
+      source: 'default',
+    });
+  });
+});
+
+describe('POST /admin/ask-dispatch (+ resolve-defaults)', () => {
+  async function app() {
+    const trips = new InMemoryTripRepository();
+    const subscriptions = new InMemorySubscriptionRepository();
+    const reservations = new InMemoryReservationRepository();
+    await trips.create({ routeId: ROUTE_A, scheduledAt: at('06:30') });
+    await subscriptions.create({ userId: 'rider-x', plan: 'monthly', routeId: ROUTE_A });
+    const built = await buildApp({ auth, trips, subscriptions, reservations });
+    return { built, reservations };
+  }
+
+  it('requires the admin role (commuter → 403)', async () => {
+    const { built } = await app();
+    const token = await jwt.signAccessToken({ userId: 'u', role: 'commuter' });
+    const res = await built.inject({
+      method: 'POST',
+      url: '/admin/ask-dispatch',
+      headers: bearer(token),
+      payload: { travelDate: TOMORROW, direction: 'morning' },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('admin dispatches → rider gets a pending reservation → resolve defaults it', async () => {
+    const { built, reservations } = await app();
+    const admin = await jwt.signAccessToken({ userId: 'admin', role: 'admin' });
+
+    const dispatch = await built.inject({
+      method: 'POST',
+      url: '/admin/ask-dispatch',
+      headers: bearer(admin),
+      payload: { travelDate: TOMORROW, direction: 'morning' },
+    });
+    expect(dispatch.json()).toEqual({ trips: 1, asked: 1 });
+    expect((await reservations.find('rider-x', TOMORROW, 'morning'))?.status).toBe('pending');
+
+    const resolve = await built.inject({
+      method: 'POST',
+      url: '/admin/resolve-defaults',
+      headers: bearer(admin),
+      payload: { travelDate: TOMORROW, direction: 'morning' },
+    });
+    expect(resolve.json()).toEqual({ defaulted: 1 });
+    expect((await reservations.find('rider-x', TOMORROW, 'morning'))?.status).toBe('reserved');
+  });
+});

--- a/services/api/tests/payments.service.test.ts
+++ b/services/api/tests/payments.service.test.ts
@@ -80,6 +80,18 @@ describe('PaymentsService.handleWebhook', () => {
     expect((await payments.findByReference(reference))?.status).toBe('paid');
   });
 
+  it('pins the paid route onto the activated subscription (E3 rider↔route)', async () => {
+    const { service, subscriptions } = make();
+    const routeId = crypto.randomUUID();
+    const { reference } = await service.initializeSubscription('u1', 'monthly', routeId);
+    const { body, signature } = chargeSuccess(reference);
+
+    await service.handleWebhook(body, signature);
+
+    expect(await subscriptions.findActiveByUser('u1')).toMatchObject({ routeId });
+    expect(await subscriptions.findActiveByRoute(routeId)).toHaveLength(1);
+  });
+
   it('is idempotent — a replayed webhook does not double-activate or double-allocate', async () => {
     const { service, subscriptions, entitlements } = make();
     const { reference } = await service.initializeSubscription('u1', 'monthly');
@@ -106,6 +118,7 @@ describe('PaymentsService.handleWebhook', () => {
   it('treats a unique-violation on activation as already-active', async () => {
     const subscriptions: SubscriptionRepository = {
       findActiveByUser: async () => null,
+      findActiveByRoute: async () => [],
       create: async () => {
         throw Object.assign(new Error('dup'), { code: '23505' });
       },
@@ -119,6 +132,7 @@ describe('PaymentsService.handleWebhook', () => {
   it('propagates non-unique errors from activation', async () => {
     const subscriptions: SubscriptionRepository = {
       findActiveByUser: async () => null,
+      findActiveByRoute: async () => [],
       create: async () => {
         throw new Error('db down');
       },

--- a/services/api/vitest.config.ts
+++ b/services/api/vitest.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
       // to the logic layer (services + in-memory repos).
       exclude: [
         'src/server.ts',
+        'src/cron/**',
         'src/db/**',
         'src/**/*.pg.ts',
         'src/**/*.redis.ts',


### PR DESCRIPTION
Completes the **E3 daily confirmation loop** (#101). E3-core (the reservation lifecycle + confirm/decline API + default-yes) already shipped; this adds the **scheduled ask-dispatch**, the **rider↔route** link that targets the right riders, the **real FCM push**, and the **cron schedule** that drives it.

## Rider ↔ route (the pilot model)
Nothing linked a rider to a corridor. Decision: **pin the subscription to one route.** The rider picks their corridor at checkout; `route_id` threads through the payment and is applied to the subscription on activation. Ask-dispatch then targets a trip's riders via `subscriptions.findActiveByRoute(trip.routeId)`.

- **migration 019** — `subscriptions.route_id` (FK `routes`, `ON DELETE SET NULL`) + `payments.route_id`; partial index on active subs. Nullable, so pre-E3 subs simply aren't targeted.
- routeId threaded end-to-end: `payments.schema`/`routes` → `initializeSubscription` → payment row → webhook → `activateSubscription` → subscription.

## Ask-dispatch
- **`AskDispatchService.dispatchAsks(travelDate, direction)`** — for each scheduled trip of that day+direction, seed a `pending` reservation for every active subscriber of the trip's route and push the "travelling?" prompt. **Idempotent**. `resolveDefaults` runs the cutoff default-yes.
- **admin triggers** — `POST /admin/ask-dispatch` and `POST /admin/resolve-defaults`, admin-role gated (#26).
- **direction heuristic** — a trip scheduled before noon UTC → morning (same as the boarding scan).

## FCM push (real transport)
Now that the Firebase project is set up (FE lane, #88–90), the real sender drops in behind the `NotificationSender` seam:
- **`FcmNotificationSender`** (`notification.sender.live.ts`) — looks up the recipient's device tokens (#84) and delivers a multicast push via `firebase-admin`; prunes dead tokens. Best-effort — a failure is logged, never thrown.
- **`server.ts`** — real FCM when `FIREBASE_SERVICE_ACCOUNT` is set, else the recording fake (same pattern as Paystack/Google/R2). The key is a **secret → Render env only**. `firebase-admin` stays external to the bundle.

## Cron schedule
- **`src/cron/ask-dispatch-cron.ts`** — a tiny entrypoint that mints a short-lived admin token from `JWT_SECRET` (auth is stateless — no user row needed) and POSTs the deployed API's trigger. Reuses `createJwtService` so iss/aud/alg can't drift; exits non-zero on failure. Built as a second tsup entry (`dist/cron/ask-dispatch-cron.js`), shipping in the same image.
- **`render.yaml`** — 4 cron jobs (18:00/21:00 morning, 12:00/14:00 evening — Ghana is UTC) + a `trotxi-cron-staging` env group holding `JWT_SECRET` + `API_BASE_URL`. Smoke-tested locally: `ask morning` → tomorrow, `resolve evening` → today, both 200.

## Tests
- ask-dispatch service (targeting, direction filter, idempotency, resolve-defaults), admin routes (403/200), routeId pinning through subscribe.
- `301 pass`, typecheck + lint + build clean.

## Ops (to activate)
1. Set **`FIREBASE_SERVICE_ACCOUNT`** in Render (staging + prod) to the service-account key JSON — until then the fake notifier runs.
2. Set the **`trotxi-cron-staging` env group's `JWT_SECRET`** to the **same value** as the web service's, and apply the blueprint so the cron jobs exist.
   NB: on Render, cron jobs may require a paid instance type — bump `plan` if the free tier rejects them.

Still deferred (E6): seat **capacity / release** to standby.

Closes #101.