### PR TITLE
feat(boarding): E4 confirmed-yes no-show deduction (cutoff cron)

### DIFF
--- a/docs/features/boarding.md
+++ b/docs/features/boarding.md
@@ -1,12 +1,12 @@
 # Boarding — QR passes & scan verification
 
-**Owner:** Godfred Awuku · **Last updated:** 2026-07-02
+**Owner:** Godfred Awuku · **Last updated:** 2026-07-08
 
 **Status:** 🟢 All three verification layers live (#20, E4): **QR scan**,
 **driver manifest** (photo pass), and **daily PIN** — any one boards the rider's
-confirmed reservation and **debits one ride** (ADR-0014). Still deferred: the
-confirmed-yes **no-show** cron and restricting the manifest to a trip's assigned
-driver (both pair with #25) — see below.
+confirmed reservation and **debits one ride** (ADR-0014). The **confirmed-yes
+no-show** deduction (cutoff cron) and the **assigned-driver-only manifest**
+(#129) are now built too — see below.
 
 Lets a driver confirm a rider is boarding with a **genuine, unforged, unexpired
 pass**, and logs every scan for audit. Rationale: #20.
@@ -104,16 +104,19 @@ The commercial model is decided
 ([ADR-0014](../adr/0014-hybrid-subscription-model.md)): boarding is **three
 verification layers**, and any one consumes **1 ride from the subscription
 entitlement**. **Done (this + prior slices):** QR scan + deduction, the driver
-**manifest** (photo pass), and the **daily PIN**. Still to come:
+**manifest** (photo pass, assigned-driver-gated), the **daily PIN**, and the
+**no-show** cutoff deduction. Still to come:
 
 - ✅ **QR scan** — `POST /boarding/scan` (deducts).
 - ✅ **Driver manifest** — `GET /boarding/manifest?tripId=` (name + signed photo).
 - ✅ **Daily PIN** — `POST /boarding/verify-pin` (boards + deducts, idempotent).
-- **Confirmed-yes no-show** deduction job (cron); operator cancellation never
-  deducts. Same idempotency key space (`board:<reservationId>`) so a late board
-  and the no-show sweep can't both charge.
-- **Manifest → assigned driver only** — restrict a trip's manifest to its
-  assigned driver (needs the driver↔user lookup #25 also uses; they land together).
+- ✅ **Confirmed-yes no-show** — `POST /admin/resolve-no-shows` (admin cutoff
+  cron): every still-`reserved` seat that wasn't boarded is deducted and marked
+  `no_show`. Deducts on the **same idempotency key as boarding**
+  (`board:<reservationId>`) so a late board and the no-show sweep can't both
+  charge; operator cancellation never deducts.
+- ✅ **Manifest → assigned driver only** (#129) — a trip's manifest is restricted
+  to its assigned driver (`drivers.findByUserId` + `trip.assignedDriverId`).
 - **Per-rider pickup point** on the manifest — needs a rider↔stop link.
 - Direction/trip resolution: a QR scan still boards the rider's **earliest open
   leg for the day** (morning before evening); the PIN + manifest target a

--- a/services/api/src/modules/boarding/boarding.routes.ts
+++ b/services/api/src/modules/boarding/boarding.routes.ts
@@ -15,6 +15,8 @@ import {
   manifestQuerySchema,
   manifestResponseSchema,
   passResponseSchema,
+  resolveNoShowsBodySchema,
+  resolveNoShowsResponseSchema,
   scanBodySchema,
   scanResponseSchema,
   verifyPinBodySchema,
@@ -170,5 +172,33 @@ export async function boardingRoutes(
       const riders = await opts.manifestService.getManifest(request.query.tripId);
       return { tripId: request.query.tripId, riders };
     },
+  );
+
+  // Cutoff no-show resolution (E4). A scheduled Render cron hits this with an
+  // admin token after each travel window: every still-reserved seat that was
+  // never boarded is deducted as a no-show. Admin-role gated, like the rest of
+  // the ops surface (#26) and the E3/E5 cutoff triggers.
+  r.post(
+    '/admin/resolve-no-shows',
+    {
+      schema: {
+        tags: ['admin'],
+        summary: 'Cutoff: deduct confirmed-but-unboarded seats as no-shows',
+        security: [{ bearerAuth: [] }],
+        body: resolveNoShowsBodySchema,
+        response: {
+          200: resolveNoShowsResponseSchema,
+          401: errorResponseSchema,
+          403: errorResponseSchema,
+        },
+      },
+      preHandler: [
+        app.authenticate,
+        app.rateLimit({ ...opts.rateLimit, by: 'user' }),
+        app.requireRole('admin'),
+      ],
+    },
+    async (request) =>
+      opts.boardingService.resolveNoShows(request.body.travelDate, request.body.direction),
   );
 }

--- a/services/api/src/modules/boarding/boarding.schema.ts
+++ b/services/api/src/modules/boarding/boarding.schema.ts
@@ -35,6 +35,16 @@ export const verifyPinResponseSchema = z.object({
   deducted: z.boolean(),
 });
 
+export const resolveNoShowsBodySchema = z.object({
+  travelDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'expected YYYY-MM-DD'),
+  direction: z.enum(['morning', 'evening']),
+});
+
+export const resolveNoShowsResponseSchema = z.object({
+  /** How many confirmed-but-unboarded seats were deducted as no-shows. */
+  noShows: z.number().int(),
+});
+
 export const manifestQuerySchema = z.object({
   tripId: z.string().uuid(),
 });

--- a/services/api/src/modules/boarding/boarding.service.ts
+++ b/services/api/src/modules/boarding/boarding.service.ts
@@ -14,7 +14,11 @@
 import { errors } from 'jose';
 import type { KvStore } from '../../kv/kv.store';
 import type { EntitlementLedgerRepository } from '../entitlements/entitlement-ledger.repository';
-import type { Reservation, ReservationRepository } from '../reservations/reservation.repository';
+import type {
+  Reservation,
+  ReservationDirection,
+  ReservationRepository,
+} from '../reservations/reservation.repository';
 import { verifyPin as checkPin } from '../reservations/pin';
 import { signPass, verifyPass, type IssuedPass } from './pass';
 import type { ScanEventRepository, ScanMethod } from './scan-event.repository';
@@ -218,6 +222,42 @@ export class BoardingService {
       idempotencyKey: `board:${reservation.id}`,
     });
     return true;
+  }
+
+  /**
+   * Cutoff no-show resolution (E4): every still-`reserved` seat for the
+   * day+direction that was never boarded is a no-show — deduct one ride and mark
+   * it `no_show`. The mirror of boarding: both consume the confirmed seat's ride.
+   *
+   * Deducts on the **same idempotency key as boarding** (`board:<reservationId>`)
+   * so a seat is charged **at most once**: a late board after a no-show sweep (or
+   * a re-run) collides on the key and is a no-op. Combined with only selecting
+   * `reserved` rows, a re-run neither double-deducts nor re-marks. Deducts BEFORE
+   * marking (like the credit conversion) so a partial run converges without
+   * losing the deduction. No-op when the ledgers aren't wired.
+   *
+   * @param travelDate - the travel day (`YYYY-MM-DD`).
+   * @param direction - morning or evening.
+   * @returns how many reservations were resolved as no-shows.
+   */
+  async resolveNoShows(
+    travelDate: string,
+    direction: ReservationDirection,
+  ): Promise<{ noShows: number }> {
+    if (!this.deps.reservations || !this.deps.entitlements) return { noShows: 0 };
+    const reserved = await this.deps.reservations.listReserved(travelDate, direction);
+    for (const r of reserved) {
+      await this.deps.entitlements.record({
+        userId: r.userId,
+        deltaRides: -1,
+        reason: 'no_show',
+        refType: 'reservation',
+        refId: r.id,
+        idempotencyKey: `board:${r.id}`,
+      });
+      await this.deps.reservations.markNoShow(r.id);
+    }
+    return { noShows: reserved.length };
   }
 
   /**

--- a/services/api/src/modules/reservations/reservation.repository.pg.ts
+++ b/services/api/src/modules/reservations/reservation.repository.pg.ts
@@ -134,6 +134,25 @@ export class PgReservationRepository implements ReservationRepository {
     return rows[0] ? toReservation(rows[0]) : null;
   }
 
+  /** Still-`reserved` reservations for a day+direction (no-show candidates, E4). */
+  async listReserved(travelDate: string, direction: ReservationDirection): Promise<Reservation[]> {
+    const { rows } = await this.pool.query<ReservationRow>(
+      `SELECT * FROM reservations
+       WHERE travel_date = $1 AND direction = $2 AND status = 'reserved'`,
+      [travelDate, direction],
+    );
+    return rows.map(toReservation);
+  }
+
+  /** Mark a reservation `no_show` (caller deducts the ride, E4). */
+  async markNoShow(id: string): Promise<Reservation | null> {
+    const { rows } = await this.pool.query<ReservationRow>(
+      `UPDATE reservations SET status = 'no_show', updated_at = now() WHERE id = $1 RETURNING *`,
+      [id],
+    );
+    return rows[0] ? toReservation(rows[0]) : null;
+  }
+
   async listForTrip(tripId: string): Promise<Reservation[]> {
     const { rows } = await this.pool.query<ReservationRow>(
       `SELECT * FROM reservations WHERE trip_id = $1

--- a/services/api/src/modules/reservations/reservation.repository.ts
+++ b/services/api/src/modules/reservations/reservation.repository.ts
@@ -133,6 +133,24 @@ export interface ReservationRepository {
    */
   markBoarded(id: string): Promise<Reservation | null>;
   /**
+   * Confirmed-but-not-boarded reservations for a day+direction — the no-show
+   * candidates the cutoff resolves (still `reserved`, so a boarded seat is
+   * never a no-show). E4.
+   *
+   * @param travelDate - the travel day (`YYYY-MM-DD`).
+   * @param direction - morning or evening.
+   * @returns the still-`reserved` reservations for that day+direction.
+   */
+  listReserved(travelDate: string, direction: ReservationDirection): Promise<Reservation[]>;
+  /**
+   * Mark a reservation `no_show` (confirmed but didn't board — a ride is
+   * deducted by the caller). E4.
+   *
+   * @param id - the reservation id.
+   * @returns the updated reservation, or null if not found.
+   */
+  markNoShow(id: string): Promise<Reservation | null>;
+  /**
    * All reservations attached to a trip — the raw rows behind a driver's
    * manifest (the handler filters to the confirmed ones and enriches with rider
    * name/photo).
@@ -267,6 +285,20 @@ export class InMemoryReservationRepository implements ReservationRepository {
     const row = this.rows.find((r) => r.id === id);
     if (!row) return null;
     row.status = 'boarded';
+    row.updatedAt = new Date();
+    return row;
+  }
+
+  async listReserved(travelDate: string, direction: ReservationDirection): Promise<Reservation[]> {
+    return this.rows.filter(
+      (r) => r.travelDate === travelDate && r.direction === direction && r.status === 'reserved',
+    );
+  }
+
+  async markNoShow(id: string): Promise<Reservation | null> {
+    const row = this.rows.find((r) => r.id === id);
+    if (!row) return null;
+    row.status = 'no_show';
     row.updatedAt = new Date();
     return row;
   }

--- a/services/api/tests/no-show.test.ts
+++ b/services/api/tests/no-show.test.ts
@@ -1,0 +1,152 @@
+// No-show resolution (E4) — the cutoff mirror of boarding: a confirmed seat that
+// was never boarded is deducted as a no-show (ADR-0014: deduct on boarding OR
+// confirmed no-show).
+
+import { describe, expect, it } from 'vitest';
+import { buildApp } from '../src/app';
+import { BoardingService } from '../src/modules/boarding/boarding.service';
+import { InMemoryScanEventRepository } from '../src/modules/boarding/scan-event.repository';
+import { InMemoryReservationRepository } from '../src/modules/reservations/reservation.repository';
+import { InMemoryEntitlementLedgerRepository } from '../src/modules/entitlements/entitlement-ledger.repository';
+import { InMemoryKvStore } from '../src/kv/kv.store';
+import { createJwtService, type AuthConfig } from '../src/modules/auth/jwt';
+
+const auth: AuthConfig = {
+  secret: 'test-secret-at-least-32-characters-long-0000',
+  accessTtl: '15m',
+  issuer: 'trotxi',
+  audience: 'trotxi-api',
+};
+const jwt = createJwtService(auth);
+const bearer = (t: string) => ({ authorization: `Bearer ${t}` });
+const DATE = '2026-07-09';
+
+function make() {
+  const reservations = new InMemoryReservationRepository();
+  const entitlements = new InMemoryEntitlementLedgerRepository();
+  const svc = new BoardingService({
+    scanEvents: new InMemoryScanEventRepository(),
+    kv: new InMemoryKvStore(),
+    reservations,
+    entitlements,
+    secret: auth.secret,
+    passTtlSeconds: 60,
+  });
+  return { reservations, entitlements, svc };
+}
+
+/** Confirm (reserve) a rider for the day+direction and give them `rides`. */
+async function reserve(
+  reservations: InMemoryReservationRepository,
+  entitlements: InMemoryEntitlementLedgerRepository,
+  userId: string,
+  direction: 'morning' | 'evening' = 'morning',
+  rides = 10,
+) {
+  await entitlements.record({
+    userId,
+    deltaRides: rides,
+    reason: 'allocation',
+    idempotencyKey: `seed:${userId}`,
+  });
+  return reservations.respond({ userId, travelDate: DATE, direction, travelling: true });
+}
+
+describe('BoardingService.resolveNoShows', () => {
+  it('deducts a ride and marks no_show for each confirmed-but-unboarded seat', async () => {
+    const { reservations, entitlements, svc } = make();
+    const ama = await reserve(reservations, entitlements, 'ama');
+    await reserve(reservations, entitlements, 'kofi');
+
+    expect(await svc.resolveNoShows(DATE, 'morning')).toEqual({ noShows: 2 });
+    expect(await entitlements.remainingRides('ama')).toBe(9); // 10 − 1
+    expect((await reservations.findById(ama.id))?.status).toBe('no_show');
+  });
+
+  it('only touches still-reserved rows of that day+direction', async () => {
+    const { reservations, entitlements, svc } = make();
+    const reserved = await reserve(reservations, entitlements, 'ama'); // target
+    const boarded = await reserve(reservations, entitlements, 'kofi');
+    await reservations.markBoarded(boarded.id); // already boarded → skip
+    await reservations.respond({
+      userId: 'yaw',
+      travelDate: DATE,
+      direction: 'morning',
+      travelling: false,
+    }); // declined
+    await reservations.createPending({ userId: 'esi', travelDate: DATE, direction: 'morning' }); // pending
+    await reserve(reservations, entitlements, 'kwame', 'evening'); // other direction
+
+    expect(await svc.resolveNoShows(DATE, 'morning')).toEqual({ noShows: 1 });
+    expect((await reservations.findById(reserved.id))?.status).toBe('no_show');
+    expect((await reservations.findById(boarded.id))?.status).toBe('boarded'); // untouched
+    expect(await entitlements.remainingRides('kofi')).toBe(10); // boarded row NOT no-show-deducted
+  });
+
+  it('is idempotent — a re-run does not double-deduct', async () => {
+    const { reservations, entitlements, svc } = make();
+    await reserve(reservations, entitlements, 'ama');
+
+    await svc.resolveNoShows(DATE, 'morning');
+    expect(await svc.resolveNoShows(DATE, 'morning')).toEqual({ noShows: 0 }); // already no_show
+    expect(await entitlements.remainingRides('ama')).toBe(9); // deducted once, not twice
+  });
+
+  it('shares the boarding key space — a late board after a no-show cannot double-charge', async () => {
+    const { reservations, entitlements, svc } = make();
+    const ama = await reserve(reservations, entitlements, 'ama');
+
+    await svc.resolveNoShows(DATE, 'morning'); // deducts on board:<id>, → 9
+    // A late board would deduct on the SAME key (`board:<reservationId>`):
+    await entitlements.record({
+      userId: 'ama',
+      deltaRides: -1,
+      reason: 'boarding',
+      refType: 'reservation',
+      refId: ama.id,
+      idempotencyKey: `board:${ama.id}`,
+    });
+    expect(await entitlements.remainingRides('ama')).toBe(9); // charged once, not twice
+  });
+
+  it('is a no-op when the ledgers are not wired', async () => {
+    const svc = new BoardingService({
+      scanEvents: new InMemoryScanEventRepository(),
+      kv: new InMemoryKvStore(),
+      secret: auth.secret,
+      passTtlSeconds: 60,
+    });
+    expect(await svc.resolveNoShows(DATE, 'morning')).toEqual({ noShows: 0 });
+  });
+});
+
+describe('POST /admin/resolve-no-shows', () => {
+  it('requires the admin role (driver → 403)', async () => {
+    const app = await buildApp({ auth });
+    const driver = await jwt.signAccessToken({ userId: 'd', role: 'driver' });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/admin/resolve-no-shows',
+      headers: bearer(driver),
+      payload: { travelDate: DATE, direction: 'morning' },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('admin resolves no-shows and deducts the rides', async () => {
+    const reservations = new InMemoryReservationRepository();
+    const entitlements = new InMemoryEntitlementLedgerRepository();
+    await reserve(reservations, entitlements, 'ama');
+    const app = await buildApp({ auth, reservations, entitlements });
+    const admin = await jwt.signAccessToken({ userId: 'admin', role: 'admin' });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/admin/resolve-no-shows',
+      headers: bearer(admin),
+      payload: { travelDate: DATE, direction: 'morning' },
+    });
+    expect(res.json()).toEqual({ noShows: 1 });
+    expect(await entitlements.remainingRides('ama')).toBe(9);
+  });
+});


### PR DESCRIPTION
Completes **E4** (#102). The three boarding verification layers already deduct a ride; this adds the **other** deduction path the model requires — the **confirmed-yes no-show** (ADR-0014: *"deduct only on boarding verification OR confirmed no-show"*).

## What it does
A rider who confirmed a seat (`reserved`) but was never boarded by the cutoff is a no-show: deduct one ride and mark the seat `no_show`. The mirror of boarding.

- **`BoardingService.resolveNoShows(travelDate, direction)`** — every still-`reserved` seat for that day+direction is deducted + marked `no_show`.
- **`POST /admin/resolve-no-shows`** — admin-gated cutoff trigger (a Render cron hits it after each travel window), mirroring the E3 `resolve-defaults` / E5 `convert-credits` endpoints.
- **`ReservationRepository`** — `listReserved(date, direction)` + `markNoShow(id)` (interface + InMemory + Pg).

## Correctness (it deducts rides, so this matters)
- **Charged at most once per seat.** The no-show deducts on the **same idempotency key as boarding** (`board:<reservationId>`) — as the boarding doc intended — so a late board after the sweep, or a re-run, collides on the key and no-ops. (I initially used a separate `noshow:` key; switched to the shared key after re-reading `boarding.md`.)
- **Only `reserved` rows** are selected — a `boarded`/`declined`/`pending` seat is never a no-show.
- **Deduct-before-mark** (like the credit conversion) so a partial run converges without losing a deduction.

## Tests
Per-seat deduction + `no_show`, only-reserved targeting, idempotent re-run, the **shared-key late-board invariant**, unwired no-op, and the admin route 403/200. **318 pass**, coverage above thresholds, typecheck + build clean.

Closes #102.