### PR TITLE
E5: month-end credit conversion (unused rides → Ride Credits)

### DIFF
--- a/docs/features/entitlements.md
+++ b/docs/features/entitlements.md
@@ -1,6 +1,6 @@
 # Ride entitlements & credits
 
-**Owner:** Godfred Awuku · **Last updated:** 2026-07-05 · **Issue:** #100 (epic E1)
+**Owner:** Godfred Awuku · **Last updated:** 2026-07-08 · **Issue:** #100 (epic E1) · #104 (E5)
 
 The money core of the **Hybrid Subscription Model** (ADR-0014). A subscription
 buys a **ride entitlement** (a count of rides for the period); unused rides
@@ -9,8 +9,10 @@ as **append-only, idempotent ledgers** — the same no-lost-update pattern the o
 token wallet used (system-design §4.1), reused twice.
 
 > **Scope (E1):** the two ledgers, allocation-on-subscription, and `GET /me/rides`.
-> Deferred: plan tiers/prices (E1b), boarding deduction + no-show (E4), month-end
-> credit conversion + credit-netted renewal (E5).
+> **E5 (built):** month-end **credit conversion** — unused rides → Ride Credits.
+> Deferred: plan tiers/prices (E1b); **credit-netted renewal + auto-renew (E5b,
+> #104)** — applying credit to reduce a renewal charge, incl. the "credit covers
+> the whole fee" (zero-charge) edge.
 
 ---
 
@@ -39,14 +41,39 @@ The rider's balance (replaces the removed wallet `GET /me/balance`; FE #35).
 - **200:** `{ "remainingRides": 44, "creditPesewas": 0 }`
 - **401** · **429** · **503** not configured
 
+#### `POST /admin/convert-credits` (E5)
+
+Month-end job: convert **every active rider's** unused rides to Ride Credits.
+A Render cron hits this with an admin token at each period end.
+
+- **Auth:** `Bearer` **admin**. **Rate limit:** per user.
+- **200:** `{ "riders": <n>, "ridesConverted": <n>, "creditPesewas": <n> }`
+- **401** · **403** (non-admin) · **503** (no subscription store wired)
+
 ---
+
+## Credit conversion (E5)
+
+At period end a rider's remaining rides are worth a credit toward their next
+renewal; the rides are then **retired** so they don't carry forward.
+
+- `creditPesewas = remainingRides × creditPesewasPerRide`, keyed by the rider's
+  subscription id (the ending period) — re-running is a no-op.
+- **Credit is granted before the rides are retired**, so a crash mid-way
+  converges exactly-once: a retry re-reads the full remaining, recomputes the
+  identical amount, no-ops the already-granted credit, and applies the debit.
+- `creditPesewasPerRide` is a **placeholder** (`PLACEHOLDER_CREDIT_PESEWAS_PER_RIDE
+= 45`, ~ fee ÷ rides) until E5 pricing is decided (#104) — same posture as
+  `PLACEHOLDER_RIDES_PER_PERIOD`.
+- **Not yet built (E5b):** applying the accrued credit to _reduce_ a renewal
+  charge, and card auto-renew.
 
 ## Data
 
 ```
 entitlement_ledger(id, user_id, delta_rides, reason, ref_type, ref_id,
   idempotency_key unique, created_at)
-  -- reason ∈ allocation | boarding | no_show | returned | refund
+  -- reason ∈ allocation | boarding | no_show | returned | refund | converted
 credit_ledger(id, user_id, delta_pesewas, reason, ref_type, ref_id,
   idempotency_key unique, created_at)
   -- reason ∈ month_end_conversion | compensation | loyalty | renewal_applied
@@ -84,8 +111,11 @@ services/api/src/modules/entitlements/
   credit-ledger.repository.ts(.pg)       # Ride Credit pesewas (append-only)
   entitlements.routes.ts                 # GET /me/rides
   entitlements.schema.ts
+  credit.service.ts                      # E5 conversion (unused rides → credit)
+  credit.routes.ts                       # POST /admin/convert-credits
 services/api/src/modules/payments/payments.service.ts  # allocation on webhook
 services/api/src/db/migrations/011_entitlement_ledger.sql · 012_credit_ledger.sql
+services/api/src/db/migrations/020_entitlement_converted.sql  # 'converted' reason
 ```
 
 ## Related

--- a/services/api/src/app.ts
+++ b/services/api/src/app.ts
@@ -30,6 +30,11 @@ import {
   InMemoryCreditLedgerRepository,
   type CreditLedgerRepository,
 } from './modules/entitlements/credit-ledger.repository';
+import { creditRoutes } from './modules/entitlements/credit.routes';
+import {
+  CreditService,
+  PLACEHOLDER_CREDIT_PESEWAS_PER_RIDE,
+} from './modules/entitlements/credit.service';
 import { reservationRoutes } from './modules/reservations/reservations.routes';
 import {
   InMemoryReservationRepository,
@@ -103,6 +108,8 @@ export interface AppDeps {
   entitlements?: EntitlementLedgerRepository;
   /** Ride Credit ledger (in-memory vs Postgres). Defaults to in-memory. */
   credits?: CreditLedgerRepository;
+  /** Pesewas granted per unused ride on month-end conversion (E5). Placeholder default. */
+  creditPesewasPerRide?: number;
   /** Daily reservation store (in-memory vs Postgres). Defaults to in-memory. */
   reservations?: ReservationRepository;
   /** Push notification sender (FCM in prod, recording fake in dev/tests). */
@@ -227,6 +234,19 @@ export async function buildApp(deps: AppDeps = {}): Promise<FastifyInstance> {
   await app.register(entitlementRoutes, {
     entitlements,
     credits,
+    rateLimit: deps.rateLimit ?? DEFAULT_RATE_LIMIT,
+  });
+  // Credit conversion (E5): the month-end job. Only wired when a subscription
+  // store is available (the route 503s otherwise), since it iterates active subs.
+  await app.register(creditRoutes, {
+    creditService: deps.subscriptions
+      ? new CreditService({
+          entitlements,
+          credits,
+          subscriptions: deps.subscriptions,
+          creditPesewasPerRide: deps.creditPesewasPerRide ?? PLACEHOLDER_CREDIT_PESEWAS_PER_RIDE,
+        })
+      : undefined,
     rateLimit: deps.rateLimit ?? DEFAULT_RATE_LIMIT,
   });
   await app.register(reservationRoutes, {

--- a/services/api/src/db/migrations/020_entitlement_converted.sql
+++ b/services/api/src/db/migrations/020_entitlement_converted.sql
@@ -1,0 +1,9 @@
+-- 020_entitlement_converted: allow the 'converted' reason on the entitlement
+-- ledger — the debit side of month-end credit conversion (E5). When a period's
+-- unused rides convert to Ride Credits (credit_ledger, month_end_conversion),
+-- the rides are retired with a negative entitlement entry so they don't carry
+-- into the next period. (credit_ledger already permits month_end_conversion.)
+ALTER TABLE entitlement_ledger DROP CONSTRAINT IF EXISTS entitlement_ledger_reason_check;
+ALTER TABLE entitlement_ledger
+  ADD CONSTRAINT entitlement_ledger_reason_check
+  CHECK (reason IN ('allocation', 'boarding', 'no_show', 'returned', 'refund', 'converted'));

--- a/services/api/src/modules/entitlements/credit.routes.ts
+++ b/services/api/src/modules/entitlements/credit.routes.ts
@@ -1,0 +1,54 @@
+// Credit-conversion trigger (E5). A scheduled Render cron hits this with an admin
+// token at each period end to convert every active rider's unused rides into Ride
+// Credits. Admin-role gated, like the rest of the ops surface (#26) and the E3
+// ask-dispatch triggers. The cron schedule itself is infra.
+
+import type { FastifyInstance } from 'fastify';
+import type { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { errorResponseSchema } from '../../lib/schemas';
+import type { RateLimitConfig } from '../ratelimit/ratelimit.plugin';
+import type { CreditService } from './credit.service';
+import { convertCreditsResponseSchema } from './credit.schema';
+
+/**
+ * Register the credit-conversion trigger: `POST /admin/convert-credits`.
+ *
+ * @param app - the Fastify instance to register on.
+ * @param opts - route dependencies.
+ * @param opts.creditService - the credit service (503 when unwired).
+ * @param opts.rateLimit - rate-limit config (per user).
+ */
+export async function creditRoutes(
+  app: FastifyInstance,
+  opts: { creditService?: CreditService; rateLimit: RateLimitConfig },
+): Promise<void> {
+  const r = app.withTypeProvider<ZodTypeProvider>();
+  const UNAVAILABLE = { error: 'unavailable', message: 'Credit conversion is not configured' };
+  const adminOnly = [
+    app.authenticate,
+    app.rateLimit({ ...opts.rateLimit, by: 'user' }),
+    app.requireRole('admin'),
+  ];
+
+  r.post(
+    '/admin/convert-credits',
+    {
+      schema: {
+        tags: ['admin'],
+        summary: "Month-end: convert every active rider's unused rides to Ride Credits",
+        security: [{ bearerAuth: [] }],
+        response: {
+          200: convertCreditsResponseSchema,
+          401: errorResponseSchema,
+          403: errorResponseSchema,
+          503: errorResponseSchema,
+        },
+      },
+      preHandler: adminOnly,
+    },
+    async (_request, reply) => {
+      if (!opts.creditService) return reply.code(503).send(UNAVAILABLE);
+      return opts.creditService.convertAllActive();
+    },
+  );
+}

--- a/services/api/src/modules/entitlements/credit.schema.ts
+++ b/services/api/src/modules/entitlements/credit.schema.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+
+/** Totals returned by the month-end credit-conversion run. */
+export const convertCreditsResponseSchema = z.object({
+  /** Riders who had unused rides converted. */
+  riders: z.number().int(),
+  /** Total rides retired. */
+  ridesConverted: z.number().int(),
+  /** Total credit minted, in pesewas. */
+  creditPesewas: z.number().int(),
+});

--- a/services/api/src/modules/entitlements/credit.service.ts
+++ b/services/api/src/modules/entitlements/credit.service.ts
@@ -1,0 +1,110 @@
+// CreditService — month-end conversion of unused rides to Ride Credits (E5, the
+// Hybrid Subscription Model / ADR-0014). At the end of a period the rider's
+// remaining entitlement rides are worth a credit (in pesewas) toward their next
+// renewal; the rides themselves are retired so they don't carry forward. Both
+// ledgers are append-only and idempotent — running the job twice is a no-op.
+//
+// PLACEHOLDER pricing: `creditPesewasPerRide` is a stand-in until E5 pricing is
+// decided (see #104 — plan price ÷ entitlement vs a fixed table). The mechanism
+// ships now; only the number changes later.
+
+import type { CreditLedgerRepository } from './credit-ledger.repository';
+import type { EntitlementLedgerRepository } from './entitlement-ledger.repository';
+import type { SubscriptionRepository } from '../subscriptions/subscription.repository';
+
+/**
+ * Per-ride credit value in PESEWAS. PLACEHOLDER (#104) — ~ monthly fee (2000) ÷
+ * rides (44). Replaced when E5 pricing lands; wired via server.ts like the other
+ * placeholders (subscription fees, rides-per-period).
+ */
+export const PLACEHOLDER_CREDIT_PESEWAS_PER_RIDE = 45;
+
+/** Collaborators for {@link CreditService}, injected at app wiring. */
+export interface CreditServiceDeps {
+  entitlements: EntitlementLedgerRepository;
+  credits: CreditLedgerRepository;
+  subscriptions: SubscriptionRepository;
+  /** Pesewas granted per unused ride (placeholder until E5 pricing). */
+  creditPesewasPerRide: number;
+}
+
+/** Outcome of converting one rider's unused rides. */
+export interface ConversionResult {
+  userId: string;
+  ridesConverted: number;
+  creditPesewas: number;
+}
+
+/** Totals from a batch conversion run. */
+export interface BatchConversionResult {
+  /** Riders who had unused rides converted. */
+  riders: number;
+  /** Total rides retired across all riders. */
+  ridesConverted: number;
+  /** Total credit minted, in pesewas. */
+  creditPesewas: number;
+}
+
+/** Month-end unused-ride → Ride Credit conversion (see the file header). */
+export class CreditService {
+  /** @param deps - the two ledgers, the subscription store, and the per-ride value. */
+  constructor(private readonly deps: CreditServiceDeps) {}
+
+  /**
+   * Convert one rider's remaining rides to Ride Credits for a period. Idempotent
+   * per `periodRef`: the same key writes both ledgers exactly once. Credit is
+   * granted *before* the rides are retired, so a retry re-reads the full
+   * remaining, recomputes the identical amount, no-ops the already-granted
+   * credit, and applies the (still-pending) debit — converging exactly-once.
+   *
+   * @param userId - the rider whose unused rides to convert.
+   * @param periodRef - a stable id for the ending period (the subscription id);
+   *   also the idempotency key, so re-running is a no-op.
+   * @returns how many rides were converted and the credit minted.
+   */
+  async convertUnusedRides(userId: string, periodRef: string): Promise<ConversionResult> {
+    const remaining = await this.deps.entitlements.remainingRides(userId);
+    if (remaining <= 0) return { userId, ridesConverted: 0, creditPesewas: 0 };
+
+    const creditPesewas = remaining * this.deps.creditPesewasPerRide;
+    const key = `convert:${periodRef}`;
+    await this.deps.credits.record({
+      userId,
+      deltaPesewas: creditPesewas,
+      reason: 'month_end_conversion',
+      refType: 'period',
+      refId: periodRef,
+      idempotencyKey: key,
+    });
+    await this.deps.entitlements.record({
+      userId,
+      deltaRides: -remaining,
+      reason: 'converted',
+      refType: 'period',
+      refId: periodRef,
+      idempotencyKey: key,
+    });
+    return { userId, ridesConverted: remaining, creditPesewas };
+  }
+
+  /**
+   * Convert unused rides for every active subscriber — the month-end job. Each
+   * rider is keyed by their active subscription id, so a re-run (or a run that
+   * partially completed) converges without double-crediting.
+   *
+   * @returns batch totals (riders credited, rides retired, pesewas minted).
+   */
+  async convertAllActive(): Promise<BatchConversionResult> {
+    const subs = await this.deps.subscriptions.findAllActive();
+    const totals: BatchConversionResult = { riders: 0, ridesConverted: 0, creditPesewas: 0 };
+    for (const sub of subs) {
+      const res = await this.convertUnusedRides(sub.userId, sub.id);
+      if (res.ridesConverted > 0) {
+        totals.riders++;
+        totals.ridesConverted += res.ridesConverted;
+        totals.creditPesewas += res.creditPesewas;
+      }
+    }
+    return totals;
+  }
+}

--- a/services/api/src/modules/entitlements/entitlement-ledger.repository.ts
+++ b/services/api/src/modules/entitlements/entitlement-ledger.repository.ts
@@ -5,7 +5,14 @@
 // here, Postgres in *.pg.ts.
 
 /** Why an entitlement row exists. */
-export type EntitlementReason = 'allocation' | 'boarding' | 'no_show' | 'returned' | 'refund';
+export type EntitlementReason =
+  | 'allocation'
+  | 'boarding'
+  | 'no_show'
+  | 'returned'
+  | 'refund'
+  /** Month-end conversion of unused rides to Ride Credits (E5) — the ride debit. */
+  | 'converted';
 
 /** A single append to the entitlement ledger. */
 export interface EntitlementEntry {

--- a/services/api/src/modules/subscriptions/subscription.repository.pg.ts
+++ b/services/api/src/modules/subscriptions/subscription.repository.pg.ts
@@ -58,4 +58,12 @@ export class PgSubscriptionRepository implements SubscriptionRepository {
     );
     return rows.map(toSubscription);
   }
+
+  /** Every active subscription (E5 month-end credit conversion iterates these). */
+  async findAllActive(): Promise<Subscription[]> {
+    const { rows } = await this.pool.query<SubscriptionRow>(
+      `SELECT * FROM subscriptions WHERE status = 'active'`,
+    );
+    return rows.map(toSubscription);
+  }
 }

--- a/services/api/src/modules/subscriptions/subscription.repository.ts
+++ b/services/api/src/modules/subscriptions/subscription.repository.ts
@@ -44,6 +44,13 @@ export interface SubscriptionRepository {
    * @returns the active subscriptions on that route.
    */
   findActiveByRoute(routeId: string): Promise<Subscription[]>;
+  /**
+   * Every active subscription — the month-end credit conversion job iterates
+   * these to convert each rider's unused rides (E5).
+   *
+   * @returns all active subscriptions.
+   */
+  findAllActive(): Promise<Subscription[]>;
 }
 
 /** In-memory {@link SubscriptionRepository} for dev and unit tests. */
@@ -76,5 +83,9 @@ export class InMemorySubscriptionRepository implements SubscriptionRepository {
     return Array.from(this.subscriptions.values()).filter(
       (s) => s.status === 'active' && s.routeId === routeId,
     );
+  }
+
+  async findAllActive(): Promise<Subscription[]> {
+    return Array.from(this.subscriptions.values()).filter((s) => s.status === 'active');
   }
 }

--- a/services/api/tests/credits.test.ts
+++ b/services/api/tests/credits.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from 'vitest';
+import { buildApp } from '../src/app';
+import { CreditService } from '../src/modules/entitlements/credit.service';
+import { InMemoryCreditLedgerRepository } from '../src/modules/entitlements/credit-ledger.repository';
+import { InMemoryEntitlementLedgerRepository } from '../src/modules/entitlements/entitlement-ledger.repository';
+import { InMemorySubscriptionRepository } from '../src/modules/subscriptions/subscription.repository';
+import { createJwtService, type AuthConfig } from '../src/modules/auth/jwt';
+
+const auth: AuthConfig = {
+  secret: 'test-secret-at-least-32-characters-long-0000',
+  accessTtl: '15m',
+  issuer: 'trotxi',
+  audience: 'trotxi-api',
+};
+const jwt = createJwtService(auth);
+const bearer = (t: string) => ({ authorization: `Bearer ${t}` });
+const PER_RIDE = 50; // pesewas, test value
+
+function make() {
+  const entitlements = new InMemoryEntitlementLedgerRepository();
+  const credits = new InMemoryCreditLedgerRepository();
+  const subscriptions = new InMemorySubscriptionRepository();
+  const svc = new CreditService({
+    entitlements,
+    credits,
+    subscriptions,
+    creditPesewasPerRide: PER_RIDE,
+  });
+  return { entitlements, credits, subscriptions, svc };
+}
+
+/** Seed `rides` allocated entitlement for a user. */
+async function allocate(
+  entitlements: InMemoryEntitlementLedgerRepository,
+  userId: string,
+  rides: number,
+): Promise<void> {
+  await entitlements.record({
+    userId,
+    deltaRides: rides,
+    reason: 'allocation',
+    idempotencyKey: `seed:${userId}`,
+  });
+}
+
+describe('CreditService.convertUnusedRides', () => {
+  it('mints credit for the remaining rides and retires them', async () => {
+    const { entitlements, credits, svc } = make();
+    await allocate(entitlements, 'ama', 10);
+
+    const res = await svc.convertUnusedRides('ama', 'period-1');
+    expect(res).toEqual({ userId: 'ama', ridesConverted: 10, creditPesewas: 10 * PER_RIDE });
+    expect(await credits.balancePesewas('ama')).toBe(10 * PER_RIDE);
+    expect(await entitlements.remainingRides('ama')).toBe(0); // rides retired, don't carry
+  });
+
+  it('is a no-op when there are no unused rides', async () => {
+    const { entitlements, credits, svc } = make();
+    await allocate(entitlements, 'ama', 10);
+    await entitlements.record({
+      userId: 'ama',
+      deltaRides: -10,
+      reason: 'boarding',
+      idempotencyKey: 'used:ama',
+    });
+
+    expect(await svc.convertUnusedRides('ama', 'period-1')).toEqual({
+      userId: 'ama',
+      ridesConverted: 0,
+      creditPesewas: 0,
+    });
+    expect(await credits.balancePesewas('ama')).toBe(0);
+  });
+
+  it('is idempotent per period — re-running does not double-credit', async () => {
+    const { entitlements, credits, svc } = make();
+    await allocate(entitlements, 'ama', 8);
+
+    await svc.convertUnusedRides('ama', 'period-1');
+    await svc.convertUnusedRides('ama', 'period-1'); // replay
+    expect(await credits.balancePesewas('ama')).toBe(8 * PER_RIDE); // not 2×
+    expect(await entitlements.remainingRides('ama')).toBe(0);
+  });
+
+  it('converges after a partial run (credit written, debit not yet)', async () => {
+    const { entitlements, credits, svc } = make();
+    await allocate(entitlements, 'ama', 6);
+    // Simulate a crash after the credit grant but before the ride debit: the
+    // credit row already exists under the period key, rides still full.
+    await credits.record({
+      userId: 'ama',
+      deltaPesewas: 6 * PER_RIDE,
+      reason: 'month_end_conversion',
+      idempotencyKey: 'convert:period-1',
+    });
+
+    const res = await svc.convertUnusedRides('ama', 'period-1');
+    expect(res.ridesConverted).toBe(6);
+    expect(await credits.balancePesewas('ama')).toBe(6 * PER_RIDE); // credit not doubled
+    expect(await entitlements.remainingRides('ama')).toBe(0); // debit now applied
+  });
+});
+
+describe('CreditService.convertAllActive', () => {
+  it('converts every active subscriber and sums the totals (skipping empties)', async () => {
+    const { entitlements, subscriptions, svc } = make();
+    await subscriptions.create({ userId: 'ama', plan: 'monthly' });
+    await subscriptions.create({ userId: 'kofi', plan: 'monthly' });
+    await subscriptions.create({ userId: 'norides', plan: 'monthly' });
+    await allocate(entitlements, 'ama', 10);
+    await allocate(entitlements, 'kofi', 4);
+
+    expect(await svc.convertAllActive()).toEqual({
+      riders: 2, // 'norides' had nothing → skipped
+      ridesConverted: 14,
+      creditPesewas: 14 * PER_RIDE,
+    });
+  });
+});
+
+describe('POST /admin/convert-credits', () => {
+  it('requires the admin role (commuter → 403)', async () => {
+    const app = await buildApp({ auth, subscriptions: new InMemorySubscriptionRepository() });
+    const token = await jwt.signAccessToken({ userId: 'u', role: 'commuter' });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/admin/convert-credits',
+      headers: bearer(token),
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('503s when no subscription store is wired', async () => {
+    const app = await buildApp({ auth }); // no subscriptions → service unwired
+    const admin = await jwt.signAccessToken({ userId: 'admin', role: 'admin' });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/admin/convert-credits',
+      headers: bearer(admin),
+    });
+    expect(res.statusCode).toBe(503);
+  });
+
+  it('admin converts all active riders', async () => {
+    const entitlements = new InMemoryEntitlementLedgerRepository();
+    const credits = new InMemoryCreditLedgerRepository();
+    const subscriptions = new InMemorySubscriptionRepository();
+    await subscriptions.create({ userId: 'ama', plan: 'monthly' });
+    await entitlements.record({
+      userId: 'ama',
+      deltaRides: 12,
+      reason: 'allocation',
+      idempotencyKey: 'seed:ama',
+    });
+    const app = await buildApp({
+      auth,
+      subscriptions,
+      entitlements,
+      credits,
+      creditPesewasPerRide: PER_RIDE,
+    });
+    const admin = await jwt.signAccessToken({ userId: 'admin', role: 'admin' });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/admin/convert-credits',
+      headers: bearer(admin),
+    });
+    expect(res.json()).toEqual({ riders: 1, ridesConverted: 12, creditPesewas: 12 * PER_RIDE });
+    expect(await credits.balancePesewas('ama')).toBe(12 * PER_RIDE);
+  });
+});

--- a/services/api/tests/payments.service.test.ts
+++ b/services/api/tests/payments.service.test.ts
@@ -119,6 +119,7 @@ describe('PaymentsService.handleWebhook', () => {
     const subscriptions: SubscriptionRepository = {
       findActiveByUser: async () => null,
       findActiveByRoute: async () => [],
+      findAllActive: async () => [],
       create: async () => {
         throw Object.assign(new Error('dup'), { code: '23505' });
       },
@@ -133,6 +134,7 @@ describe('PaymentsService.handleWebhook', () => {
     const subscriptions: SubscriptionRepository = {
       findActiveByUser: async () => null,
       findActiveByRoute: async () => [],
+      findAllActive: async () => [],
       create: async () => {
         throw new Error('db down');
       },


### PR DESCRIPTION
The buildable core of **E5** (#104): at period end, convert a rider's remaining ride entitlement into **Ride Credits** (pesewas) toward their next renewal, and retire the rides so they don't carry forward. Built now with a **placeholder per-ride value** so the mechanism ships while pricing is decided — same posture as `PLACEHOLDER_RIDES_PER_PERIOD`.

## What it does
- **`CreditService.convertUnusedRides(userId, periodRef)`** — `creditPesewas = remainingRides × perRide`; grants the credit **then** retires the rides under one period key. Credit-first ordering makes a crash mid-way converge **exactly-once**: a retry re-reads the full remaining, recomputes the identical amount, no-ops the already-granted credit, and applies the debit.
- **`convertAllActive()`** — the month-end batch over every active subscriber (keyed by subscription id) → `{ riders, ridesConverted, creditPesewas }`.
- **`POST /admin/convert-credits`** — admin-gated trigger (a Render cron hits it at period end), `503` when no subscription store is wired. Mirrors the E3 ask-dispatch triggers.
- **migration 020** — `entitlement_ledger` gains the `converted` reason (the debit side; `credit_ledger` already allowed `month_end_conversion`).
- **`SubscriptionRepository.findAllActive()`** (interface + InMemory + Pg).

## Placeholder
`PLACEHOLDER_CREDIT_PESEWAS_PER_RIDE = 45` (≈ monthly fee ÷ rides). Only the number changes when E5 pricing lands (#104).

## Tests
Conversion math, no-op on empty, idempotency, **partial-run convergence** (credit written, debit not yet), batch totals, and the admin route (403 / 503 / 200). **309 pass, coverage 98%**, typecheck + build clean.

## Deferred → E5b (new issue)
Credit-**netted renewal** (apply accrued credit to reduce the renewal charge, incl. the "credit covers the whole fee" zero-charge / Paystack-minimum edge) + card **auto-renew**.

Refs #104.