### PR TITLE
fix(boarding): restrict trip manifest to its assigned driver

### DIFF
--- a/services/api/src/app.ts
+++ b/services/api/src/app.ts
@@ -262,6 +262,8 @@ export async function buildApp(deps: AppDeps = {}): Promise<FastifyInstance> {
         passTtlSeconds: 60,
       }),
     manifestService: new ManifestService({ reservations, users, objectStore }),
+    trips: deps.trips,
+    drivers: deps.drivers,
     rateLimit: deps.rateLimit ?? DEFAULT_RATE_LIMIT,
   });
   await app.register(mobilityRoutes, {

--- a/services/api/src/modules/boarding/boarding.routes.ts
+++ b/services/api/src/modules/boarding/boarding.routes.ts
@@ -7,6 +7,8 @@ import type { FastifyInstance } from 'fastify';
 import type { ZodTypeProvider } from 'fastify-type-provider-zod';
 import { errorResponseSchema } from '../../lib/schemas';
 import type { RateLimitConfig } from '../ratelimit/ratelimit.plugin';
+import type { TripRepository } from '../mobility/trip.repository';
+import type { DriverRepository } from '../mobility/driver.repository';
 import type { BoardingService } from './boarding.service';
 import type { ManifestService } from './manifest.service';
 import {
@@ -27,6 +29,8 @@ import {
  * @param opts - route dependencies.
  * @param opts.boardingService - issues passes + verifies scans.
  * @param opts.manifestService - builds a trip's driver manifest (503 when absent).
+ * @param opts.trips - trip lookup for the manifest assigned-driver authz.
+ * @param opts.drivers - resolves the signed-in user to their driver record (authz).
  * @param opts.rateLimit - per-user rate-limit config.
  */
 export async function boardingRoutes(
@@ -34,6 +38,10 @@ export async function boardingRoutes(
   opts: {
     boardingService: BoardingService;
     manifestService?: ManifestService;
+    /** Trip lookup (existence + assignedDriverId) for the manifest authz. */
+    trips?: TripRepository;
+    /** Resolves the signed-in user to their driver record (manifest authz). */
+    drivers?: DriverRepository;
     rateLimit: RateLimitConfig;
   },
 ): Promise<void> {
@@ -115,21 +123,23 @@ export async function boardingRoutes(
   );
 
   // Driver manifest for a trip — name + photo + boarded status of confirmed
-  // riders (the "photo pass"). Driver-role gated. (Restricting to the trip's
-  // ASSIGNED driver is a security follow-up — it needs the driver↔user lookup
-  // that GPS reporting #25 also requires; both land together.)
+  // riders (the "photo pass"). Restricted to the trip's ASSIGNED driver: it
+  // exposes rider PII (names + faces), so a driver role alone is not enough —
+  // the signed-in user must be the driver this trip is assigned to (same authz
+  // as GPS reporting #25).
   r.get(
     '/boarding/manifest',
     {
       schema: {
         tags: ['boarding'],
-        summary: "A trip's manifest — confirmed riders with name + photo (driver only)",
+        summary: "A trip's manifest — confirmed riders with name + photo (assigned driver only)",
         security: [{ bearerAuth: [] }],
         querystring: manifestQuerySchema,
         response: {
           200: manifestResponseSchema,
           401: errorResponseSchema,
           403: errorResponseSchema,
+          404: errorResponseSchema,
           503: errorResponseSchema,
         },
       },
@@ -140,11 +150,23 @@ export async function boardingRoutes(
       ],
     },
     async (request, reply) => {
-      if (!opts.manifestService) {
+      if (!opts.manifestService || !opts.trips || !opts.drivers) {
         return reply
           .code(503)
           .send({ error: 'unavailable', message: 'Manifest is not configured' });
       }
+      const trip = await opts.trips.findById(request.query.tripId);
+      if (!trip) return reply.code(404).send({ error: 'not_found', message: 'Trip not found' });
+
+      // Assigned-driver authz: the signed-in user must be linked to the driver
+      // this trip is assigned to. A driver role alone is not enough.
+      const driver = await opts.drivers.findByUserId(request.user!.id);
+      if (!driver || trip.assignedDriverId !== driver.id) {
+        return reply
+          .code(403)
+          .send({ error: 'forbidden', message: 'Not the assigned driver for this trip' });
+      }
+
       const riders = await opts.manifestService.getManifest(request.query.tripId);
       return { tripId: request.query.tripId, riders };
     },

--- a/services/api/tests/boarding.manifest.test.ts
+++ b/services/api/tests/boarding.manifest.test.ts
@@ -1,10 +1,13 @@
 // Driver manifest (#20, E4) — the photo pass. A trip's confirmed riders with
-// name + signed avatar URL + boarded status, driver-role gated.
+// name + signed avatar URL + boarded status, restricted to the trip's ASSIGNED
+// driver (rider PII — a driver role alone is not enough).
 
 import { describe, expect, it } from 'vitest';
 import { buildApp } from '../src/app';
 import { InMemoryReservationRepository } from '../src/modules/reservations/reservation.repository';
 import { InMemoryUserRepository } from '../src/modules/users/user.repository';
+import { InMemoryTripRepository } from '../src/modules/mobility/trip.repository';
+import { InMemoryDriverRepository } from '../src/modules/mobility/driver.repository';
 import { createJwtService, type AuthConfig } from '../src/modules/auth/jwt';
 
 const auth: AuthConfig = {
@@ -15,57 +18,73 @@ const auth: AuthConfig = {
 };
 const jwt = createJwtService(auth);
 const bearer = (t: string) => ({ authorization: `Bearer ${t}` });
-const TRIP = crypto.randomUUID();
 const OTHER_TRIP = crypto.randomUUID();
 const DATE = '2026-07-09';
 
+/** Wire users + reservations + a trip assigned to driver-1. Returns the trip id. */
 async function setup() {
   const users = new InMemoryUserRepository();
   const reservations = new InMemoryReservationRepository();
-  const app = await buildApp({ auth, users, reservations });
+  const trips = new InMemoryTripRepository();
+  const drivers = new InMemoryDriverRepository();
+  const driver = await drivers.create({ fullName: 'Driver One', userId: 'driver-1' });
+  const trip = await trips.create({
+    routeId: crypto.randomUUID(),
+    assignedDriverId: driver.id,
+    scheduledAt: new Date(`${DATE}T06:30:00Z`),
+  });
+  const app = await buildApp({ auth, users, reservations, trips, drivers });
   const driverToken = await jwt.signAccessToken({ userId: 'driver-1', role: 'driver' });
-  return { users, reservations, app, driverToken };
+  return { users, reservations, trips, drivers, driver, app, driverToken, tripId: trip.id };
 }
 
-const manifest = (
-  app: Awaited<ReturnType<typeof buildApp>>,
-  token: string,
-  tripId: string = TRIP,
-) =>
+const manifest = (app: Awaited<ReturnType<typeof buildApp>>, token: string, tripId: string) =>
   app.inject({ method: 'GET', url: `/boarding/manifest?tripId=${tripId}`, headers: bearer(token) });
 
 describe('GET /boarding/manifest', () => {
   it('requires the driver role (commuter → 403)', async () => {
-    const { app } = await setup();
+    const { app, tripId } = await setup();
     const commuter = await jwt.signAccessToken({ userId: 'rider-1', role: 'commuter' });
-    expect((await manifest(app, commuter)).statusCode).toBe(403);
+    expect((await manifest(app, commuter, tripId)).statusCode).toBe(403);
+  });
+
+  it('rejects a driver who is not the trip’s assigned driver (403)', async () => {
+    const { app, tripId } = await setup();
+    // a valid driver token, but this user has no driver record / not assigned
+    const other = await jwt.signAccessToken({ userId: 'driver-2', role: 'driver' });
+    expect((await manifest(app, other, tripId)).statusCode).toBe(403);
+  });
+
+  it('404 when the trip does not exist', async () => {
+    const { app, driverToken } = await setup();
+    expect((await manifest(app, driverToken, crypto.randomUUID())).statusCode).toBe(404);
   });
 
   it('lists confirmed riders for the trip with name + signed photo', async () => {
-    const { app, users, reservations, driverToken } = await setup();
+    const { app, users, reservations, driverToken, tripId } = await setup();
     const ama = await users.create({ displayName: 'Ama Mensah' });
     await users.setAvatarKey(ama.id, `avatars/${ama.id}`);
     const kofi = await users.create({ displayName: 'Kofi B' }); // no avatar
 
     await reservations.respond({
       userId: ama.id,
-      tripId: TRIP,
+      tripId,
       travelDate: DATE,
       direction: 'morning',
       travelling: true,
     });
     await reservations.respond({
       userId: kofi.id,
-      tripId: TRIP,
+      tripId,
       travelDate: DATE,
       direction: 'morning',
       travelling: true,
     });
 
-    const res = await manifest(app, driverToken);
+    const res = await manifest(app, driverToken, tripId);
     expect(res.statusCode).toBe(200);
     const body = res.json();
-    expect(body.tripId).toBe(TRIP);
+    expect(body.tripId).toBe(tripId);
     expect(body.riders).toHaveLength(2);
     const amaRow = body.riders.find((r: { userId: string }) => r.userId === ama.id);
     expect(amaRow).toMatchObject({ name: 'Ama Mensah', boarded: false, direction: 'morning' });
@@ -75,14 +94,14 @@ describe('GET /boarding/manifest', () => {
   });
 
   it('excludes declined seats and other trips; shows boarded status', async () => {
-    const { app, users, reservations, driverToken } = await setup();
+    const { app, users, reservations, driverToken, tripId } = await setup();
     const yes = await users.create({ displayName: 'Yes Rider' });
     const no = await users.create({ displayName: 'No Rider' });
     const other = await users.create({ displayName: 'Other Trip' });
 
     const confirmed = await reservations.respond({
       userId: yes.id,
-      tripId: TRIP,
+      tripId,
       travelDate: DATE,
       direction: 'morning',
       travelling: true,
@@ -90,7 +109,7 @@ describe('GET /boarding/manifest', () => {
     await reservations.markBoarded(confirmed.id);
     await reservations.respond({
       userId: no.id,
-      tripId: TRIP,
+      tripId,
       travelDate: DATE,
       direction: 'morning',
       travelling: false, // declined → excluded
@@ -103,32 +122,32 @@ describe('GET /boarding/manifest', () => {
       travelling: true, // different trip → excluded
     });
 
-    const body = (await manifest(app, driverToken)).json();
+    const body = (await manifest(app, driverToken, tripId)).json();
     expect(body.riders).toHaveLength(1);
     expect(body.riders[0]).toMatchObject({ userId: yes.id, boarded: true });
   });
 
   it('orders morning before evening (not alphabetical)', async () => {
-    const { app, users, reservations, driverToken } = await setup();
+    const { app, users, reservations, driverToken, tripId } = await setup();
     const m = await users.create({ displayName: 'Morning Rider' });
     const e = await users.create({ displayName: 'Evening Rider' });
     // insert evening first so a stable/alphabetical sort would keep it first
     await reservations.respond({
       userId: e.id,
-      tripId: TRIP,
+      tripId,
       travelDate: DATE,
       direction: 'evening',
       travelling: true,
     });
     await reservations.respond({
       userId: m.id,
-      tripId: TRIP,
+      tripId,
       travelDate: DATE,
       direction: 'morning',
       travelling: true,
     });
 
-    const riders = (await manifest(app, driverToken)).json().riders;
+    const riders = (await manifest(app, driverToken, tripId)).json().riders;
     expect(riders.map((row: { direction: string }) => row.direction)).toEqual([
       'morning',
       'evening',
@@ -136,9 +155,9 @@ describe('GET /boarding/manifest', () => {
   });
 
   it('empty manifest for a trip with no reservations', async () => {
-    const { app, driverToken } = await setup();
-    const body = (await manifest(app, driverToken)).json();
-    expect(body).toEqual({ tripId: TRIP, riders: [] });
+    const { app, driverToken, tripId } = await setup();
+    const body = (await manifest(app, driverToken, tripId)).json();
+    expect(body).toEqual({ tripId, riders: [] });
   });
 
   it('400 when tripId is missing or not a uuid', async () => {


### PR DESCRIPTION
## The gap
`GET /boarding/manifest` returns a trip's confirmed riders with **names + faces** (signed avatar URLs). It was gated on the `driver` **role alone** — so any driver could pull **any** trip's manifest, exposing other riders' PII. The code carried a `TODO` deferring this ("needs the driver↔user lookup that GPS #25 also requires").

## The fix
Restrict it to the trip's **assigned driver**, reusing the exact authz GPS reporting (#25) already enforces:
- Load the trip → **404** if it doesn't exist.
- Resolve the signed-in user via `drivers.findByUserId(user.id)`.
- **403** unless `trip.assignedDriverId === driver.id`.

`boardingRoutes` now takes `trips` + `drivers` (wired in `app.ts`); the endpoint **503**s if they're unwired.

## Tests
Added **non-assigned driver → 403** and **missing trip → 404**; the existing cases now seed an assigned trip. **303 pass**, typecheck + lint clean.

Closes the manifest-authz follow-up noted in the E4 boarding code.