### PR TITLE
docs: refresh STATUS.md to the current platform state

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,116 +1,129 @@
 # Platform status & gap analysis
 
-**Snapshot:** 2026-06-26 · a point-in-time map of `mobility-core`. Update as
+**Snapshot:** 2026-07-08 · a point-in-time map of `mobility-core`. Update as
 areas land; it is not authoritative once the code moves.
 
 ## Architecture (what exists)
 
 `services/api` — Fastify 5 + TypeScript (Node 24), single process, layered
-`server.ts → buildApp (app.ts) → plugins/routes → repositories`.
+`server.ts → buildApp (app.ts) → plugins → routes → services → repositories`.
+The **service layer now exists** (business logic no longer lives in routes):
+`AuthService`, `PaymentsService`, `BoardingService`, `ManifestService`,
+`AskDispatchService`, `CreditService`.
 
-| Layer        | Modules                                                                                                                                                                                                  |
-| ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Config       | `config/env.ts` (zod-validated env), `config/dotenv.ts`                                                                                                                                                  |
-| Data         | `db/migrate.ts` (runner), `db/pool.ts`; migrations `001_init` (users, auth_identity, sessions), `002`/`003` (subscriptions + constraints), `014` (mobility routes/stops), `015` (trips/vehicles/drivers) |
-| KV           | `kv/kv.store.ts` (interface + in-memory), `kv.store.redis.ts` (ADR-0010)                                                                                                                                 |
-| Auth         | `auth/jwt.ts`, `auth/auth.plugin.ts` (`authenticate`/`requireRole`), `auth/auth.routes.ts` (`/me`) (ADR-0007)                                                                                            |
-| Rate limit   | `ratelimit/ratelimit.plugin.ts` (#23)                                                                                                                                                                    |
-| Domain repos | `users/*`, `subscriptions/*` — **repos only, no routes**; `mobility/*` — repos + browse routes (#17)                                                                                                     |
-| Contract     | `lib/schemas.ts`, `user.schema.ts`, `mobility.schema.ts`, OpenAPI via zod type-provider (ADR-0008)                                                                                                       |
+| Layer         | Modules                                                                                                                                                                                                      |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Config        | `config/env.ts` (zod-validated env), `config/dotenv.ts`                                                                                                                                                      |
+| Data          | `db/migrate.ts` (runner + `_migrations` table), `db/pool.ts`; migrations `001`–`020` (auth, subscriptions, mobility, payments, ledgers, reservations, boarding PIN, flags, route pinning, credit conversion) |
+| KV            | `kv/kv.store.ts` (interface + in-memory), `kv.store.redis.ts` (ADR-0010)                                                                                                                                     |
+| Object store  | `storage/object-store.ts` (Fake) + `object-store.r2.ts` (Cloudflare R2, #24)                                                                                                                                 |
+| Auth          | `auth/jwt.ts`, `auth/auth.plugin.ts` (`authenticate`/`requireRole`), `auth.service.ts`, Google verifier (ADR-0007)                                                                                           |
+| Rate limit    | `ratelimit/ratelimit.plugin.ts` (#23)                                                                                                                                                                        |
+| Observability | `observability/tracing.live.ts` (OTel → Grafana/Tempo), `metrics/metrics.plugin.ts` (Prometheus `/metrics`, RED) (#28, ADR-0012)                                                                             |
+| Contract      | zod schemas per module, OpenAPI via zod type-provider (ADR-0008), Swagger UI at `/docs`                                                                                                                      |
 
-**Live HTTP surface:** `/`, `/version`, `/healthz`, `/readyz`, `/me`, `/docs`, `/routes`, `/routes/:id`, `/trips`, `/trips/:id`, `/flags` (public feature flags + min supported version, #27), `/admin/*` (fleet CRUD + trip assignment + flags/min-versions, admin-only, #26/#27).
+**Cross-cutting (in place):** repository pattern (ADR-0009, InMemory + Pg
+selected by `DATABASE_URL`), KV fallback (ADR-0010), readiness pings DB+KV,
+rate limiting, typed OpenAPI, OTel tracing + Prometheus metrics, push
+notifications (FCM), CI + security gates (gitleaks/CodeQL/pnpm-audit), CD
+(migrate→deploy, staging auto / prod gated), CODEOWNERS reviews.
 
-**Cross-cutting (in place):** repository pattern (ADR-0009), KV fallback
-(ADR-0010), readiness pings DB+KV, rate limiting, typed OpenAPI, ~100% unit
-coverage, CI + security gates (gitleaks/CodeQL/audit), CD (migrate→deploy,
-staging auto / prod gated), CODEOWNERS + code-owner reviews.
+**Live HTTP surface (main):**
 
-## Gaps
+- **Public:** `/`, `/version`, `/healthz`, `/readyz`, `/docs`, `/flags`, `/routes`, `/routes/:id`, `/webhooks/paystack`
+- **Auth:** `/auth/google`, `/auth/refresh`, `/auth/logout`, `/me`, `/me/sessions`, `DELETE /me/sessions/:id`
+- **Rider:** `/me/avatar`, `/me/devices`, `/me/rides`, `/me/reservations`, `/me/pass`, `/payments/subscribe`, `/trips`, `/trips/:id`, `/trips/:id/position`
+- **Driver:** `/boarding/scan`, `/boarding/verify-pin`, `/boarding/manifest`
+- **Admin/ops:** `/admin/{routes,stops,vehicles,drivers,trips}` CRUD + `/admin/trips/:id/assignment`, `/admin/users/:id/role`, `/admin/flags`, `/admin/min-versions`, `/admin/ask-dispatch`, `/admin/resolve-defaults`, `/admin/convert-credits`
+- **Metrics:** `/metrics` (token-gated)
 
-### 🔴 Auth is half-built (highest impact)
+## Status by domain
 
-- **No sign-in** — no `/auth/google` / `/auth/apple`, no ID-token verification
-  (slice 2). Blocks the mobile login flow (#34).
-- **`sessions` and `auth_identity` tables exist but are unused** — no refresh
-  tokens, rotation, revoke, or logout. The refresh half of ADR-0007 is unbuilt.
+### 🟢 Auth (ADR-0007)
 
-### 🟡 Subscriptions
+Google **sign-in** (`/auth/google`, ID-token verification), **refresh** tokens
+(`/auth/refresh`, rotation), **logout**, **sessions** (`/me/sessions`), and
+**role grant** (`PATCH /admin/users/:id/role`). JWT HS256 + `requireRole` RBAC.
+_Missing:_ Apple sign-in (#34 covers the app side).
 
-- Data layer only — **no endpoint** (e.g. `GET /me/subscription`); not usable
-  over HTTP. `plan` is free-text (no enum/CHECK). In-memory repo does not enforce
-  one-active-per-user (the DB does — see ADR-0009).
+### 🟢 Mobility
 
-### 🟡 Mobility — browse layer only (closes #17, PR #57)
+Routes/stops (public browse, PostGIS), **trips** (#18 — `/trips`, `/trips/:id`),
+**admin fleet CRUD + trip assignment** (#26), **live positions** (#25 —
+`POST/GET /trips/:id/position`, assigned-driver-gated, deterministic ETA).
+_Missing:_ nearest-stop spatial endpoint (GiST index is in place).
 
-Data model and read endpoints are in place; trips landed (#18), so the
-operational layer now has schedules — boarding and live positions are next.
+### 🟢 Users / media
 
-**What landed (migration `004_mobility_routes.sql`):**
+`/me`, avatar upload → **Cloudflare R2** (#24, sharp resize + EXIF strip).
 
-- `routes` table — name, description, timestamps.
-- `stops` table — name, `location geography(Point, 4326)`, GiST index. Stored as
-  PostGIS geography so spatial queries (nearest stop, corridor search) can run
-  without a second datastore (ADR-0005). The domain model exposes plain `lat`/`lng`
-  numbers; `ST_MakePoint`/`ST_X`/`ST_Y` handle the conversion at the Pg adapter
-  boundary only.
-- `route_stops` join table — `(route_id, stop_id, seq)`. `seq` is a per-route
-  integer that defines boarding order. `UNIQUE (route_id, seq)` prevents duplicate
-  positions at the DB level; the in-memory adapter does not enforce this (ADR-0009).
+### 🟡 Money — Hybrid Subscription Model (ADR-0014, epics E1–E7)
 
-**Design choices:**
+The wallet model was dropped for the **Hybrid Subscription Model**: a
+subscription buys a **ride entitlement**; unused rides become **Ride Credits**
+against renewal; **no prepaid wallet**. Append-only, idempotent ledgers.
 
-- **Browse endpoints are intentionally public** (`GET /routes`, `GET /routes/:id`).
-  The mobile app must display the route map before a user signs in — requiring auth
-  here would block the discovery flow.
-- **Stop resolution is a fan-out, not a JOIN.** `GET /routes/:id` fetches ordered
-  `route_stops`, then resolves each stop via `Promise.all`. This keeps the domain
-  model decoupled from the DB schema. At browse-only scale the N+1 is negligible;
-  if it becomes a hotspot, a single query returning a JSON array can replace the
-  fan-out without changing the API contract.
-- **Follows ADR-0009 exactly** — `InMemory*` repos for unit tests / zero-infra dev;
-  `Pg*` adapters for real runs; `server.ts` selects by `DATABASE_URL`.
+| Epic         | Area                                                                                                                                                                                                                      | State                                            |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| **E1**       | Entitlement + credit ledgers, `/me/rides`, allocation on paid webhook                                                                                                                                                     | ✅ live                                          |
+| **Payments** | Paystack `/payments/subscribe` + `/webhooks/paystack` (HMAC-verified)                                                                                                                                                     | ✅ live                                          |
+| **E3**       | Reservations (`/me/reservations` confirm/decline + daily PIN), scheduled **ask-dispatch** (`/admin/ask-dispatch`, `/admin/resolve-defaults`), rider↔route pinning, **FCM push** (real, behind `FIREBASE_SERVICE_ACCOUNT`) | ✅ live                                          |
+| **E4**       | Boarding: QR scan + daily PIN + manifest (assigned-driver-gated), ride **deduction**                                                                                                                                      | ✅ live · **no-show deduction in review (#132)** |
+| **E5**       | Month-end **credit conversion** (`/admin/convert-credits`)                                                                                                                                                                | ✅ live (placeholder per-ride value)             |
+| **E1b**      | Plan tiers + pricing (#103)                                                                                                                                                                                               | 🔴 **blocked: product pricing**                  |
+| **E5b**      | Credit-netted renewal + auto-renew (#128)                                                                                                                                                                                 | 🔴 **blocked: credit value**                     |
+| **E6**       | Standby pool (KYC + offer cascade + instant fare, #105)                                                                                                                                                                   | 🔴 **blocked: fare + KYC**                       |
+| **E7**       | Drop legacy `token_ledger` table (#106)                                                                                                                                                                                   | **in review (#130)**                             |
 
-**Still missing (mobility):**
+Fees, rides-per-period, and per-ride credit value are **placeholder constants**
+(`payments.service.ts`, `credit.service.ts`) until pricing is decided — the
+mechanisms are built; only the numbers change.
 
-| Area                                | Issue | Notes                                                                                                                 |
-| ----------------------------------- | ----- | --------------------------------------------------------------------------------------------------------------------- |
-| Trips & schedules                   | #18   | ✅ landed — trips/vehicles/drivers + `assigned_driver_id`; `GET /trips` (`?routeId`), `GET /trips/:id` (auth-gated)   |
-| Admin/ops (fleet CRUD + assignment) | #26   | ✅ landed — `/admin/*` admin-guarded CRUD for routes/stops/vehicles/drivers/trips + `PUT /admin/trips/:id/assignment` |
-| QR boarding / passes / scan_events  | #20   | none                                                                                                                  |
-| Live vehicle positions (polling)    | #25   | no positions table; ADR-0002 telemetry deferred                                                                       |
-| Nearest-stop spatial query          | —     | GiST index is in place; no endpoint yet                                                                               |
+### 🟢 Notifications / devices
 
-### ❌ Not started (mapped to issues)
+FCM device-token registry (`/me/devices`, #84), real `FcmNotificationSender`
+behind `FIREBASE_SERVICE_ACCOUNT` (set + confirmed live on staging), recording
+fake otherwise.
 
-| Area                                    | Issue         | Notes                                   |
-| --------------------------------------- | ------------- | --------------------------------------- |
-| Token ledger & payments (Paystack)      | #21           | no tables/logic (CTO)                   |
-| QR boarding / passes / scan_events      | #20           | none (CTO)                              |
-| Avatar upload → R2                      | #24           | none                                    |
-| Observability (RED metrics, `/metrics`) | #28           | only default pino logs                  |
-| Account deletion                        | #30           | none                                    |
-| Flutter apps                            | #32+          | `apps/` is a README — no scaffold       |
-| Telemetry (MQTT→Go)                     | ADR-0002/0006 | EMQX in compose, no pipeline (deferred) |
+### 🟢 Flags / force-update (#27)
 
-### 🟡 Architecture notes
+Public `/flags` (feature flags + min supported version), admin `/admin/flags`
+and `/admin/min-versions`.
 
-- **No service layer** yet — routes call repositories directly. Fine at this size;
-  introduce `routes → services → repositories` before real business logic lands.
-- e2e is minimal — no DB-backed flows (ci.yml has a TODO for a postgis service
-  container + seed).
+### 🟢 Observability (#28, ADR-0012)
+
+OTel tracing → Grafana Cloud (Tempo), Prometheus `/metrics` (RED, token-gated),
+structured pino logs.
+
+## In review (open PRs)
+
+- **#130** — E7: drop legacy `token_ledger` table (+ ADR-0011 marked superseded).
+- **#131** — chore: bump vitest 2 → 4 (coordinated with coverage-v8 + vite).
+- **#132** — E4: confirmed-yes no-show deduction (`/admin/resolve-no-shows`).
+
+## Not started / other lanes
+
+| Area                                                      | Issue         | Owner / note                              |
+| --------------------------------------------------------- | ------------- | ----------------------------------------- |
+| Account deletion (data-subject rights)                    | #30           | Foyade                                    |
+| Apple sign-in                                             | #34           | FE lane                                   |
+| Flutter apps (auth, home, subscribe, board, map, history) | #34–41        | adomfosugit / FE                          |
+| Commuter app: handle ask-dispatch push                    | #125          | adomfosugit                               |
+| Activate ask-dispatch cron on Render                      | #126          | CTO (ops)                                 |
+| Convert-credits / no-show **cron schedules**              | —             | needs a product-timing decision           |
+| Paystack nightly reconciliation                           | —             | deferred with the money work              |
+| MQTT→Go telemetry pipeline                                | ADR-0002/0006 | deferred (HTTP polling is the pilot path) |
 
 ## ADR status
 
-- **0003** (TS+Fastify) — amended for Node 24 (was 22).
-- **0007** (JWT) — accurate; rate limiting it cited as "slice 3" has since landed (#23).
-- **0009** (repository pattern), **0010** (KV/Redis) — added to record patterns
-  that were previously only in code comments.
+- **0007** (JWT) — sign-in + refresh + rate limiting have all landed.
+- **0009** (repository pattern), **0010** (KV/Redis) — in force across the codebase.
+- **0011** (token wallet ledger) — **superseded by 0014** (wallet dropped; the
+  append-only-ledger _pattern_ is reused by the entitlement + credit ledgers).
+- **0014** (Hybrid Subscription Model) — the active money ADR (epics E1–E7).
 
-## Suggested next
+## Highest-leverage next step
 
-1. **Auth slice 2** (sign-in + refresh) — the biggest unblock; needs Google OAuth
-   setup.
-2. `GET /me/subscription` — make subscriptions a real, secured, documented API.
-3. **Trips & schedules** (#18) — next mobility slice; builds on the routes/stops
-   foundation from PR #57.
-4. Observability (#28) — `/metrics` + structured fields, before traffic grows.
+**Pilot pricing decisions** (per-ride credit value, plan tiers/prices, standby
+fare) unblock **E1b, E5b, and E6** at once — the mechanisms are already built and
+only need real numbers.


### PR DESCRIPTION
`docs/STATUS.md` was a **2026-06-26** snapshot — stale by many epics. It still claimed "auth half-built / no sign-in", "QR boarding: none", "payments: no tables/logic", "no service layer", and omitted the **entire Hybrid Subscription Model (E1–E7)**, reservations, observability, avatars, and flags. Anyone onboarding was reading a map of a codebase that no longer exists.

## Rewritten from the actual current state
Grounded in a route enumeration + merged history (every claim verified against `main`):
- **Architecture** — service layer now exists (Auth/Payments/Boarding/Manifest/AskDispatch/Credit services); full layer table (OTel, R2, metrics, KV, migrations 001–020).
- **Live HTTP surface** grouped by audience (public / auth / rider / driver / admin).
- **Domain status** — auth (sign-in/refresh/sessions/role), mobility (trips/ops/positions/ETA), a clear **E1–E7 money table** (✅ live vs 🔴 pricing-blocked), FCM, flags, observability.
- **In review** (open PRs #130/#131/#132), **not started / other lanes** with owners, and refreshed **ADR status** (0011 superseded by 0014).
- Ends with the highest-leverage next step: the **pilot pricing decisions** that unblock E1b/E5b/E6.

## Verification
Docs-only — no code touched (lint + typecheck clean via pre-commit; full suite/build unaffected). Claims cross-checked against `main`: migration ceiling `020`, auth routes, positions+ETA, and the merged E1/E3/E4/E5 surface.