### PR TITLE
chore(api): E7 — drop legacy token_ledger table

### DIFF
--- a/docs/adr/0011-token-ledger.md
+++ b/docs/adr/0011-token-ledger.md
@@ -1,6 +1,12 @@
 # ADR-0011 — Append-only token ledger (the GHS wallet)
 
-**Status:** accepted · **Date:** 2026-06-27
+**Status:** superseded by [ADR-0014](0014-hybrid-subscription-model.md) · **Date:** 2026-06-27
+
+> **Superseded (2026-07-08).** The prepaid GHS wallet this ADR introduced was
+> dropped in the Hybrid Subscription Model pivot (ADR-0014): the `token_ledger`
+> code was removed (#99) and the table dropped by migration `021` (E7, #106).
+> The **append-only-ledger pattern** decided here lives on, reused by E1's
+> entitlement and credit ledgers — this ADR is retained for that rationale.
 
 ## Context
 

--- a/docs/features/payments-and-wallet.md
+++ b/docs/features/payments-and-wallet.md
@@ -12,9 +12,9 @@ The old wallet/top-up flow has been **removed from the code** (clean-slate
 sweep): `POST /payments/topup`, `GET /me/balance`, and the entire ledger module
 are deleted. What remains — and what epic **E1** builds on — is
 `POST /payments/subscribe` + the Paystack webhook that activates a membership.
-The `token_ledger` table stays in migration history (dropped by a later
-migration); the **append-only-ledger pattern** it established returns in E1 as
-the entitlement and credit ledgers.
+The `token_ledger` table stays in migration history and is **dropped by
+migration `021`** (E7, #106); the **append-only-ledger pattern** it established
+returns in E1 as the entitlement and credit ledgers.
 
 ---
 
@@ -162,7 +162,7 @@ services/api/src/modules/payments/
   payments.schema.ts
 services/api/src/db/migrations/
   007_payments.sql · 008_payment_purpose.sql
-  # 006_token_ledger.sql retained (history); table dropped by a later migration
+  # 006_token_ledger.sql retained (history); table dropped by 021_drop_token_ledger.sql (E7)
 ```
 
 ## Related

--- a/services/api/src/db/migrations/021_drop_token_ledger.sql
+++ b/services/api/src/db/migrations/021_drop_token_ledger.sql
@@ -1,0 +1,7 @@
+-- 021_drop_token_ledger: retire the legacy wallet ledger table (E7, #106).
+-- The token wallet was superseded by the entitlement + credit ledgers
+-- (ADR-0014); its code was removed in #99 and E1's ledgers are live, so the now
+-- unused table can go. Historical migrations 006 (create) and 008 (alter its
+-- reason CHECK) are left untouched so replay on an existing DB stays valid — the
+-- table is created and altered as before, then dropped here at the end.
+DROP TABLE IF EXISTS token_ledger;


### PR DESCRIPTION
Closes **#106** — the close-out of the wallet retirement.

The prepaid token wallet was superseded by the entitlement + credit ledgers (ADR-0014). Its **code** was removed in #99 and E1's ledgers are live, so the now-unused `token_ledger` **table** can finally go.

## Change
- **migration 021** — `DROP TABLE IF EXISTS token_ledger`. Historical migrations `006` (create) and `008` (alter its reason CHECK) are **left untouched** so replay on an existing DB stays valid: the table is created + altered as before, then dropped at the end of the chain. (Numbered `021`; `020` was E5's `entitlement_converted`, now on main.)
- **docs** — `payments-and-wallet.md` already said the table was "dropped by a later migration"; pointed it at `021`. Marked **ADR-0011 superseded by ADR-0014** — the wallet is gone, but the append-only-ledger *pattern* it established lives on in E1 (kept for that rationale).

## Verification
No source or test references `token_ledger` (only the three migrations). The **Migrations (Postgres)** CI job replays the full chain — `006` create → `008` alter → `021` drop — proving it applies cleanly.