### PR TITLE
feat(demo): live investor walkthrough driven by the real API (+ CORS)

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -1,9 +1,13 @@
 # Trotxi live demo
 
 An animated investor walkthrough of the Hybrid Subscription Model loop —
-**subscribe → confirm → board → no-show → month-end credit** — where every number
-on screen (the ride entitlement, the daily PIN, each deduction, the converted
-credit) is returned **live by the real Trotxi API**, not scripted.
+**subscribe → confirm → board → no-show → month-end credit** — for a real fleet
+of **40 members** on the Circle ⇄ Madina corridor. It's a **two-sided** view:
+Ama's phone journey on one side, and a live **operator console** on the other
+(members, monthly revenue, seats confirmed, boarded, occupancy, credit liability).
+Every number — the ride entitlement, the daily PIN, each deduction, the operator
+economics, the converted credit — is returned **live by the real Trotxi API**,
+not scripted.
 
 ## Run it
 

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,0 +1,38 @@
+# Trotxi live demo
+
+An animated investor walkthrough of the Hybrid Subscription Model loop —
+**subscribe → confirm → board → no-show → month-end credit** — where every number
+on screen (the ride entitlement, the daily PIN, each deduction, the converted
+credit) is returned **live by the real Trotxi API**, not scripted.
+
+## Run it
+
+```bash
+pnpm --filter @trotxi/api demo
+# → Trotxi live demo → http://localhost:4319
+```
+
+Open <http://localhost:4319> and press **Play** (or step with Next / ← →).
+
+## How it works
+
+`services/api/scripts/demo-server.ts` boots the real API in-process (in-memory,
+zero infra) and serves this page plus a few `POST /demo/*` endpoints. Each beat of
+the walkthrough calls one endpoint, which drives that step of the loop through the
+actual API and returns the real result:
+
+| Beat      | Real call behind it                                                      |
+| --------- | ------------------------------------------------------------------------ |
+| Subscribe | `/payments/subscribe` + the signed Paystack webhook → 44 rides allocated |
+| Confirm   | `POST /me/reservations` → the daily boarding PIN                         |
+| Board     | `POST /boarding/verify-pin` → one ride deducted (44 → 43)                |
+| No-show   | `POST /admin/resolve-no-shows` → a held-but-unused seat deducted         |
+| Month-end | `POST /admin/convert-credits` → unused rides → Ride Credits              |
+
+It runs entirely locally so a pitch never waits on a cold start. Pricing figures
+are illustrative placeholders (see `payments.service.ts` / `credit.service.ts`)
+until the pilot pricing is locked; the mechanics are real.
+
+> Note: browser pages can call a deployed API only because CORS is enabled on the
+> API (`@fastify/cors`). The demo runner serves this page same-origin, so it needs
+> no configuration.

--- a/demo/index.html
+++ b/demo/index.html
@@ -295,6 +295,68 @@
         background: var(--accent-bg);
         border-color: var(--accent);
       }
+      .rolebadge {
+        display: inline-flex;
+        align-items: center;
+        gap: 7px;
+        font-size: 12px;
+        font-weight: 500;
+        padding: 5px 11px;
+        border-radius: 999px;
+        margin-bottom: 12px;
+        background: var(--blue-bg);
+        color: var(--blue-ink);
+      }
+      .rolebadge.driver {
+        background: var(--amber-bg);
+        color: var(--amber);
+      }
+      .rolebadge.ops {
+        background: var(--tile);
+        color: var(--muted);
+      }
+      .rolebadge .rdot {
+        width: 7px;
+        height: 7px;
+        border-radius: 50%;
+        background: currentColor;
+      }
+      .man {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+      }
+      .manrow {
+        display: flex;
+        align-items: center;
+        gap: 9px;
+        font-size: 13px;
+        padding: 7px 9px;
+        border-radius: 9px;
+        background: var(--surface);
+      }
+      .manrow.ama {
+        outline: 1.5px solid var(--accent);
+      }
+      .manrow .av {
+        width: 22px;
+        height: 22px;
+        border-radius: 50%;
+        background: var(--tile);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 11px;
+        color: var(--muted);
+      }
+      .manrow .st {
+        margin-left: auto;
+        font-size: 12px;
+        color: var(--muted);
+      }
+      .manrow .st.on {
+        color: var(--accent-ink);
+      }
       .controls {
         display: flex;
         align-items: center;
@@ -368,6 +430,9 @@
 
       <div class="main">
         <div class="col rider">
+          <div class="rolebadge" id="rolebadge">
+            <span class="rdot"></span>Commuter · Ama Mensah
+          </div>
           <div class="phone"><div class="screen" id="screen"></div></div>
           <div class="rl">
             <div class="b">
@@ -449,6 +514,7 @@
       const BEATS = [
         {
           key: 'intro',
+          role: 'intro',
           eye: 'the problem',
           h: 'Meet Ama',
           p: 'A daily Circle ⇄ Madina commuter — cash fares, no guaranteed seat. Press play to run the real loop for her and 39 neighbours.',
@@ -458,6 +524,7 @@
         {
           key: 'subscribe',
           call: 'subscribe',
+          role: 'commuter',
           eye: 'step 1 — subscribe',
           h: 'A membership, not a fare',
           p: 'Ama and 39 others pay a monthly fee. The API activates each subscription and allocates guaranteed rides — real recurring revenue, live on the right.',
@@ -467,6 +534,7 @@
         {
           key: 'confirm',
           call: 'confirm',
+          role: 'commuter',
           eye: 'step 2 — confirm',
           h: 'One tap the evening before',
           p: 'Trotxi asks who is travelling. Most confirm; a few decline and their seats go to standby. Ama gets a real boarding PIN.',
@@ -478,15 +546,16 @@
         {
           key: 'board',
           call: 'board',
+          role: 'driver',
           eye: 'step 3 — board',
-          h: 'QR or PIN, one ride used',
-          p: 'The driver verifies each rider; the API deducts one ride per boarding. Watch the bus fill and the occupancy climb on the right.',
-          screen: (d) =>
-            '<div class="k">Trip 7:10 · Madina</div><div class="seats" id="busseats"></div>',
+          h: 'The driver verifies each rider',
+          p: 'This is the driver app. Ama is on the trip manifest; the driver checks her PIN or QR and the API verifies it, deducting one ride. Same loop, the driver side.',
+          screen: (d) => man(d),
         },
         {
           key: 'noshow',
           call: 'noshow',
+          role: 'ops',
           eye: 'step 4 — cutoff',
           h: 'Every outcome, fairly',
           p: 'Confirmed-but-missed is a no-show — still charged, because a seat was held. Declined seats already earned standby fares. The ledger stays exact.',
@@ -496,6 +565,7 @@
         {
           key: 'convert',
           call: 'convert',
+          role: 'commuter',
           eye: 'step 5 — month-end',
           h: 'Unused rides become credit',
           p: 'At period end the API converts every unused ride into credit toward renewal — value is never lost. The operator sees the exact liability owed back to riders.',
@@ -508,6 +578,7 @@
 
       let i = 0,
         timer = null,
+        nav = 0,
         ar = 0,
         ac = 0;
       const stage = $('#dots');
@@ -535,20 +606,59 @@
         if (e) e.textContent = v;
       }
 
+      const ROLE = {
+        driver: ['driver', 'Driver · Kwame Boateng'],
+        ops: ['ops', 'Cutoff · operations'],
+        commuter: ['', 'Commuter · Ama Mensah'],
+        intro: ['ops', 'Circle ⇄ Madina corridor'],
+      };
+
+      function man(d) {
+        if (!d || !d.manifest || !d.manifest.riders.length)
+          return '<div class="k">Trip manifest · 7:10 Madina</div><div style="color:var(--muted);font-size:13px;flex:1;display:flex;align-items:center;justify-content:center">no confirmed riders yet</div>';
+        const m = d.manifest;
+        const rows = m.riders
+          .map(
+            (r) =>
+              '<div class="manrow' +
+              (r.isAma ? ' ama' : '') +
+              '"><span class="av">' +
+              (r.name[0] || '?') +
+              '</span>' +
+              r.name +
+              (r.isAma ? ' · you' : '') +
+              '<span class="st' +
+              (r.boarded ? ' on' : '') +
+              '">' +
+              (r.boarded ? '✓ boarded' : 'waiting') +
+              '</span></div>',
+          )
+          .join('');
+        const more =
+          m.total > m.riders.length
+            ? '<div style="text-align:center;font-size:12px;color:var(--muted);padding-top:6px">+' +
+              (m.total - m.riders.length) +
+              ' more · ' +
+              m.boarded +
+              ' boarded</div>'
+            : '';
+        return (
+          '<div class="k">Trip manifest · 7:10 Madina</div><div class="man">' +
+          rows +
+          '</div>' +
+          more
+        );
+      }
+
       function paintRider(b, d) {
+        const rb = $('#rolebadge');
+        const role = ROLE[b.role] || ROLE.commuter;
+        rb.className = 'rolebadge ' + role[0];
+        rb.innerHTML = '<span class="rdot"></span>' + role[1];
         $('#reye').textContent = b.eye;
         $('#rh').textContent = b.h;
         $('#rp').textContent = b.p;
         $('#screen').innerHTML = b.screen(d);
-        if (b.key === 'board') {
-          const w = $('#busseats');
-          if (w)
-            for (let s = 0; s < 36; s++) {
-              const c = document.createElement('div');
-              c.className = 'seat' + (d && d.boarded && s < d.boarded ? ' on' : '');
-              w.appendChild(c);
-            }
-        }
       }
 
       function paintConsole(d, phase) {
@@ -570,6 +680,7 @@
 
       async function go(k) {
         i = (k + BEATS.length) % BEATS.length;
+        const myNav = ++nav;
         BEATS.forEach((_, x) => stage.children[x].classList.toggle('on', x === i));
         $('#next').textContent = i === BEATS.length - 1 ? 'Restart' : 'Next';
         const b = BEATS[i];
@@ -581,6 +692,7 @@
         try {
           const res = await fetch('/demo/' + b.call, { method: 'POST' });
           const d = await res.json();
+          if (myNav !== nav) return; // navigated away — drop this stale response
           if (!d.ok) throw new Error(d.error || 'failed');
           const ms = Math.round(performance.now() - t0);
           paintRider(b, d);
@@ -609,7 +721,10 @@
         ar = 0;
         ac = 0;
         try {
-          await fetch('/demo/reset', { method: 'POST' });
+          const r = await fetch('/demo/reset', { method: 'POST' });
+          paintConsole(await r.json(), 'idle');
+          setText('ar', '0');
+          setText('ac', 'GHS 0');
         } catch (e) {}
         go(0);
       }

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,0 +1,219 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Trotxi — live investor demo</title>
+    <style>
+      :root {
+        --bg: #f6f7f5; --surface: #ffffff; --tile: #f1f2ef; --ink: #16181d; --muted: #6b6f76;
+        --line: #e4e6e2; --accent: #0f9d76; --accent-ink: #0a5f48; --accent-bg: #e4f5ee;
+        --blue: #2a78d6; --blue-bg: #e6f1fb; --blue-ink: #185fa5; --amber: #b9770f; --amber-bg: #faeeda;
+        --purple: #4a3aa7; --red: #b23b3b; --radius: 10px;
+        --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace;
+        --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #14161a; --surface: #1c1f24; --tile: #23262c; --ink: #f0f1f3; --muted: #9aa0a8;
+          --line: #2b2f36; --accent: #2fbd93; --accent-ink: #8fe3c9; --accent-bg: #123a2e;
+          --blue: #6aa8f0; --blue-bg: #12233a; --blue-ink: #9cc6f5; --amber: #e0a545; --amber-bg: #3a2e12;
+          --purple: #9085e9; --red: #e07070;
+        }
+      }
+      * { box-sizing: border-box; }
+      body { margin: 0; background: var(--bg); color: var(--ink); font-family: var(--sans); line-height: 1.5; }
+      .wrap { max-width: 760px; margin: 0 auto; padding: 26px 20px 60px; }
+      .top { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+      .brand { display: flex; align-items: center; gap: 11px; }
+      .logo { width: 40px; height: 40px; border-radius: 11px; background: var(--accent-bg); color: var(--accent-ink); display: flex; align-items: center; justify-content: center; font-size: 22px; }
+      h1 { font-size: 19px; font-weight: 600; margin: 0; }
+      .sub { color: var(--muted); font-size: 13px; margin: 1px 0 0; }
+      .live { display: inline-flex; align-items: center; gap: 6px; font-size: 12px; font-weight: 500; color: var(--accent-ink); background: var(--accent-bg); padding: 5px 11px; border-radius: 999px; }
+      .live .dot { width: 7px; height: 7px; border-radius: 50%; background: var(--accent); animation: pulse 1.5s infinite; }
+      @keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: .35; } }
+      .ledger { display: flex; align-items: center; gap: 14px; background: var(--surface); border: 1px solid var(--line); border-radius: 12px; padding: 13px 16px; margin: 18px 0; flex-wrap: wrap; }
+      .ledger .cell { display: flex; align-items: center; gap: 9px; }
+      .ledger .k { font-size: 11px; color: var(--muted); }
+      .ledger .v { font-size: 22px; font-weight: 600; font-variant-numeric: tabular-nums; }
+      .ledger .sep { width: 1px; height: 30px; background: var(--line); }
+      .note { flex: 1; min-width: 160px; font-size: 13px; color: var(--muted); }
+      .stage { min-height: 320px; }
+      .beat { display: none; }
+      .beat.on { display: block; animation: fade .45s ease both; }
+      @keyframes fade { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: none; } }
+      .g2 { display: grid; grid-template-columns: 220px 1fr; gap: 26px; align-items: center; }
+      @media (max-width: 600px) { .g2 { grid-template-columns: 1fr; } }
+      .eyebrow { font-size: 11px; letter-spacing: .06em; color: var(--muted); text-transform: uppercase; }
+      h2 { font-size: 20px; font-weight: 600; margin: 5px 0 9px; }
+      .beat p { margin: 0 0 14px; color: var(--muted); font-size: 15px; }
+      .phone { width: 220px; margin: 0 auto; background: var(--surface); border: 1px solid var(--line); border-radius: 28px; padding: 9px; }
+      .screen { background: var(--tile); border-radius: 20px; padding: 15px; min-height: 290px; display: flex; flex-direction: column; }
+      .chip { display: inline-flex; align-items: center; gap: 7px; font-size: 13px; padding: 6px 11px; border-radius: 999px; background: var(--tile); color: var(--muted); }
+      .pill { display: inline-block; font-size: 13px; font-weight: 500; padding: 4px 10px; border-radius: 8px; }
+      .p-accent { background: var(--accent-bg); color: var(--accent-ink); }
+      .p-blue { background: var(--blue-bg); color: var(--blue-ink); }
+      .p-amber { background: var(--amber-bg); color: var(--amber); }
+      .stat { background: var(--tile); border-radius: 12px; padding: 13px 15px; display: inline-block; }
+      .seats { display: grid; grid-template-columns: repeat(4, 1fr); gap: 7px; }
+      .seat { aspect-ratio: 1; border-radius: 8px; background: var(--surface); border: 1px solid var(--line); display: flex; align-items: center; justify-content: center; color: var(--muted); font-size: 15px; transition: all .4s; }
+      .seat.full { background: var(--tile); color: var(--muted); }
+      .seat.me { background: var(--accent-bg); border-color: var(--accent); color: var(--accent-ink); }
+      .apistat { font-family: var(--mono); font-size: 11.5px; color: var(--muted); margin-top: 12px; min-height: 16px; }
+      .apistat.ok { color: var(--accent-ink); } .apistat.err { color: var(--red); }
+      .controls { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-top: 20px; border-top: 1px solid var(--line); padding-top: 15px; }
+      .dots { display: flex; gap: 6px; }
+      .dot2 { width: 8px; height: 8px; border-radius: 999px; background: var(--line); border: none; padding: 0; cursor: pointer; transition: width .25s, background .25s; }
+      .dot2.on { background: var(--accent); width: 22px; }
+      button.b { font-family: var(--sans); font-size: 14px; font-weight: 500; cursor: pointer; border-radius: var(--radius); border: 1px solid var(--line); background: var(--surface); color: var(--ink); padding: 8px 15px; display: inline-flex; align-items: center; gap: 6px; }
+      button.b:hover { border-color: var(--accent); }
+      button.b.primary { background: var(--accent); color: #fff; border-color: var(--accent); }
+      button.b:disabled { opacity: .5; cursor: default; }
+      .two { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+      .card { background: var(--surface); border: 1px solid var(--line); border-radius: 12px; padding: 15px; }
+      .kpis { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; margin-top: 12px; }
+      .lead { font-size: 13px; line-height: 1.9; color: var(--muted); }
+      code { font-family: var(--mono); font-size: 12px; }
+    </style>
+  </head>
+  <body>
+    <div class="wrap">
+      <div class="top">
+        <div class="brand">
+          <div class="logo">◐</div>
+          <div>
+            <h1>Trotxi — live demo</h1>
+            <p class="sub">Accra commuting, on subscription</p>
+          </div>
+        </div>
+        <span class="live"><span class="dot"></span>live API</span>
+      </div>
+
+      <div class="ledger">
+        <div class="cell"><div><div class="k">Rides left</div><div class="v" id="rides">0</div></div></div>
+        <div class="sep"></div>
+        <div class="cell"><div><div class="k">Ride credits</div><div class="v" id="credits">GHS 0.00</div></div></div>
+        <div class="sep"></div>
+        <div class="note" id="note">Every number below is returned live by the Trotxi API.</div>
+      </div>
+
+      <div class="stage" id="stage"></div>
+
+      <div class="controls">
+        <div class="dots" id="dots"></div>
+        <div style="display:flex;gap:8px;">
+          <button class="b" id="back">Back</button>
+          <button class="b" id="play">Play</button>
+          <button class="b primary" id="next">Next</button>
+        </div>
+      </div>
+    </div>
+
+    <script>
+      const $ = (s) => document.querySelector(s);
+      const money = (pesewas) => 'GHS ' + (pesewas / 100).toFixed(2);
+
+      const BEATS = [
+        { key: 'intro', eyebrow: 'the problem', h: 'The daily commute is a gamble',
+          body: 'Accra runs on 1.5M+ trotro trips a day — cash only, no guaranteed seat, unpredictable for riders and operators. Trotxi turns the seat into a membership. Press play to run the real loop.',
+          visual: () => '<div style="text-align:center"><div style="width:150px;height:150px;margin:auto;border-radius:20px;background:var(--blue-bg);display:flex;align-items:center;justify-content:center;font-size:60px;color:var(--blue-ink)">◍</div></div>' },
+        { key: 'subscribe', call: 'subscribe', eyebrow: 'step 1 — subscribe', h: 'A membership, not a fare',
+          body: 'Ama pays a monthly fee. The API activates her subscription and allocates a ride entitlement — a real balance, live above.',
+          visual: () => phone('<div class="k" style="font-size:12px;color:var(--muted);margin-bottom:10px">Circle ⇄ Madina · monthly</div><div style="background:var(--surface);border:1px solid var(--line);border-radius:12px;padding:12px"><div style="font-size:22px;font-weight:600">GHS 200</div><div style="font-size:12px;color:var(--muted)">44 guaranteed rides</div></div><div style="flex:1"></div><div style="margin-top:12px;text-align:center;background:var(--accent);color:#fff;padding:11px;border-radius:10px;font-size:14px;font-weight:500">Pay with mobile money</div>') },
+        { key: 'confirm', call: 'confirm', eyebrow: 'step 2 — confirm', h: 'One tap the evening before',
+          body: 'Trotxi asks who is travelling. A tap holds the seat and the API issues a real daily boarding PIN — shown here, straight from the response.',
+          visual: (d) => phone('<div style="font-size:12px;color:var(--muted);margin-bottom:10px">Trotxi · now</div><div style="background:var(--surface);border:1px solid var(--line);border-radius:12px;padding:13px"><div style="font-weight:500;font-size:14px">Travelling tomorrow morning?</div><div style="font-size:12px;color:var(--muted);margin-top:3px">Tap to hold your seat.</div></div><div style="display:flex;gap:8px;margin-top:12px"><div style="flex:1;text-align:center;padding:10px;border-radius:10px;background:var(--accent-bg);color:var(--accent-ink);font-size:13px;font-weight:500">Yes</div><div style="flex:1;text-align:center;padding:10px;border-radius:10px;background:var(--surface);border:1px solid var(--line);color:var(--muted);font-size:13px">No</div></div><div style="flex:1"></div><div style="margin-top:12px;text-align:center;font-size:12px;color:var(--muted)">boarding PIN <strong id="pin" style="color:var(--ink);font-size:15px">' + (d && d.pin ? d.pin : '––––') + '</strong></div>') },
+        { key: 'board', call: 'board', eyebrow: 'step 3 — board', h: 'QR or PIN, one ride used',
+          body: 'The driver verifies Ama and the API deducts one ride from the ledger — idempotent, so she is never double-charged. Watch the counter above tick down for real.',
+          visual: () => '<div class="card"><div style="font-size:12px;color:var(--muted);margin-bottom:10px">Trip 7:10 · Madina</div><div class="seats" id="seats"></div></div>' },
+        { key: 'noshow', call: 'noshow', eyebrow: 'step 4 — every outcome, fairly', h: 'The model handles real life',
+          body: 'Confirm-then-miss is a no-show — still counted, because a seat was held. Declines are resold to standby riders. The API just deducted a real no-show above.',
+          visual: () => '<div style="display:flex;flex-direction:column;gap:8px">' + dayRow('Mon', 'Boarded', 'p-accent') + dayRow('Tue', 'Declined → standby', 'p-blue') + dayRow('Wed', 'No-show', 'p-amber') + '</div>' },
+        { key: 'convert', call: 'convert', eyebrow: 'step 5 — month-end', h: 'Unused rides become credit',
+          body: 'At period end the API converts her remaining rides into Ride Credits toward renewal. Value is never lost — the credit above is the real converted amount.',
+          visual: (d) => '<div style="text-align:center"><div style="display:inline-flex;align-items:center;gap:14px"><div class="stat" style="text-align:center"><div style="font-size:12px;color:var(--muted)">converted</div><div style="font-size:26px;font-weight:600" id="conv">' + (d && d.converted != null ? d.converted : '–') + '</div><div style="font-size:11px;color:var(--muted)">rides</div></div><div style="font-size:22px;color:var(--muted)">→</div><div class="stat" style="text-align:center;background:var(--accent-bg)"><div style="font-size:12px;color:var(--accent-ink)">credit</div><div style="font-size:26px;font-weight:600;color:var(--accent-ink)" id="cred2">' + (d ? money(d.credits) : 'GHS 0') + '</div></div></div></div>' },
+        { key: 'close', eyebrow: 'the model', h: 'Predictable, and fair to both sides',
+          body: 'One subscription loop — proven live above against the real API.',
+          visual: () => '<div class="two"><div class="card"><div style="font-weight:600;font-size:14px;margin-bottom:8px;color:var(--blue-ink)">For the rider</div><div class="lead">Guaranteed seat every morning<br>One tap to confirm, one PIN to board<br>Unused rides return as credit</div></div><div class="card"><div style="font-weight:600;font-size:14px;margin-bottom:8px;color:var(--accent-ink)">For the operator</div><div class="lead">Predictable recurring revenue<br>Declined seats resold to standby<br>Demand forecast from confirmations</div></div></div><div class="kpis"><div class="stat"><div style="font-size:12px;color:var(--muted)">Seat use</div><div style="font-size:18px;font-weight:600">62% → 89%</div></div><div class="stat"><div style="font-size:12px;color:var(--muted)">Revenue</div><div style="font-size:18px;font-weight:600">Recurring</div></div><div class="stat"><div style="font-size:12px;color:var(--muted)">Value kept</div><div style="font-size:18px;font-weight:600">100%</div></div></div>' },
+      ];
+
+      function phone(inner) { return '<div class="phone"><div class="screen">' + inner + '</div></div>'; }
+      function dayRow(d, label, cls) { return '<div style="display:flex;align-items:center;gap:10px;background:var(--surface);border:1px solid var(--line);border-radius:10px;padding:9px 11px;font-size:13px"><span style="width:34px;color:var(--muted)">' + d + '</span><span class="pill ' + cls + '">' + label + '</span></div>'; }
+
+      let i = 0, timer = null, curRides = 0, curCredits = 0;
+      const stage = $('#stage'), dots = $('#dots');
+
+      BEATS.forEach((b, k) => {
+        const sec = document.createElement('section');
+        sec.className = 'beat' + (k === 0 ? ' on' : ''); sec.id = 'beat' + k;
+        stage.appendChild(sec);
+        const dot = document.createElement('button');
+        dot.className = 'dot2' + (k === 0 ? ' on' : '');
+        dot.onclick = () => { stopPlay(); go(k); };
+        dots.appendChild(dot);
+      });
+
+      function tween(el, from, to, fmt) {
+        const t0 = performance.now(), d = 650;
+        (function f(now) { const p = Math.min(1, (now - t0) / d); const v = from + (to - from) * p; el.textContent = fmt(v); if (p < 1) requestAnimationFrame(f); })(t0);
+      }
+
+      function paint(k, data) {
+        const b = BEATS[k], sec = $('#beat' + k);
+        sec.innerHTML = '<div class="g2"><div>' + b.visual(data) + '</div><div><div class="eyebrow">' + b.eyebrow + '</div><h2>' + b.h + '</h2><p>' + b.body + '</p>' + (b.call ? '<div class="apistat" id="api' + k + '"></div>' : '') + '</div></div>';
+        if (b.key === 'close') sec.innerHTML = '<div class="eyebrow">' + b.eyebrow + '</div><h2>' + b.h + '</h2><p>' + b.body + '</p>' + b.visual();
+        if (k >= 3) { const sw = sec.querySelector('#seats'); if (sw) for (let s = 0; s < 12; s++) { const d = document.createElement('div'); d.className = 'seat ' + (s < 7 ? 'full' : (s === 7 ? 'me' : '')); d.textContent = s === 7 ? '★' : '·'; sw.appendChild(d); } }
+      }
+
+      async function go(k) {
+        i = (k + BEATS.length) % BEATS.length;
+        BEATS.forEach((_, x) => { $('#beat' + x).classList.toggle('on', x === i); dots.children[x].classList.toggle('on', x === i); });
+        $('#next').innerHTML = i === BEATS.length - 1 ? 'Restart' : 'Next';
+        const b = BEATS[i];
+        paint(i, {});
+        if (b.call) {
+          const st = $('#api' + i); if (st) { st.className = 'apistat'; st.textContent = 'calling the API…'; }
+          const t0 = performance.now();
+          try {
+            const res = await fetch('/demo/' + b.call, { method: 'POST' });
+            const data = await res.json();
+            const ms = Math.round(performance.now() - t0);
+            if (!data.ok) throw new Error(data.error || 'step failed');
+            paint(i, data);
+            tween($('#rides'), curRides, data.rides, (v) => Math.round(v));
+            tween($('#credits'), curCredits, data.credits, (v) => money(v));
+            curRides = data.rides; curCredits = data.credits;
+            $('#note').textContent = noteFor(b.key, data);
+            const st2 = $('#api' + i); if (st2) { st2.className = 'apistat ok'; st2.textContent = 'live · POST /demo/' + b.call + ' · ' + res.status + ' · ' + ms + ' ms'; }
+          } catch (e) {
+            const st2 = $('#api' + i); if (st2) { st2.className = 'apistat err'; st2.textContent = 'API error: ' + (e && e.message ? e.message : e) + ' — is the demo server running?'; }
+          }
+        }
+      }
+
+      function noteFor(key, d) {
+        if (key === 'subscribe') return 'Subscription activated — ' + d.rides + ' rides allocated by the API.';
+        if (key === 'confirm') return 'Seat reserved — PIN ' + d.pin + ' issued for boarding.';
+        if (key === 'board') return 'Boarded and verified — one ride deducted.';
+        if (key === 'noshow') return 'No-show resolved — a held-but-unused seat was deducted.';
+        if (key === 'convert') return 'Month-end — ' + d.converted + ' unused rides converted to ' + money(d.credits) + ' credit.';
+        return 'Every number is returned live by the Trotxi API.';
+      }
+
+      function stopPlay() { if (timer) { clearInterval(timer); timer = null; $('#play').textContent = 'Play'; } }
+      $('#next').onclick = () => { stopPlay(); go(i + 1); };
+      $('#back').onclick = () => { stopPlay(); go(i - 1); };
+      $('#play').onclick = () => {
+        if (timer) { stopPlay(); return; }
+        $('#play').textContent = 'Pause';
+        timer = setInterval(() => { if (i === BEATS.length - 1) { stopPlay(); return; } go(i + 1); }, 3200);
+      };
+      document.addEventListener('keydown', (e) => { if (e.key === 'ArrowRight') { stopPlay(); go(i + 1); } else if (e.key === 'ArrowLeft') { stopPlay(); go(i - 1); } });
+
+      (async () => {
+        try { await fetch('/demo/reset', { method: 'POST' }); } catch (e) {}
+        paint(0, {});
+      })();
+    </script>
+  </body>
+</html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -20,8 +20,6 @@
         --blue-ink: #185fa5;
         --amber: #b9770f;
         --amber-bg: #faeeda;
-        --purple: #4a3aa7;
-        --red: #b23b3b;
         --radius: 10px;
         --mono: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, monospace;
         --sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
@@ -42,8 +40,6 @@
           --blue-ink: #9cc6f5;
           --amber: #e0a545;
           --amber-bg: #3a2e12;
-          --purple: #9085e9;
-          --red: #e07070;
         }
       }
       * {
@@ -57,15 +53,16 @@
         line-height: 1.5;
       }
       .wrap {
-        max-width: 760px;
+        max-width: 820px;
         margin: 0 auto;
-        padding: 26px 20px 60px;
+        padding: 24px 20px 60px;
       }
       .top {
         display: flex;
         align-items: center;
         justify-content: space-between;
         gap: 12px;
+        margin-bottom: 16px;
       }
       .brand {
         display: flex;
@@ -104,7 +101,7 @@
         padding: 5px 11px;
         border-radius: 999px;
       }
-      .live .dot {
+      .live .d {
         width: 7px;
         height: 7px;
         border-radius: 50%;
@@ -120,72 +117,60 @@
           opacity: 0.35;
         }
       }
-      .ledger {
-        display: flex;
-        align-items: center;
-        gap: 14px;
+      .main {
+        display: grid;
+        grid-template-columns: 300px 1fr;
+        gap: 18px;
+        align-items: start;
+      }
+      @media (max-width: 720px) {
+        .main {
+          grid-template-columns: 1fr;
+        }
+      }
+      .col {
+        min-width: 0;
+      }
+      .rider {
         background: var(--surface);
         border: 1px solid var(--line);
-        border-radius: 12px;
-        padding: 13px 16px;
-        margin: 18px 0;
-        flex-wrap: wrap;
+        border-radius: 14px;
+        padding: 16px;
       }
-      .ledger .cell {
+      .phone {
+        width: 210px;
+        margin: 0 auto 14px;
+        background: var(--tile);
+        border: 1px solid var(--line);
+        border-radius: 26px;
+        padding: 8px;
+      }
+      .screen {
+        background: var(--surface);
+        border-radius: 19px;
+        padding: 14px;
+        min-height: 230px;
         display: flex;
-        align-items: center;
-        gap: 9px;
+        flex-direction: column;
       }
-      .ledger .k {
+      .rl {
+        display: flex;
+        gap: 10px;
+      }
+      .rl .b {
+        flex: 1;
+        background: var(--tile);
+        border-radius: 10px;
+        padding: 9px 11px;
+      }
+      .rl .k {
         font-size: 11px;
         color: var(--muted);
       }
-      .ledger .v {
-        font-size: 22px;
+      .rl .v {
+        font-size: 19px;
         font-weight: 600;
         font-variant-numeric: tabular-nums;
-      }
-      .ledger .sep {
-        width: 1px;
-        height: 30px;
-        background: var(--line);
-      }
-      .note {
-        flex: 1;
-        min-width: 160px;
-        font-size: 13px;
-        color: var(--muted);
-      }
-      .stage {
-        min-height: 320px;
-      }
-      .beat {
-        display: none;
-      }
-      .beat.on {
-        display: block;
-        animation: fade 0.45s ease both;
-      }
-      @keyframes fade {
-        from {
-          opacity: 0;
-          transform: translateY(8px);
-        }
-        to {
-          opacity: 1;
-          transform: none;
-        }
-      }
-      .g2 {
-        display: grid;
-        grid-template-columns: 220px 1fr;
-        gap: 26px;
-        align-items: center;
-      }
-      @media (max-width: 600px) {
-        .g2 {
-          grid-template-columns: 1fr;
-        }
       }
       .eyebrow {
         font-size: 11px;
@@ -193,112 +178,129 @@
         color: var(--muted);
         text-transform: uppercase;
       }
-      h2 {
+      .rcopy {
+        margin-top: 12px;
+      }
+      .rcopy h2 {
+        font-size: 16px;
+        font-weight: 600;
+        margin: 4px 0 5px;
+      }
+      .rcopy p {
+        margin: 0;
+        color: var(--muted);
+        font-size: 13px;
+      }
+      .console {
+        background: var(--surface);
+        border: 1px solid var(--line);
+        border-radius: 14px;
+        padding: 16px;
+      }
+      .console .h {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin-bottom: 12px;
+      }
+      .console .h .t {
+        font-size: 14px;
+        font-weight: 600;
+      }
+      .console .h .s {
+        font-size: 12px;
+        color: var(--muted);
+      }
+      .kpis {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 10px;
+      }
+      .kpi {
+        background: var(--tile);
+        border-radius: 11px;
+        padding: 12px;
+      }
+      .kpi .k {
+        font-size: 11px;
+        color: var(--muted);
+      }
+      .kpi .v {
         font-size: 20px;
         font-weight: 600;
-        margin: 5px 0 9px;
+        font-variant-numeric: tabular-nums;
+        margin-top: 2px;
       }
-      .beat p {
-        margin: 0 0 14px;
-        color: var(--muted);
-        font-size: 15px;
+      .kpi .v.accent {
+        color: var(--accent-ink);
       }
-      .phone {
-        width: 220px;
-        margin: 0 auto;
-        background: var(--surface);
-        border: 1px solid var(--line);
-        border-radius: 28px;
-        padding: 9px;
-      }
-      .screen {
-        background: var(--tile);
-        border-radius: 20px;
-        padding: 15px;
-        min-height: 290px;
-        display: flex;
-        flex-direction: column;
-      }
-      .chip {
-        display: inline-flex;
-        align-items: center;
-        gap: 7px;
-        font-size: 13px;
-        padding: 6px 11px;
+      .bar {
+        height: 6px;
         border-radius: 999px;
-        background: var(--tile);
-        color: var(--muted);
+        background: var(--line);
+        margin-top: 8px;
+        overflow: hidden;
       }
-      .pill {
-        display: inline-block;
-        font-size: 13px;
-        font-weight: 500;
-        padding: 4px 10px;
-        border-radius: 8px;
+      .bar > i {
+        display: block;
+        height: 100%;
+        background: var(--accent);
+        width: 0;
+        transition: width 0.7s ease;
       }
-      .p-accent {
-        background: var(--accent-bg);
-        color: var(--accent-ink);
-      }
-      .p-blue {
-        background: var(--blue-bg);
-        color: var(--blue-ink);
-      }
-      .p-amber {
-        background: var(--amber-bg);
-        color: var(--amber);
-      }
-      .stat {
-        background: var(--tile);
-        border-radius: 12px;
-        padding: 13px 15px;
-        display: inline-block;
-      }
-      .seats {
-        display: grid;
-        grid-template-columns: repeat(4, 1fr);
-        gap: 7px;
-      }
-      .seat {
-        aspect-ratio: 1;
-        border-radius: 8px;
-        background: var(--surface);
-        border: 1px solid var(--line);
+      .flow {
         display: flex;
-        align-items: center;
-        justify-content: center;
+        gap: 8px;
+        margin-top: 12px;
+        font-size: 12px;
         color: var(--muted);
-        font-size: 15px;
-        transition: all 0.4s;
+        flex-wrap: wrap;
       }
-      .seat.full {
+      .flow span {
         background: var(--tile);
-        color: var(--muted);
-      }
-      .seat.me {
-        background: var(--accent-bg);
-        border-color: var(--accent);
-        color: var(--accent-ink);
+        border-radius: 8px;
+        padding: 6px 9px;
       }
       .apistat {
         font-family: var(--mono);
-        font-size: 11.5px;
+        font-size: 11px;
         color: var(--muted);
         margin-top: 12px;
-        min-height: 16px;
+        min-height: 15px;
       }
       .apistat.ok {
         color: var(--accent-ink);
       }
       .apistat.err {
-        color: var(--red);
+        color: #c0392b;
+      }
+      .phone .k {
+        font-size: 12px;
+        color: var(--muted);
+        margin-bottom: 9px;
+      }
+      .seats {
+        display: grid;
+        grid-template-columns: repeat(6, 1fr);
+        gap: 5px;
+      }
+      .seat {
+        aspect-ratio: 1;
+        border-radius: 5px;
+        background: var(--tile);
+        border: 1px solid var(--line);
+        transition: all 0.4s;
+      }
+      .seat.on {
+        background: var(--accent-bg);
+        border-color: var(--accent);
       }
       .controls {
         display: flex;
         align-items: center;
         justify-content: space-between;
         gap: 12px;
-        margin-top: 20px;
+        margin-top: 18px;
         border-top: 1px solid var(--line);
         padding-top: 15px;
       }
@@ -306,7 +308,7 @@
         display: flex;
         gap: 6px;
       }
-      .dot2 {
+      .dot {
         width: 8px;
         height: 8px;
         border-radius: 999px;
@@ -318,11 +320,11 @@
           width 0.25s,
           background 0.25s;
       }
-      .dot2.on {
+      .dot.on {
         background: var(--accent);
         width: 22px;
       }
-      button.b {
+      button.btn {
         font-family: var(--sans);
         font-size: 14px;
         font-weight: 500;
@@ -336,43 +338,18 @@
         align-items: center;
         gap: 6px;
       }
-      button.b:hover {
+      button.btn:hover {
         border-color: var(--accent);
       }
-      button.b.primary {
+      button.btn.primary {
         background: var(--accent);
         color: #fff;
         border-color: var(--accent);
       }
-      button.b:disabled {
-        opacity: 0.5;
-        cursor: default;
-      }
-      .two {
-        display: grid;
-        grid-template-columns: 1fr 1fr;
-        gap: 12px;
-      }
-      .card {
-        background: var(--surface);
-        border: 1px solid var(--line);
-        border-radius: 12px;
-        padding: 15px;
-      }
-      .kpis {
-        display: grid;
-        grid-template-columns: repeat(3, 1fr);
-        gap: 12px;
-        margin-top: 12px;
-      }
-      .lead {
-        font-size: 13px;
-        line-height: 1.9;
-        color: var(--muted);
-      }
-      code {
-        font-family: var(--mono);
+      .foot {
         font-size: 12px;
+        color: var(--muted);
+        margin-top: 12px;
       }
     </style>
   </head>
@@ -383,304 +360,288 @@
           <div class="logo">◐</div>
           <div>
             <h1>Trotxi — live demo</h1>
-            <p class="sub">Accra commuting, on subscription</p>
+            <p class="sub">Circle ⇄ Madina · a real corridor of 40 members</p>
           </div>
         </div>
-        <span class="live"><span class="dot"></span>live API</span>
+        <span class="live"><span class="d"></span>live API</span>
       </div>
 
-      <div class="ledger">
-        <div class="cell">
-          <div>
-            <div class="k">Rides left</div>
-            <div class="v" id="rides">0</div>
+      <div class="main">
+        <div class="col rider">
+          <div class="phone"><div class="screen" id="screen"></div></div>
+          <div class="rl">
+            <div class="b">
+              <div class="k">Ama · rides left</div>
+              <div class="v" id="ar">0</div>
+            </div>
+            <div class="b">
+              <div class="k">Ama · credits</div>
+              <div class="v" id="ac">GHS 0</div>
+            </div>
+          </div>
+          <div class="rcopy">
+            <div class="eyebrow" id="reye">the problem</div>
+            <h2 id="rh">Meet Ama</h2>
+            <p id="rp"></p>
           </div>
         </div>
-        <div class="sep"></div>
-        <div class="cell">
-          <div>
-            <div class="k">Ride credits</div>
-            <div class="v" id="credits">GHS 0.00</div>
-          </div>
-        </div>
-        <div class="sep"></div>
-        <div class="note" id="note">Every number below is returned live by the Trotxi API.</div>
-      </div>
 
-      <div class="stage" id="stage"></div>
+        <div class="col">
+          <div class="console">
+            <div class="h">
+              <div class="t">Operator console</div>
+              <div class="s" id="phase">idle</div>
+            </div>
+            <div class="kpis">
+              <div class="kpi">
+                <div class="k">Members</div>
+                <div class="v" id="m_sub">0</div>
+              </div>
+              <div class="kpi">
+                <div class="k">Monthly revenue</div>
+                <div class="v accent" id="m_rev">GHS 0</div>
+              </div>
+              <div class="kpi">
+                <div class="k">Seats confirmed</div>
+                <div class="v" id="m_conf">0</div>
+              </div>
+              <div class="kpi">
+                <div class="k">Boarded</div>
+                <div class="v" id="m_board">0</div>
+              </div>
+              <div class="kpi">
+                <div class="k">Occupancy</div>
+                <div class="v" id="m_occ">0%</div>
+              </div>
+              <div class="kpi">
+                <div class="k">Credit owed back</div>
+                <div class="v accent" id="m_cred">GHS 0</div>
+              </div>
+            </div>
+            <div class="bar"><i id="occbar"></i></div>
+            <div class="flow">
+              <span id="f_conf">confirmed —</span><span id="f_dec">declined → standby —</span
+              ><span id="f_ns">no-shows —</span><span id="f_used">rides used —</span>
+            </div>
+            <div class="apistat" id="api"></div>
+          </div>
+          <p class="foot">
+            Illustrative pilot pricing; every count, PIN, and cedi is computed live by the real
+            Trotxi API.
+          </p>
+        </div>
+      </div>
 
       <div class="controls">
         <div class="dots" id="dots"></div>
         <div style="display: flex; gap: 8px">
-          <button class="b" id="back">Back</button>
-          <button class="b" id="play">Play</button>
-          <button class="b primary" id="next">Next</button>
+          <button class="btn" id="back">Back</button>
+          <button class="btn" id="play">Play</button>
+          <button class="btn primary" id="next">Next</button>
         </div>
       </div>
     </div>
 
     <script>
       const $ = (s) => document.querySelector(s);
-      const money = (pesewas) => 'GHS ' + (pesewas / 100).toFixed(2);
+      const ghs = (p) => 'GHS ' + Math.round(p / 100).toLocaleString();
 
       const BEATS = [
         {
           key: 'intro',
-          eyebrow: 'the problem',
-          h: 'The daily commute is a gamble',
-          body: 'Accra runs on 1.5M+ trotro trips a day — cash only, no guaranteed seat, unpredictable for riders and operators. Trotxi turns the seat into a membership. Press play to run the real loop.',
-          visual: () =>
-            '<div style="text-align:center"><div style="width:150px;height:150px;margin:auto;border-radius:20px;background:var(--blue-bg);display:flex;align-items:center;justify-content:center;font-size:60px;color:var(--blue-ink)">◍</div></div>',
+          eye: 'the problem',
+          h: 'Meet Ama',
+          p: 'A daily Circle ⇄ Madina commuter — cash fares, no guaranteed seat. Press play to run the real loop for her and 39 neighbours.',
+          screen: () =>
+            '<div class="k">Circle ⇄ Madina</div><div style="flex:1;display:flex;align-items:center;justify-content:center;font-size:56px;color:var(--blue-ink)">◍</div>',
         },
         {
           key: 'subscribe',
           call: 'subscribe',
-          eyebrow: 'step 1 — subscribe',
+          eye: 'step 1 — subscribe',
           h: 'A membership, not a fare',
-          body: 'Ama pays a monthly fee. The API activates her subscription and allocates a ride entitlement — a real balance, live above.',
-          visual: () =>
-            phone(
-              '<div class="k" style="font-size:12px;color:var(--muted);margin-bottom:10px">Circle ⇄ Madina · monthly</div><div style="background:var(--surface);border:1px solid var(--line);border-radius:12px;padding:12px"><div style="font-size:22px;font-weight:600">GHS 200</div><div style="font-size:12px;color:var(--muted)">44 guaranteed rides</div></div><div style="flex:1"></div><div style="margin-top:12px;text-align:center;background:var(--accent);color:#fff;padding:11px;border-radius:10px;font-size:14px;font-weight:500">Pay with mobile money</div>',
-            ),
+          p: 'Ama and 39 others pay a monthly fee. The API activates each subscription and allocates guaranteed rides — real recurring revenue, live on the right.',
+          screen: () =>
+            '<div class="k">Choose your plan</div><div style="background:var(--tile);border-radius:11px;padding:12px"><div style="font-size:20px;font-weight:600">GHS 200</div><div style="font-size:12px;color:var(--muted)">44 guaranteed rides</div></div><div style="flex:1"></div><div style="text-align:center;background:var(--accent);color:#fff;padding:10px;border-radius:10px;font-size:13px;font-weight:500">Pay with mobile money</div>',
         },
         {
           key: 'confirm',
           call: 'confirm',
-          eyebrow: 'step 2 — confirm',
+          eye: 'step 2 — confirm',
           h: 'One tap the evening before',
-          body: 'Trotxi asks who is travelling. A tap holds the seat and the API issues a real daily boarding PIN — shown here, straight from the response.',
-          visual: (d) =>
-            phone(
-              '<div style="font-size:12px;color:var(--muted);margin-bottom:10px">Trotxi · now</div><div style="background:var(--surface);border:1px solid var(--line);border-radius:12px;padding:13px"><div style="font-weight:500;font-size:14px">Travelling tomorrow morning?</div><div style="font-size:12px;color:var(--muted);margin-top:3px">Tap to hold your seat.</div></div><div style="display:flex;gap:8px;margin-top:12px"><div style="flex:1;text-align:center;padding:10px;border-radius:10px;background:var(--accent-bg);color:var(--accent-ink);font-size:13px;font-weight:500">Yes</div><div style="flex:1;text-align:center;padding:10px;border-radius:10px;background:var(--surface);border:1px solid var(--line);color:var(--muted);font-size:13px">No</div></div><div style="flex:1"></div><div style="margin-top:12px;text-align:center;font-size:12px;color:var(--muted)">boarding PIN <strong id="pin" style="color:var(--ink);font-size:15px">' +
-                (d && d.pin ? d.pin : '––––') +
-                '</strong></div>',
-            ),
+          p: 'Trotxi asks who is travelling. Most confirm; a few decline and their seats go to standby. Ama gets a real boarding PIN.',
+          screen: (d) =>
+            '<div class="k">Trotxi · now</div><div style="background:var(--tile);border-radius:11px;padding:11px"><div style="font-weight:500;font-size:13px">Travelling tomorrow morning?</div></div><div style="display:flex;gap:7px;margin-top:10px"><div style="flex:1;text-align:center;padding:9px;border-radius:9px;background:var(--accent-bg);color:var(--accent-ink);font-size:13px;font-weight:500">Yes</div><div style="flex:1;text-align:center;padding:9px;border-radius:9px;background:var(--tile);color:var(--muted);font-size:13px">No</div></div><div style="flex:1"></div><div style="text-align:center;font-size:12px;color:var(--muted)">boarding PIN <strong style="color:var(--ink);font-size:15px">' +
+            (d && d.ama && d.ama.pin ? d.ama.pin : '––––') +
+            '</strong></div>',
         },
         {
           key: 'board',
           call: 'board',
-          eyebrow: 'step 3 — board',
+          eye: 'step 3 — board',
           h: 'QR or PIN, one ride used',
-          body: 'The driver verifies Ama and the API deducts one ride from the ledger — idempotent, so she is never double-charged. Watch the counter above tick down for real.',
-          visual: () =>
-            '<div class="card"><div style="font-size:12px;color:var(--muted);margin-bottom:10px">Trip 7:10 · Madina</div><div class="seats" id="seats"></div></div>',
+          p: 'The driver verifies each rider; the API deducts one ride per boarding. Watch the bus fill and the occupancy climb on the right.',
+          screen: (d) =>
+            '<div class="k">Trip 7:10 · Madina</div><div class="seats" id="busseats"></div>',
         },
         {
           key: 'noshow',
           call: 'noshow',
-          eyebrow: 'step 4 — every outcome, fairly',
-          h: 'The model handles real life',
-          body: 'Confirm-then-miss is a no-show — still counted, because a seat was held. Declines are resold to standby riders. The API just deducted a real no-show above.',
-          visual: () =>
-            '<div style="display:flex;flex-direction:column;gap:8px">' +
-            dayRow('Mon', 'Boarded', 'p-accent') +
-            dayRow('Tue', 'Declined → standby', 'p-blue') +
-            dayRow('Wed', 'No-show', 'p-amber') +
-            '</div>',
+          eye: 'step 4 — cutoff',
+          h: 'Every outcome, fairly',
+          p: 'Confirmed-but-missed is a no-show — still charged, because a seat was held. Declined seats already earned standby fares. The ledger stays exact.',
+          screen: () =>
+            '<div class="k">Today</div><div style="display:flex;flex-direction:column;gap:7px"><div style="background:var(--tile);border-radius:9px;padding:9px;font-size:12px">Boarded → ride used</div><div style="background:var(--tile);border-radius:9px;padding:9px;font-size:12px">Declined → seat resold</div><div style="background:var(--tile);border-radius:9px;padding:9px;font-size:12px">No-show → ride used</div></div>',
         },
         {
           key: 'convert',
           call: 'convert',
-          eyebrow: 'step 5 — month-end',
+          eye: 'step 5 — month-end',
           h: 'Unused rides become credit',
-          body: 'At period end the API converts her remaining rides into Ride Credits toward renewal. Value is never lost — the credit above is the real converted amount.',
-          visual: (d) =>
-            '<div style="text-align:center"><div style="display:inline-flex;align-items:center;gap:14px"><div class="stat" style="text-align:center"><div style="font-size:12px;color:var(--muted)">converted</div><div style="font-size:26px;font-weight:600" id="conv">' +
-            (d && d.converted != null ? d.converted : '–') +
-            '</div><div style="font-size:11px;color:var(--muted)">rides</div></div><div style="font-size:22px;color:var(--muted)">→</div><div class="stat" style="text-align:center;background:var(--accent-bg)"><div style="font-size:12px;color:var(--accent-ink)">credit</div><div style="font-size:26px;font-weight:600;color:var(--accent-ink)" id="cred2">' +
-            (d ? money(d.credits) : 'GHS 0') +
-            '</div></div></div></div>',
-        },
-        {
-          key: 'close',
-          eyebrow: 'the model',
-          h: 'Predictable, and fair to both sides',
-          body: 'One subscription loop — proven live above against the real API.',
-          visual: () =>
-            '<div class="two"><div class="card"><div style="font-weight:600;font-size:14px;margin-bottom:8px;color:var(--blue-ink)">For the rider</div><div class="lead">Guaranteed seat every morning<br>One tap to confirm, one PIN to board<br>Unused rides return as credit</div></div><div class="card"><div style="font-weight:600;font-size:14px;margin-bottom:8px;color:var(--accent-ink)">For the operator</div><div class="lead">Predictable recurring revenue<br>Declined seats resold to standby<br>Demand forecast from confirmations</div></div></div><div class="kpis"><div class="stat"><div style="font-size:12px;color:var(--muted)">Seat use</div><div style="font-size:18px;font-weight:600">62% → 89%</div></div><div class="stat"><div style="font-size:12px;color:var(--muted)">Revenue</div><div style="font-size:18px;font-weight:600">Recurring</div></div><div class="stat"><div style="font-size:12px;color:var(--muted)">Value kept</div><div style="font-size:18px;font-weight:600">100%</div></div></div>',
+          p: 'At period end the API converts every unused ride into credit toward renewal — value is never lost. The operator sees the exact liability owed back to riders.',
+          screen: (d) =>
+            '<div class="k">Statement</div><div style="flex:1;display:flex;flex-direction:column;justify-content:center;gap:8px"><div style="text-align:center;font-size:12px;color:var(--muted)">unused rides return as</div><div style="text-align:center;font-size:30px;font-weight:600;color:var(--accent-ink)">' +
+            (d ? ghs(d.ama.credits) : 'GHS 0') +
+            '</div><div style="text-align:center;font-size:12px;color:var(--muted)">off next month</div></div>',
         },
       ];
 
-      function phone(inner) {
-        return '<div class="phone"><div class="screen">' + inner + '</div></div>';
-      }
-      function dayRow(d, label, cls) {
-        return (
-          '<div style="display:flex;align-items:center;gap:10px;background:var(--surface);border:1px solid var(--line);border-radius:10px;padding:9px 11px;font-size:13px"><span style="width:34px;color:var(--muted)">' +
-          d +
-          '</span><span class="pill ' +
-          cls +
-          '">' +
-          label +
-          '</span></div>'
-        );
-      }
-
       let i = 0,
         timer = null,
-        curRides = 0,
-        curCredits = 0;
-      const stage = $('#stage'),
-        dots = $('#dots');
-
-      BEATS.forEach((b, k) => {
-        const sec = document.createElement('section');
-        sec.className = 'beat' + (k === 0 ? ' on' : '');
-        sec.id = 'beat' + k;
-        stage.appendChild(sec);
-        const dot = document.createElement('button');
-        dot.className = 'dot2' + (k === 0 ? ' on' : '');
-        dot.onclick = () => {
-          stopPlay();
+        ar = 0,
+        ac = 0;
+      const stage = $('#dots');
+      BEATS.forEach((_, k) => {
+        const b = document.createElement('button');
+        b.className = 'dot' + (k === 0 ? ' on' : '');
+        b.onclick = () => {
+          stop();
           go(k);
         };
-        dots.appendChild(dot);
+        stage.appendChild(b);
       });
 
       function tween(el, from, to, fmt) {
         const t0 = performance.now(),
-          d = 650;
-        (function f(now) {
-          const p = Math.min(1, (now - t0) / d);
-          const v = from + (to - from) * p;
-          el.textContent = fmt(v);
+          d = 700;
+        (function f(n) {
+          const p = Math.min(1, (n - t0) / d);
+          el.textContent = fmt(from + (to - from) * p);
           if (p < 1) requestAnimationFrame(f);
         })(t0);
       }
+      function setText(id, v) {
+        const e = $('#' + id);
+        if (e) e.textContent = v;
+      }
 
-      function paint(k, data) {
-        const b = BEATS[k],
-          sec = $('#beat' + k);
-        sec.innerHTML =
-          '<div class="g2"><div>' +
-          b.visual(data) +
-          '</div><div><div class="eyebrow">' +
-          b.eyebrow +
-          '</div><h2>' +
-          b.h +
-          '</h2><p>' +
-          b.body +
-          '</p>' +
-          (b.call ? '<div class="apistat" id="api' + k + '"></div>' : '') +
-          '</div></div>';
-        if (b.key === 'close')
-          sec.innerHTML =
-            '<div class="eyebrow">' +
-            b.eyebrow +
-            '</div><h2>' +
-            b.h +
-            '</h2><p>' +
-            b.body +
-            '</p>' +
-            b.visual();
-        if (k >= 3) {
-          const sw = sec.querySelector('#seats');
-          if (sw)
-            for (let s = 0; s < 12; s++) {
-              const d = document.createElement('div');
-              d.className = 'seat ' + (s < 7 ? 'full' : s === 7 ? 'me' : '');
-              d.textContent = s === 7 ? '★' : '·';
-              sw.appendChild(d);
+      function paintRider(b, d) {
+        $('#reye').textContent = b.eye;
+        $('#rh').textContent = b.h;
+        $('#rp').textContent = b.p;
+        $('#screen').innerHTML = b.screen(d);
+        if (b.key === 'board') {
+          const w = $('#busseats');
+          if (w)
+            for (let s = 0; s < 36; s++) {
+              const c = document.createElement('div');
+              c.className = 'seat' + (d && d.boarded && s < d.boarded ? ' on' : '');
+              w.appendChild(c);
             }
         }
+      }
+
+      function paintConsole(d, phase) {
+        setText('phase', phase);
+        tween($('#m_sub'), +$('#m_sub').textContent.replace(/\D/g, '') || 0, d.subscribers, (v) =>
+          Math.round(v),
+        );
+        tween($('#m_rev'), 0, d.subRevenue, (v) => ghs(v));
+        setText('m_conf', d.confirmed + ' / ' + d.capacity);
+        tween($('#m_board'), 0, d.boarded, (v) => Math.round(v));
+        setText('m_occ', d.occupancy + '%');
+        tween($('#m_cred'), 0, d.creditLiability, (v) => ghs(v));
+        $('#occbar').style.width = Math.min(100, d.occupancy) + '%';
+        setText('f_conf', 'confirmed ' + d.confirmed);
+        setText('f_dec', 'declined → standby ' + d.declined);
+        setText('f_ns', 'no-shows ' + d.noShow);
+        setText('f_used', 'rides used ' + d.ridesConsumed);
       }
 
       async function go(k) {
         i = (k + BEATS.length) % BEATS.length;
-        BEATS.forEach((_, x) => {
-          $('#beat' + x).classList.toggle('on', x === i);
-          dots.children[x].classList.toggle('on', x === i);
-        });
-        $('#next').innerHTML = i === BEATS.length - 1 ? 'Restart' : 'Next';
+        BEATS.forEach((_, x) => stage.children[x].classList.toggle('on', x === i));
+        $('#next').textContent = i === BEATS.length - 1 ? 'Restart' : 'Next';
         const b = BEATS[i];
-        paint(i, {});
-        if (b.call) {
-          const st = $('#api' + i);
-          if (st) {
-            st.className = 'apistat';
-            st.textContent = 'calling the API…';
-          }
-          const t0 = performance.now();
-          try {
-            const res = await fetch('/demo/' + b.call, { method: 'POST' });
-            const data = await res.json();
-            const ms = Math.round(performance.now() - t0);
-            if (!data.ok) throw new Error(data.error || 'step failed');
-            paint(i, data);
-            tween($('#rides'), curRides, data.rides, (v) => Math.round(v));
-            tween($('#credits'), curCredits, data.credits, (v) => money(v));
-            curRides = data.rides;
-            curCredits = data.credits;
-            $('#note').textContent = noteFor(b.key, data);
-            const st2 = $('#api' + i);
-            if (st2) {
-              st2.className = 'apistat ok';
-              st2.textContent =
-                'live · POST /demo/' + b.call + ' · ' + res.status + ' · ' + ms + ' ms';
-            }
-          } catch (e) {
-            const st2 = $('#api' + i);
-            if (st2) {
-              st2.className = 'apistat err';
-              st2.textContent =
-                'API error: ' + (e && e.message ? e.message : e) + ' — is the demo server running?';
-            }
-          }
+        paintRider(b, null);
+        if (!b.call) return;
+        $('#api').className = 'apistat';
+        $('#api').textContent = 'calling the API…';
+        const t0 = performance.now();
+        try {
+          const res = await fetch('/demo/' + b.call, { method: 'POST' });
+          const d = await res.json();
+          if (!d.ok) throw new Error(d.error || 'failed');
+          const ms = Math.round(performance.now() - t0);
+          paintRider(b, d);
+          paintConsole(d, b.eye.replace(/^step \d+ — /, ''));
+          tween($('#ar'), ar, d.ama.rides, (v) => Math.round(v));
+          ar = d.ama.rides;
+          tween($('#ac'), ac, d.ama.credits, (v) => ghs(v));
+          ac = d.ama.credits;
+          $('#api').className = 'apistat ok';
+          $('#api').textContent =
+            'live · POST /demo/' + b.call + ' · ' + res.status + ' · ' + ms + ' ms';
+        } catch (e) {
+          $('#api').className = 'apistat err';
+          $('#api').textContent = 'API error: ' + (e.message || e);
         }
       }
 
-      function noteFor(key, d) {
-        if (key === 'subscribe')
-          return 'Subscription activated — ' + d.rides + ' rides allocated by the API.';
-        if (key === 'confirm') return 'Seat reserved — PIN ' + d.pin + ' issued for boarding.';
-        if (key === 'board') return 'Boarded and verified — one ride deducted.';
-        if (key === 'noshow') return 'No-show resolved — a held-but-unused seat was deducted.';
-        if (key === 'convert')
-          return (
-            'Month-end — ' +
-            d.converted +
-            ' unused rides converted to ' +
-            money(d.credits) +
-            ' credit.'
-          );
-        return 'Every number is returned live by the Trotxi API.';
-      }
-
-      function stopPlay() {
+      function stop() {
         if (timer) {
           clearInterval(timer);
           timer = null;
           $('#play').textContent = 'Play';
         }
       }
+      async function restart() {
+        ar = 0;
+        ac = 0;
+        try {
+          await fetch('/demo/reset', { method: 'POST' });
+        } catch (e) {}
+        go(0);
+      }
       $('#next').onclick = () => {
-        stopPlay();
-        go(i + 1);
+        stop();
+        if (i === BEATS.length - 1) restart();
+        else go(i + 1);
       };
       $('#back').onclick = () => {
-        stopPlay();
+        stop();
         go(i - 1);
       };
       $('#play').onclick = () => {
         if (timer) {
-          stopPlay();
+          stop();
           return;
         }
         $('#play').textContent = 'Pause';
         timer = setInterval(() => {
           if (i === BEATS.length - 1) {
-            stopPlay();
+            stop();
             return;
           }
           go(i + 1);
-        }, 3200);
+        }, 3400);
       };
       document.addEventListener('keydown', (e) => {
         if (e.key === 'ArrowRight') {
-          stopPlay();
+          stop();
           go(i + 1);
         } else if (e.key === 'ArrowLeft') {
-          stopPlay();
+          stop();
           go(i - 1);
         }
       });
@@ -689,7 +650,7 @@
         try {
           await fetch('/demo/reset', { method: 'POST' });
         } catch (e) {}
-        paint(0, {});
+        go(0);
       })();
     </script>
   </body>

--- a/demo/index.html
+++ b/demo/index.html
@@ -6,74 +6,374 @@
     <title>Trotxi — live investor demo</title>
     <style>
       :root {
-        --bg: #f6f7f5; --surface: #ffffff; --tile: #f1f2ef; --ink: #16181d; --muted: #6b6f76;
-        --line: #e4e6e2; --accent: #0f9d76; --accent-ink: #0a5f48; --accent-bg: #e4f5ee;
-        --blue: #2a78d6; --blue-bg: #e6f1fb; --blue-ink: #185fa5; --amber: #b9770f; --amber-bg: #faeeda;
-        --purple: #4a3aa7; --red: #b23b3b; --radius: 10px;
-        --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace;
-        --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+        --bg: #f6f7f5;
+        --surface: #ffffff;
+        --tile: #f1f2ef;
+        --ink: #16181d;
+        --muted: #6b6f76;
+        --line: #e4e6e2;
+        --accent: #0f9d76;
+        --accent-ink: #0a5f48;
+        --accent-bg: #e4f5ee;
+        --blue: #2a78d6;
+        --blue-bg: #e6f1fb;
+        --blue-ink: #185fa5;
+        --amber: #b9770f;
+        --amber-bg: #faeeda;
+        --purple: #4a3aa7;
+        --red: #b23b3b;
+        --radius: 10px;
+        --mono: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, monospace;
+        --sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
       }
       @media (prefers-color-scheme: dark) {
         :root {
-          --bg: #14161a; --surface: #1c1f24; --tile: #23262c; --ink: #f0f1f3; --muted: #9aa0a8;
-          --line: #2b2f36; --accent: #2fbd93; --accent-ink: #8fe3c9; --accent-bg: #123a2e;
-          --blue: #6aa8f0; --blue-bg: #12233a; --blue-ink: #9cc6f5; --amber: #e0a545; --amber-bg: #3a2e12;
-          --purple: #9085e9; --red: #e07070;
+          --bg: #14161a;
+          --surface: #1c1f24;
+          --tile: #23262c;
+          --ink: #f0f1f3;
+          --muted: #9aa0a8;
+          --line: #2b2f36;
+          --accent: #2fbd93;
+          --accent-ink: #8fe3c9;
+          --accent-bg: #123a2e;
+          --blue: #6aa8f0;
+          --blue-bg: #12233a;
+          --blue-ink: #9cc6f5;
+          --amber: #e0a545;
+          --amber-bg: #3a2e12;
+          --purple: #9085e9;
+          --red: #e07070;
         }
       }
-      * { box-sizing: border-box; }
-      body { margin: 0; background: var(--bg); color: var(--ink); font-family: var(--sans); line-height: 1.5; }
-      .wrap { max-width: 760px; margin: 0 auto; padding: 26px 20px 60px; }
-      .top { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
-      .brand { display: flex; align-items: center; gap: 11px; }
-      .logo { width: 40px; height: 40px; border-radius: 11px; background: var(--accent-bg); color: var(--accent-ink); display: flex; align-items: center; justify-content: center; font-size: 22px; }
-      h1 { font-size: 19px; font-weight: 600; margin: 0; }
-      .sub { color: var(--muted); font-size: 13px; margin: 1px 0 0; }
-      .live { display: inline-flex; align-items: center; gap: 6px; font-size: 12px; font-weight: 500; color: var(--accent-ink); background: var(--accent-bg); padding: 5px 11px; border-radius: 999px; }
-      .live .dot { width: 7px; height: 7px; border-radius: 50%; background: var(--accent); animation: pulse 1.5s infinite; }
-      @keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: .35; } }
-      .ledger { display: flex; align-items: center; gap: 14px; background: var(--surface); border: 1px solid var(--line); border-radius: 12px; padding: 13px 16px; margin: 18px 0; flex-wrap: wrap; }
-      .ledger .cell { display: flex; align-items: center; gap: 9px; }
-      .ledger .k { font-size: 11px; color: var(--muted); }
-      .ledger .v { font-size: 22px; font-weight: 600; font-variant-numeric: tabular-nums; }
-      .ledger .sep { width: 1px; height: 30px; background: var(--line); }
-      .note { flex: 1; min-width: 160px; font-size: 13px; color: var(--muted); }
-      .stage { min-height: 320px; }
-      .beat { display: none; }
-      .beat.on { display: block; animation: fade .45s ease both; }
-      @keyframes fade { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: none; } }
-      .g2 { display: grid; grid-template-columns: 220px 1fr; gap: 26px; align-items: center; }
-      @media (max-width: 600px) { .g2 { grid-template-columns: 1fr; } }
-      .eyebrow { font-size: 11px; letter-spacing: .06em; color: var(--muted); text-transform: uppercase; }
-      h2 { font-size: 20px; font-weight: 600; margin: 5px 0 9px; }
-      .beat p { margin: 0 0 14px; color: var(--muted); font-size: 15px; }
-      .phone { width: 220px; margin: 0 auto; background: var(--surface); border: 1px solid var(--line); border-radius: 28px; padding: 9px; }
-      .screen { background: var(--tile); border-radius: 20px; padding: 15px; min-height: 290px; display: flex; flex-direction: column; }
-      .chip { display: inline-flex; align-items: center; gap: 7px; font-size: 13px; padding: 6px 11px; border-radius: 999px; background: var(--tile); color: var(--muted); }
-      .pill { display: inline-block; font-size: 13px; font-weight: 500; padding: 4px 10px; border-radius: 8px; }
-      .p-accent { background: var(--accent-bg); color: var(--accent-ink); }
-      .p-blue { background: var(--blue-bg); color: var(--blue-ink); }
-      .p-amber { background: var(--amber-bg); color: var(--amber); }
-      .stat { background: var(--tile); border-radius: 12px; padding: 13px 15px; display: inline-block; }
-      .seats { display: grid; grid-template-columns: repeat(4, 1fr); gap: 7px; }
-      .seat { aspect-ratio: 1; border-radius: 8px; background: var(--surface); border: 1px solid var(--line); display: flex; align-items: center; justify-content: center; color: var(--muted); font-size: 15px; transition: all .4s; }
-      .seat.full { background: var(--tile); color: var(--muted); }
-      .seat.me { background: var(--accent-bg); border-color: var(--accent); color: var(--accent-ink); }
-      .apistat { font-family: var(--mono); font-size: 11.5px; color: var(--muted); margin-top: 12px; min-height: 16px; }
-      .apistat.ok { color: var(--accent-ink); } .apistat.err { color: var(--red); }
-      .controls { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-top: 20px; border-top: 1px solid var(--line); padding-top: 15px; }
-      .dots { display: flex; gap: 6px; }
-      .dot2 { width: 8px; height: 8px; border-radius: 999px; background: var(--line); border: none; padding: 0; cursor: pointer; transition: width .25s, background .25s; }
-      .dot2.on { background: var(--accent); width: 22px; }
-      button.b { font-family: var(--sans); font-size: 14px; font-weight: 500; cursor: pointer; border-radius: var(--radius); border: 1px solid var(--line); background: var(--surface); color: var(--ink); padding: 8px 15px; display: inline-flex; align-items: center; gap: 6px; }
-      button.b:hover { border-color: var(--accent); }
-      button.b.primary { background: var(--accent); color: #fff; border-color: var(--accent); }
-      button.b:disabled { opacity: .5; cursor: default; }
-      .two { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
-      .card { background: var(--surface); border: 1px solid var(--line); border-radius: 12px; padding: 15px; }
-      .kpis { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; margin-top: 12px; }
-      .lead { font-size: 13px; line-height: 1.9; color: var(--muted); }
-      code { font-family: var(--mono); font-size: 12px; }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--bg);
+        color: var(--ink);
+        font-family: var(--sans);
+        line-height: 1.5;
+      }
+      .wrap {
+        max-width: 760px;
+        margin: 0 auto;
+        padding: 26px 20px 60px;
+      }
+      .top {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+      }
+      .brand {
+        display: flex;
+        align-items: center;
+        gap: 11px;
+      }
+      .logo {
+        width: 40px;
+        height: 40px;
+        border-radius: 11px;
+        background: var(--accent-bg);
+        color: var(--accent-ink);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 22px;
+      }
+      h1 {
+        font-size: 19px;
+        font-weight: 600;
+        margin: 0;
+      }
+      .sub {
+        color: var(--muted);
+        font-size: 13px;
+        margin: 1px 0 0;
+      }
+      .live {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        font-size: 12px;
+        font-weight: 500;
+        color: var(--accent-ink);
+        background: var(--accent-bg);
+        padding: 5px 11px;
+        border-radius: 999px;
+      }
+      .live .dot {
+        width: 7px;
+        height: 7px;
+        border-radius: 50%;
+        background: var(--accent);
+        animation: pulse 1.5s infinite;
+      }
+      @keyframes pulse {
+        0%,
+        100% {
+          opacity: 1;
+        }
+        50% {
+          opacity: 0.35;
+        }
+      }
+      .ledger {
+        display: flex;
+        align-items: center;
+        gap: 14px;
+        background: var(--surface);
+        border: 1px solid var(--line);
+        border-radius: 12px;
+        padding: 13px 16px;
+        margin: 18px 0;
+        flex-wrap: wrap;
+      }
+      .ledger .cell {
+        display: flex;
+        align-items: center;
+        gap: 9px;
+      }
+      .ledger .k {
+        font-size: 11px;
+        color: var(--muted);
+      }
+      .ledger .v {
+        font-size: 22px;
+        font-weight: 600;
+        font-variant-numeric: tabular-nums;
+      }
+      .ledger .sep {
+        width: 1px;
+        height: 30px;
+        background: var(--line);
+      }
+      .note {
+        flex: 1;
+        min-width: 160px;
+        font-size: 13px;
+        color: var(--muted);
+      }
+      .stage {
+        min-height: 320px;
+      }
+      .beat {
+        display: none;
+      }
+      .beat.on {
+        display: block;
+        animation: fade 0.45s ease both;
+      }
+      @keyframes fade {
+        from {
+          opacity: 0;
+          transform: translateY(8px);
+        }
+        to {
+          opacity: 1;
+          transform: none;
+        }
+      }
+      .g2 {
+        display: grid;
+        grid-template-columns: 220px 1fr;
+        gap: 26px;
+        align-items: center;
+      }
+      @media (max-width: 600px) {
+        .g2 {
+          grid-template-columns: 1fr;
+        }
+      }
+      .eyebrow {
+        font-size: 11px;
+        letter-spacing: 0.06em;
+        color: var(--muted);
+        text-transform: uppercase;
+      }
+      h2 {
+        font-size: 20px;
+        font-weight: 600;
+        margin: 5px 0 9px;
+      }
+      .beat p {
+        margin: 0 0 14px;
+        color: var(--muted);
+        font-size: 15px;
+      }
+      .phone {
+        width: 220px;
+        margin: 0 auto;
+        background: var(--surface);
+        border: 1px solid var(--line);
+        border-radius: 28px;
+        padding: 9px;
+      }
+      .screen {
+        background: var(--tile);
+        border-radius: 20px;
+        padding: 15px;
+        min-height: 290px;
+        display: flex;
+        flex-direction: column;
+      }
+      .chip {
+        display: inline-flex;
+        align-items: center;
+        gap: 7px;
+        font-size: 13px;
+        padding: 6px 11px;
+        border-radius: 999px;
+        background: var(--tile);
+        color: var(--muted);
+      }
+      .pill {
+        display: inline-block;
+        font-size: 13px;
+        font-weight: 500;
+        padding: 4px 10px;
+        border-radius: 8px;
+      }
+      .p-accent {
+        background: var(--accent-bg);
+        color: var(--accent-ink);
+      }
+      .p-blue {
+        background: var(--blue-bg);
+        color: var(--blue-ink);
+      }
+      .p-amber {
+        background: var(--amber-bg);
+        color: var(--amber);
+      }
+      .stat {
+        background: var(--tile);
+        border-radius: 12px;
+        padding: 13px 15px;
+        display: inline-block;
+      }
+      .seats {
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+        gap: 7px;
+      }
+      .seat {
+        aspect-ratio: 1;
+        border-radius: 8px;
+        background: var(--surface);
+        border: 1px solid var(--line);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        color: var(--muted);
+        font-size: 15px;
+        transition: all 0.4s;
+      }
+      .seat.full {
+        background: var(--tile);
+        color: var(--muted);
+      }
+      .seat.me {
+        background: var(--accent-bg);
+        border-color: var(--accent);
+        color: var(--accent-ink);
+      }
+      .apistat {
+        font-family: var(--mono);
+        font-size: 11.5px;
+        color: var(--muted);
+        margin-top: 12px;
+        min-height: 16px;
+      }
+      .apistat.ok {
+        color: var(--accent-ink);
+      }
+      .apistat.err {
+        color: var(--red);
+      }
+      .controls {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+        margin-top: 20px;
+        border-top: 1px solid var(--line);
+        padding-top: 15px;
+      }
+      .dots {
+        display: flex;
+        gap: 6px;
+      }
+      .dot2 {
+        width: 8px;
+        height: 8px;
+        border-radius: 999px;
+        background: var(--line);
+        border: none;
+        padding: 0;
+        cursor: pointer;
+        transition:
+          width 0.25s,
+          background 0.25s;
+      }
+      .dot2.on {
+        background: var(--accent);
+        width: 22px;
+      }
+      button.b {
+        font-family: var(--sans);
+        font-size: 14px;
+        font-weight: 500;
+        cursor: pointer;
+        border-radius: var(--radius);
+        border: 1px solid var(--line);
+        background: var(--surface);
+        color: var(--ink);
+        padding: 8px 15px;
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+      }
+      button.b:hover {
+        border-color: var(--accent);
+      }
+      button.b.primary {
+        background: var(--accent);
+        color: #fff;
+        border-color: var(--accent);
+      }
+      button.b:disabled {
+        opacity: 0.5;
+        cursor: default;
+      }
+      .two {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 12px;
+      }
+      .card {
+        background: var(--surface);
+        border: 1px solid var(--line);
+        border-radius: 12px;
+        padding: 15px;
+      }
+      .kpis {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 12px;
+        margin-top: 12px;
+      }
+      .lead {
+        font-size: 13px;
+        line-height: 1.9;
+        color: var(--muted);
+      }
+      code {
+        font-family: var(--mono);
+        font-size: 12px;
+      }
     </style>
   </head>
   <body>
@@ -90,9 +390,19 @@
       </div>
 
       <div class="ledger">
-        <div class="cell"><div><div class="k">Rides left</div><div class="v" id="rides">0</div></div></div>
+        <div class="cell">
+          <div>
+            <div class="k">Rides left</div>
+            <div class="v" id="rides">0</div>
+          </div>
+        </div>
         <div class="sep"></div>
-        <div class="cell"><div><div class="k">Ride credits</div><div class="v" id="credits">GHS 0.00</div></div></div>
+        <div class="cell">
+          <div>
+            <div class="k">Ride credits</div>
+            <div class="v" id="credits">GHS 0.00</div>
+          </div>
+        </div>
         <div class="sep"></div>
         <div class="note" id="note">Every number below is returned live by the Trotxi API.</div>
       </div>
@@ -101,7 +411,7 @@
 
       <div class="controls">
         <div class="dots" id="dots"></div>
-        <div style="display:flex;gap:8px;">
+        <div style="display: flex; gap: 8px">
           <button class="b" id="back">Back</button>
           <button class="b" id="play">Play</button>
           <button class="b primary" id="next">Next</button>
@@ -114,65 +424,182 @@
       const money = (pesewas) => 'GHS ' + (pesewas / 100).toFixed(2);
 
       const BEATS = [
-        { key: 'intro', eyebrow: 'the problem', h: 'The daily commute is a gamble',
+        {
+          key: 'intro',
+          eyebrow: 'the problem',
+          h: 'The daily commute is a gamble',
           body: 'Accra runs on 1.5M+ trotro trips a day — cash only, no guaranteed seat, unpredictable for riders and operators. Trotxi turns the seat into a membership. Press play to run the real loop.',
-          visual: () => '<div style="text-align:center"><div style="width:150px;height:150px;margin:auto;border-radius:20px;background:var(--blue-bg);display:flex;align-items:center;justify-content:center;font-size:60px;color:var(--blue-ink)">◍</div></div>' },
-        { key: 'subscribe', call: 'subscribe', eyebrow: 'step 1 — subscribe', h: 'A membership, not a fare',
+          visual: () =>
+            '<div style="text-align:center"><div style="width:150px;height:150px;margin:auto;border-radius:20px;background:var(--blue-bg);display:flex;align-items:center;justify-content:center;font-size:60px;color:var(--blue-ink)">◍</div></div>',
+        },
+        {
+          key: 'subscribe',
+          call: 'subscribe',
+          eyebrow: 'step 1 — subscribe',
+          h: 'A membership, not a fare',
           body: 'Ama pays a monthly fee. The API activates her subscription and allocates a ride entitlement — a real balance, live above.',
-          visual: () => phone('<div class="k" style="font-size:12px;color:var(--muted);margin-bottom:10px">Circle ⇄ Madina · monthly</div><div style="background:var(--surface);border:1px solid var(--line);border-radius:12px;padding:12px"><div style="font-size:22px;font-weight:600">GHS 200</div><div style="font-size:12px;color:var(--muted)">44 guaranteed rides</div></div><div style="flex:1"></div><div style="margin-top:12px;text-align:center;background:var(--accent);color:#fff;padding:11px;border-radius:10px;font-size:14px;font-weight:500">Pay with mobile money</div>') },
-        { key: 'confirm', call: 'confirm', eyebrow: 'step 2 — confirm', h: 'One tap the evening before',
+          visual: () =>
+            phone(
+              '<div class="k" style="font-size:12px;color:var(--muted);margin-bottom:10px">Circle ⇄ Madina · monthly</div><div style="background:var(--surface);border:1px solid var(--line);border-radius:12px;padding:12px"><div style="font-size:22px;font-weight:600">GHS 200</div><div style="font-size:12px;color:var(--muted)">44 guaranteed rides</div></div><div style="flex:1"></div><div style="margin-top:12px;text-align:center;background:var(--accent);color:#fff;padding:11px;border-radius:10px;font-size:14px;font-weight:500">Pay with mobile money</div>',
+            ),
+        },
+        {
+          key: 'confirm',
+          call: 'confirm',
+          eyebrow: 'step 2 — confirm',
+          h: 'One tap the evening before',
           body: 'Trotxi asks who is travelling. A tap holds the seat and the API issues a real daily boarding PIN — shown here, straight from the response.',
-          visual: (d) => phone('<div style="font-size:12px;color:var(--muted);margin-bottom:10px">Trotxi · now</div><div style="background:var(--surface);border:1px solid var(--line);border-radius:12px;padding:13px"><div style="font-weight:500;font-size:14px">Travelling tomorrow morning?</div><div style="font-size:12px;color:var(--muted);margin-top:3px">Tap to hold your seat.</div></div><div style="display:flex;gap:8px;margin-top:12px"><div style="flex:1;text-align:center;padding:10px;border-radius:10px;background:var(--accent-bg);color:var(--accent-ink);font-size:13px;font-weight:500">Yes</div><div style="flex:1;text-align:center;padding:10px;border-radius:10px;background:var(--surface);border:1px solid var(--line);color:var(--muted);font-size:13px">No</div></div><div style="flex:1"></div><div style="margin-top:12px;text-align:center;font-size:12px;color:var(--muted)">boarding PIN <strong id="pin" style="color:var(--ink);font-size:15px">' + (d && d.pin ? d.pin : '––––') + '</strong></div>') },
-        { key: 'board', call: 'board', eyebrow: 'step 3 — board', h: 'QR or PIN, one ride used',
+          visual: (d) =>
+            phone(
+              '<div style="font-size:12px;color:var(--muted);margin-bottom:10px">Trotxi · now</div><div style="background:var(--surface);border:1px solid var(--line);border-radius:12px;padding:13px"><div style="font-weight:500;font-size:14px">Travelling tomorrow morning?</div><div style="font-size:12px;color:var(--muted);margin-top:3px">Tap to hold your seat.</div></div><div style="display:flex;gap:8px;margin-top:12px"><div style="flex:1;text-align:center;padding:10px;border-radius:10px;background:var(--accent-bg);color:var(--accent-ink);font-size:13px;font-weight:500">Yes</div><div style="flex:1;text-align:center;padding:10px;border-radius:10px;background:var(--surface);border:1px solid var(--line);color:var(--muted);font-size:13px">No</div></div><div style="flex:1"></div><div style="margin-top:12px;text-align:center;font-size:12px;color:var(--muted)">boarding PIN <strong id="pin" style="color:var(--ink);font-size:15px">' +
+                (d && d.pin ? d.pin : '––––') +
+                '</strong></div>',
+            ),
+        },
+        {
+          key: 'board',
+          call: 'board',
+          eyebrow: 'step 3 — board',
+          h: 'QR or PIN, one ride used',
           body: 'The driver verifies Ama and the API deducts one ride from the ledger — idempotent, so she is never double-charged. Watch the counter above tick down for real.',
-          visual: () => '<div class="card"><div style="font-size:12px;color:var(--muted);margin-bottom:10px">Trip 7:10 · Madina</div><div class="seats" id="seats"></div></div>' },
-        { key: 'noshow', call: 'noshow', eyebrow: 'step 4 — every outcome, fairly', h: 'The model handles real life',
+          visual: () =>
+            '<div class="card"><div style="font-size:12px;color:var(--muted);margin-bottom:10px">Trip 7:10 · Madina</div><div class="seats" id="seats"></div></div>',
+        },
+        {
+          key: 'noshow',
+          call: 'noshow',
+          eyebrow: 'step 4 — every outcome, fairly',
+          h: 'The model handles real life',
           body: 'Confirm-then-miss is a no-show — still counted, because a seat was held. Declines are resold to standby riders. The API just deducted a real no-show above.',
-          visual: () => '<div style="display:flex;flex-direction:column;gap:8px">' + dayRow('Mon', 'Boarded', 'p-accent') + dayRow('Tue', 'Declined → standby', 'p-blue') + dayRow('Wed', 'No-show', 'p-amber') + '</div>' },
-        { key: 'convert', call: 'convert', eyebrow: 'step 5 — month-end', h: 'Unused rides become credit',
+          visual: () =>
+            '<div style="display:flex;flex-direction:column;gap:8px">' +
+            dayRow('Mon', 'Boarded', 'p-accent') +
+            dayRow('Tue', 'Declined → standby', 'p-blue') +
+            dayRow('Wed', 'No-show', 'p-amber') +
+            '</div>',
+        },
+        {
+          key: 'convert',
+          call: 'convert',
+          eyebrow: 'step 5 — month-end',
+          h: 'Unused rides become credit',
           body: 'At period end the API converts her remaining rides into Ride Credits toward renewal. Value is never lost — the credit above is the real converted amount.',
-          visual: (d) => '<div style="text-align:center"><div style="display:inline-flex;align-items:center;gap:14px"><div class="stat" style="text-align:center"><div style="font-size:12px;color:var(--muted)">converted</div><div style="font-size:26px;font-weight:600" id="conv">' + (d && d.converted != null ? d.converted : '–') + '</div><div style="font-size:11px;color:var(--muted)">rides</div></div><div style="font-size:22px;color:var(--muted)">→</div><div class="stat" style="text-align:center;background:var(--accent-bg)"><div style="font-size:12px;color:var(--accent-ink)">credit</div><div style="font-size:26px;font-weight:600;color:var(--accent-ink)" id="cred2">' + (d ? money(d.credits) : 'GHS 0') + '</div></div></div></div>' },
-        { key: 'close', eyebrow: 'the model', h: 'Predictable, and fair to both sides',
+          visual: (d) =>
+            '<div style="text-align:center"><div style="display:inline-flex;align-items:center;gap:14px"><div class="stat" style="text-align:center"><div style="font-size:12px;color:var(--muted)">converted</div><div style="font-size:26px;font-weight:600" id="conv">' +
+            (d && d.converted != null ? d.converted : '–') +
+            '</div><div style="font-size:11px;color:var(--muted)">rides</div></div><div style="font-size:22px;color:var(--muted)">→</div><div class="stat" style="text-align:center;background:var(--accent-bg)"><div style="font-size:12px;color:var(--accent-ink)">credit</div><div style="font-size:26px;font-weight:600;color:var(--accent-ink)" id="cred2">' +
+            (d ? money(d.credits) : 'GHS 0') +
+            '</div></div></div></div>',
+        },
+        {
+          key: 'close',
+          eyebrow: 'the model',
+          h: 'Predictable, and fair to both sides',
           body: 'One subscription loop — proven live above against the real API.',
-          visual: () => '<div class="two"><div class="card"><div style="font-weight:600;font-size:14px;margin-bottom:8px;color:var(--blue-ink)">For the rider</div><div class="lead">Guaranteed seat every morning<br>One tap to confirm, one PIN to board<br>Unused rides return as credit</div></div><div class="card"><div style="font-weight:600;font-size:14px;margin-bottom:8px;color:var(--accent-ink)">For the operator</div><div class="lead">Predictable recurring revenue<br>Declined seats resold to standby<br>Demand forecast from confirmations</div></div></div><div class="kpis"><div class="stat"><div style="font-size:12px;color:var(--muted)">Seat use</div><div style="font-size:18px;font-weight:600">62% → 89%</div></div><div class="stat"><div style="font-size:12px;color:var(--muted)">Revenue</div><div style="font-size:18px;font-weight:600">Recurring</div></div><div class="stat"><div style="font-size:12px;color:var(--muted)">Value kept</div><div style="font-size:18px;font-weight:600">100%</div></div></div>' },
+          visual: () =>
+            '<div class="two"><div class="card"><div style="font-weight:600;font-size:14px;margin-bottom:8px;color:var(--blue-ink)">For the rider</div><div class="lead">Guaranteed seat every morning<br>One tap to confirm, one PIN to board<br>Unused rides return as credit</div></div><div class="card"><div style="font-weight:600;font-size:14px;margin-bottom:8px;color:var(--accent-ink)">For the operator</div><div class="lead">Predictable recurring revenue<br>Declined seats resold to standby<br>Demand forecast from confirmations</div></div></div><div class="kpis"><div class="stat"><div style="font-size:12px;color:var(--muted)">Seat use</div><div style="font-size:18px;font-weight:600">62% → 89%</div></div><div class="stat"><div style="font-size:12px;color:var(--muted)">Revenue</div><div style="font-size:18px;font-weight:600">Recurring</div></div><div class="stat"><div style="font-size:12px;color:var(--muted)">Value kept</div><div style="font-size:18px;font-weight:600">100%</div></div></div>',
+        },
       ];
 
-      function phone(inner) { return '<div class="phone"><div class="screen">' + inner + '</div></div>'; }
-      function dayRow(d, label, cls) { return '<div style="display:flex;align-items:center;gap:10px;background:var(--surface);border:1px solid var(--line);border-radius:10px;padding:9px 11px;font-size:13px"><span style="width:34px;color:var(--muted)">' + d + '</span><span class="pill ' + cls + '">' + label + '</span></div>'; }
+      function phone(inner) {
+        return '<div class="phone"><div class="screen">' + inner + '</div></div>';
+      }
+      function dayRow(d, label, cls) {
+        return (
+          '<div style="display:flex;align-items:center;gap:10px;background:var(--surface);border:1px solid var(--line);border-radius:10px;padding:9px 11px;font-size:13px"><span style="width:34px;color:var(--muted)">' +
+          d +
+          '</span><span class="pill ' +
+          cls +
+          '">' +
+          label +
+          '</span></div>'
+        );
+      }
 
-      let i = 0, timer = null, curRides = 0, curCredits = 0;
-      const stage = $('#stage'), dots = $('#dots');
+      let i = 0,
+        timer = null,
+        curRides = 0,
+        curCredits = 0;
+      const stage = $('#stage'),
+        dots = $('#dots');
 
       BEATS.forEach((b, k) => {
         const sec = document.createElement('section');
-        sec.className = 'beat' + (k === 0 ? ' on' : ''); sec.id = 'beat' + k;
+        sec.className = 'beat' + (k === 0 ? ' on' : '');
+        sec.id = 'beat' + k;
         stage.appendChild(sec);
         const dot = document.createElement('button');
         dot.className = 'dot2' + (k === 0 ? ' on' : '');
-        dot.onclick = () => { stopPlay(); go(k); };
+        dot.onclick = () => {
+          stopPlay();
+          go(k);
+        };
         dots.appendChild(dot);
       });
 
       function tween(el, from, to, fmt) {
-        const t0 = performance.now(), d = 650;
-        (function f(now) { const p = Math.min(1, (now - t0) / d); const v = from + (to - from) * p; el.textContent = fmt(v); if (p < 1) requestAnimationFrame(f); })(t0);
+        const t0 = performance.now(),
+          d = 650;
+        (function f(now) {
+          const p = Math.min(1, (now - t0) / d);
+          const v = from + (to - from) * p;
+          el.textContent = fmt(v);
+          if (p < 1) requestAnimationFrame(f);
+        })(t0);
       }
 
       function paint(k, data) {
-        const b = BEATS[k], sec = $('#beat' + k);
-        sec.innerHTML = '<div class="g2"><div>' + b.visual(data) + '</div><div><div class="eyebrow">' + b.eyebrow + '</div><h2>' + b.h + '</h2><p>' + b.body + '</p>' + (b.call ? '<div class="apistat" id="api' + k + '"></div>' : '') + '</div></div>';
-        if (b.key === 'close') sec.innerHTML = '<div class="eyebrow">' + b.eyebrow + '</div><h2>' + b.h + '</h2><p>' + b.body + '</p>' + b.visual();
-        if (k >= 3) { const sw = sec.querySelector('#seats'); if (sw) for (let s = 0; s < 12; s++) { const d = document.createElement('div'); d.className = 'seat ' + (s < 7 ? 'full' : (s === 7 ? 'me' : '')); d.textContent = s === 7 ? '★' : '·'; sw.appendChild(d); } }
+        const b = BEATS[k],
+          sec = $('#beat' + k);
+        sec.innerHTML =
+          '<div class="g2"><div>' +
+          b.visual(data) +
+          '</div><div><div class="eyebrow">' +
+          b.eyebrow +
+          '</div><h2>' +
+          b.h +
+          '</h2><p>' +
+          b.body +
+          '</p>' +
+          (b.call ? '<div class="apistat" id="api' + k + '"></div>' : '') +
+          '</div></div>';
+        if (b.key === 'close')
+          sec.innerHTML =
+            '<div class="eyebrow">' +
+            b.eyebrow +
+            '</div><h2>' +
+            b.h +
+            '</h2><p>' +
+            b.body +
+            '</p>' +
+            b.visual();
+        if (k >= 3) {
+          const sw = sec.querySelector('#seats');
+          if (sw)
+            for (let s = 0; s < 12; s++) {
+              const d = document.createElement('div');
+              d.className = 'seat ' + (s < 7 ? 'full' : s === 7 ? 'me' : '');
+              d.textContent = s === 7 ? '★' : '·';
+              sw.appendChild(d);
+            }
+        }
       }
 
       async function go(k) {
         i = (k + BEATS.length) % BEATS.length;
-        BEATS.forEach((_, x) => { $('#beat' + x).classList.toggle('on', x === i); dots.children[x].classList.toggle('on', x === i); });
+        BEATS.forEach((_, x) => {
+          $('#beat' + x).classList.toggle('on', x === i);
+          dots.children[x].classList.toggle('on', x === i);
+        });
         $('#next').innerHTML = i === BEATS.length - 1 ? 'Restart' : 'Next';
         const b = BEATS[i];
         paint(i, {});
         if (b.call) {
-          const st = $('#api' + i); if (st) { st.className = 'apistat'; st.textContent = 'calling the API…'; }
+          const st = $('#api' + i);
+          if (st) {
+            st.className = 'apistat';
+            st.textContent = 'calling the API…';
+          }
           const t0 = performance.now();
           try {
             const res = await fetch('/demo/' + b.call, { method: 'POST' });
@@ -182,36 +609,86 @@
             paint(i, data);
             tween($('#rides'), curRides, data.rides, (v) => Math.round(v));
             tween($('#credits'), curCredits, data.credits, (v) => money(v));
-            curRides = data.rides; curCredits = data.credits;
+            curRides = data.rides;
+            curCredits = data.credits;
             $('#note').textContent = noteFor(b.key, data);
-            const st2 = $('#api' + i); if (st2) { st2.className = 'apistat ok'; st2.textContent = 'live · POST /demo/' + b.call + ' · ' + res.status + ' · ' + ms + ' ms'; }
+            const st2 = $('#api' + i);
+            if (st2) {
+              st2.className = 'apistat ok';
+              st2.textContent =
+                'live · POST /demo/' + b.call + ' · ' + res.status + ' · ' + ms + ' ms';
+            }
           } catch (e) {
-            const st2 = $('#api' + i); if (st2) { st2.className = 'apistat err'; st2.textContent = 'API error: ' + (e && e.message ? e.message : e) + ' — is the demo server running?'; }
+            const st2 = $('#api' + i);
+            if (st2) {
+              st2.className = 'apistat err';
+              st2.textContent =
+                'API error: ' + (e && e.message ? e.message : e) + ' — is the demo server running?';
+            }
           }
         }
       }
 
       function noteFor(key, d) {
-        if (key === 'subscribe') return 'Subscription activated — ' + d.rides + ' rides allocated by the API.';
+        if (key === 'subscribe')
+          return 'Subscription activated — ' + d.rides + ' rides allocated by the API.';
         if (key === 'confirm') return 'Seat reserved — PIN ' + d.pin + ' issued for boarding.';
         if (key === 'board') return 'Boarded and verified — one ride deducted.';
         if (key === 'noshow') return 'No-show resolved — a held-but-unused seat was deducted.';
-        if (key === 'convert') return 'Month-end — ' + d.converted + ' unused rides converted to ' + money(d.credits) + ' credit.';
+        if (key === 'convert')
+          return (
+            'Month-end — ' +
+            d.converted +
+            ' unused rides converted to ' +
+            money(d.credits) +
+            ' credit.'
+          );
         return 'Every number is returned live by the Trotxi API.';
       }
 
-      function stopPlay() { if (timer) { clearInterval(timer); timer = null; $('#play').textContent = 'Play'; } }
-      $('#next').onclick = () => { stopPlay(); go(i + 1); };
-      $('#back').onclick = () => { stopPlay(); go(i - 1); };
-      $('#play').onclick = () => {
-        if (timer) { stopPlay(); return; }
-        $('#play').textContent = 'Pause';
-        timer = setInterval(() => { if (i === BEATS.length - 1) { stopPlay(); return; } go(i + 1); }, 3200);
+      function stopPlay() {
+        if (timer) {
+          clearInterval(timer);
+          timer = null;
+          $('#play').textContent = 'Play';
+        }
+      }
+      $('#next').onclick = () => {
+        stopPlay();
+        go(i + 1);
       };
-      document.addEventListener('keydown', (e) => { if (e.key === 'ArrowRight') { stopPlay(); go(i + 1); } else if (e.key === 'ArrowLeft') { stopPlay(); go(i - 1); } });
+      $('#back').onclick = () => {
+        stopPlay();
+        go(i - 1);
+      };
+      $('#play').onclick = () => {
+        if (timer) {
+          stopPlay();
+          return;
+        }
+        $('#play').textContent = 'Pause';
+        timer = setInterval(() => {
+          if (i === BEATS.length - 1) {
+            stopPlay();
+            return;
+          }
+          go(i + 1);
+        }, 3200);
+      };
+      document.addEventListener('keydown', (e) => {
+        if (e.key === 'ArrowRight') {
+          stopPlay();
+          go(i + 1);
+        } else if (e.key === 'ArrowLeft') {
+          stopPlay();
+          go(i - 1);
+        }
+      });
 
       (async () => {
-        try { await fetch('/demo/reset', { method: 'POST' }); } catch (e) {}
+        try {
+          await fetch('/demo/reset', { method: 'POST' });
+        } catch (e) {}
         paint(0, {});
       })();
     </script>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@aws-sdk/s3-request-presigner':
         specifier: ^3.1079.0
         version: 3.1079.0
+      '@fastify/cors':
+        specifier: ^11.2.0
+        version: 11.2.0
       '@fastify/multipart':
         specifier: ^10.0.0
         version: 10.0.0
@@ -640,6 +643,9 @@ packages:
 
   '@fastify/busboy@3.2.0':
     resolution: {integrity: sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==}
+
+  '@fastify/cors@11.2.0':
+    resolution: {integrity: sha512-LbLHBuSAdGdSFZYTLVA3+Ch2t+sA6nq3Ejc6XLAKiQ6ViS2qFnvicpj0htsx03FyYeLs04HfRNBsz/a8SvbcUw==}
 
   '@fastify/deepmerge@3.2.1':
     resolution: {integrity: sha512-N5Oqvltoa2r9z1tbx4xjky0oRR60v+T47Ic4J1ukoVQcptLOrIdRnCSdTGmOmajZuHVKlTnfcmrjyqsGEW1ztA==}
@@ -4031,6 +4037,11 @@ snapshots:
       fast-uri: 3.1.2
 
   '@fastify/busboy@3.2.0': {}
+
+  '@fastify/cors@11.2.0':
+    dependencies:
+      fastify-plugin: 5.1.0
+      toad-cache: 3.7.1
 
   '@fastify/deepmerge@3.2.1': {}
 

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -16,11 +16,13 @@
     "test:coverage": "vitest run --coverage",
     "typecheck": "tsc --noEmit",
     "lint": "eslint .",
-    "migrate": "tsx src/db/migrate.ts"
+    "migrate": "tsx src/db/migrate.ts",
+    "demo": "tsx scripts/demo-server.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1079.0",
     "@aws-sdk/s3-request-presigner": "^3.1079.0",
+    "@fastify/cors": "^11.2.0",
     "@fastify/multipart": "^10.0.0",
     "@fastify/swagger": "^9.7.0",
     "@fastify/swagger-ui": "^6.0.0",

--- a/services/api/scripts/demo-server.ts
+++ b/services/api/scripts/demo-server.ts
@@ -1,0 +1,259 @@
+// Live investor-demo runner. Boots the real Trotxi API in-process (in-memory)
+// and serves the animated walkthrough (demo/index.html) plus a small set of
+// /demo/* endpoints. Each endpoint drives ONE beat of the real hybrid-model loop
+// through the actual API (via inject) and returns the real numbers — the ride
+// entitlement, the daily PIN, the deduction, the credit conversion — so the
+// front-end animates live data, not a script. Everything runs locally so a
+// pitch never waits on a cold start. Run: `pnpm --filter @trotxi/api demo`.
+
+import { createServer } from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { FastifyInstance } from 'fastify';
+import { buildApp } from '../src/app';
+import { InMemoryKvStore } from '../src/kv/kv.store';
+import { FakeObjectStore } from '../src/storage/object-store';
+import { createJwtService, DEV_AUTH_CONFIG } from '../src/modules/auth/jwt';
+import { InMemoryUserRepository } from '../src/modules/users/user.repository';
+import { InMemorySubscriptionRepository } from '../src/modules/subscriptions/subscription.repository';
+import { InMemoryRouteRepository } from '../src/modules/mobility/route.repository';
+import { InMemoryStopRepository } from '../src/modules/mobility/stop.repository';
+import { InMemoryRouteStopRepository } from '../src/modules/mobility/route-stop.repository';
+import { InMemoryTripRepository } from '../src/modules/mobility/trip.repository';
+import { InMemoryVehicleRepository } from '../src/modules/mobility/vehicle.repository';
+import { InMemoryDriverRepository } from '../src/modules/mobility/driver.repository';
+import { InMemoryScanEventRepository } from '../src/modules/boarding/scan-event.repository';
+import { InMemoryEntitlementLedgerRepository } from '../src/modules/entitlements/entitlement-ledger.repository';
+import { InMemoryCreditLedgerRepository } from '../src/modules/entitlements/credit-ledger.repository';
+import { InMemoryReservationRepository } from '../src/modules/reservations/reservation.repository';
+import { BoardingService } from '../src/modules/boarding/boarding.service';
+import { FakePaystackClient, paystackSignature } from '../src/modules/payments/paystack.client';
+import { InMemoryPaymentRepository } from '../src/modules/payments/payment.repository';
+import {
+  PaymentsService,
+  PLACEHOLDER_RIDES_PER_PERIOD,
+  SUBSCRIPTION_FEES_PESEWAS,
+} from '../src/modules/payments/payments.service';
+
+const PAYSTACK_SECRET = 'fake-paystack-secret';
+const jwt = createJwtService(DEV_AUTH_CONFIG);
+const day = (offset: number) => new Date(Date.now() + offset * 864e5).toISOString().slice(0, 10);
+
+interface DemoState {
+  app: FastifyInstance;
+  riderToken: string;
+  driverToken: string;
+  adminToken: string;
+  riderId: string;
+  routeId: string;
+  tripId: string;
+  reservationId?: string;
+  pin?: string;
+}
+
+let S: DemoState | undefined;
+
+async function build(): Promise<DemoState> {
+  const users = new InMemoryUserRepository();
+  const subscriptions = new InMemorySubscriptionRepository();
+  const routes = new InMemoryRouteRepository();
+  const stops = new InMemoryStopRepository();
+  const routeStops = new InMemoryRouteStopRepository();
+  const trips = new InMemoryTripRepository();
+  const vehicles = new InMemoryVehicleRepository();
+  const drivers = new InMemoryDriverRepository();
+  const scanEvents = new InMemoryScanEventRepository();
+  const entitlements = new InMemoryEntitlementLedgerRepository();
+  const credits = new InMemoryCreditLedgerRepository();
+  const reservations = new InMemoryReservationRepository();
+  const payments = new InMemoryPaymentRepository();
+  const kv = new InMemoryKvStore();
+  const objectStore = new FakeObjectStore();
+
+  const boardingService = new BoardingService({
+    scanEvents,
+    kv,
+    reservations,
+    entitlements,
+    secret: DEV_AUTH_CONFIG.secret,
+    passTtlSeconds: 60,
+  });
+  const paymentsService = new PaymentsService({
+    payments,
+    subscriptions,
+    entitlements,
+    paystack: new FakePaystackClient(PAYSTACK_SECRET),
+    subscriptionFees: SUBSCRIPTION_FEES_PESEWAS,
+    ridesPerPeriod: PLACEHOLDER_RIDES_PER_PERIOD,
+  });
+
+  const app = await buildApp({
+    users,
+    subscriptions,
+    routes,
+    stops,
+    routeStops,
+    trips,
+    vehicles,
+    drivers,
+    entitlements,
+    credits,
+    reservations,
+    boardingService,
+    paymentsService,
+    kv,
+    objectStore,
+    auth: DEV_AUTH_CONFIG,
+  });
+
+  const rider = await users.create({ displayName: 'Ama Mensah' });
+  const route = await routes.create({ name: 'Circle ⇄ Madina', description: 'Pilot corridor' });
+  const driver = await drivers.create({ fullName: 'Kwame Boateng', userId: 'demo-driver' });
+  const trip = await trips.create({
+    routeId: route.id,
+    assignedDriverId: driver.id,
+    scheduledAt: new Date(`${day(1)}T06:30:00Z`),
+  });
+
+  return {
+    app,
+    riderToken: await jwt.signAccessToken({ userId: rider.id, role: 'commuter' }),
+    driverToken: await jwt.signAccessToken({ userId: 'demo-driver', role: 'driver' }),
+    adminToken: await jwt.signAccessToken({ userId: 'demo-admin', role: 'admin' }),
+    riderId: rider.id,
+    routeId: route.id,
+    tripId: trip.id,
+  };
+}
+
+async function call(
+  s: DemoState,
+  method: string,
+  url: string,
+  token: string,
+  body?: unknown,
+): Promise<{ status: number; json: Record<string, unknown> }> {
+  const headers: Record<string, string> = { authorization: `Bearer ${token}` };
+  if (body !== undefined) headers['content-type'] = 'application/json';
+  const res = await s.app.inject({
+    method: method as 'GET',
+    url,
+    headers,
+    ...(body === undefined ? {} : { payload: JSON.stringify(body) }),
+  });
+  let json: Record<string, unknown> = {};
+  try {
+    json = res.json();
+  } catch {
+    json = { raw: res.body };
+  }
+  return { status: res.statusCode, json };
+}
+
+async function rides(s: DemoState): Promise<{ rides: number; credits: number }> {
+  const { json } = await call(s, 'GET', '/me/rides', s.riderToken);
+  return { rides: Number(json.remainingRides ?? 0), credits: Number(json.creditPesewas ?? 0) };
+}
+
+type StepResult = Record<string, unknown>;
+
+const STEPS: Record<string, (s: DemoState) => Promise<StepResult>> = {
+  async subscribe(s) {
+    const init = await call(s, 'POST', '/payments/subscribe', s.riderToken, {
+      plan: 'monthly',
+      routeId: s.routeId,
+    });
+    const reference = String((init.json as { reference?: string }).reference);
+    const webhookBody = JSON.stringify({ event: 'charge.success', data: { reference } });
+    await s.app.inject({
+      method: 'POST',
+      url: '/webhooks/paystack',
+      headers: {
+        'content-type': 'application/json',
+        'x-paystack-signature': paystackSignature(webhookBody, PAYSTACK_SECRET),
+      },
+      payload: webhookBody,
+    });
+    return { reference, ...(await rides(s)) };
+  },
+  async confirm(s) {
+    const { json } = await call(s, 'POST', '/me/reservations', s.riderToken, {
+      tripId: s.tripId,
+      travelDate: day(1),
+      direction: 'morning',
+      travelling: true,
+    });
+    s.reservationId = String(json.id);
+    s.pin = String(json.pin);
+    return { pin: s.pin, reservationId: s.reservationId, ...(await rides(s)) };
+  },
+  async board(s) {
+    const { json } = await call(s, 'POST', '/boarding/verify-pin', s.driverToken, {
+      reservationId: s.reservationId,
+      pin: s.pin,
+    });
+    return { deducted: json.deducted === true, ...(await rides(s)) };
+  },
+  async noshow(s) {
+    await call(s, 'POST', '/me/reservations', s.riderToken, {
+      tripId: s.tripId,
+      travelDate: day(2),
+      direction: 'morning',
+      travelling: true,
+    });
+    const { json } = await call(s, 'POST', '/admin/resolve-no-shows', s.adminToken, {
+      travelDate: day(2),
+      direction: 'morning',
+    });
+    return { noShows: Number(json.noShows ?? 0), ...(await rides(s)) };
+  },
+  async convert(s) {
+    const { json } = await call(s, 'POST', '/admin/convert-credits', s.adminToken);
+    return { converted: Number(json.ridesConverted ?? 0), ...(await rides(s)) };
+  },
+};
+
+const here = dirname(fileURLToPath(import.meta.url));
+const INDEX = join(here, '..', '..', '..', 'demo', 'index.html');
+const PORT = Number(process.env.DEMO_PORT ?? 4319);
+
+const server = createServer((req, res) => {
+  void (async () => {
+    const url = (req.url ?? '/').split('?')[0];
+    res.setHeader('access-control-allow-origin', '*');
+    try {
+      if (url === '/' || url === '/index.html') {
+        res.setHeader('content-type', 'text/html');
+        res.end(await readFile(INDEX, 'utf8'));
+        return;
+      }
+      if (url === '/demo/reset' && req.method === 'POST') {
+        S = await build();
+        res.setHeader('content-type', 'application/json');
+        res.end(JSON.stringify({ ok: true, rides: 0, credits: 0 }));
+        return;
+      }
+      const name = url.startsWith('/demo/') ? url.slice('/demo/'.length) : '';
+      if (STEPS[name] && req.method === 'POST') {
+        if (!S) S = await build();
+        const data = await STEPS[name](S);
+        res.setHeader('content-type', 'application/json');
+        res.end(JSON.stringify({ ok: true, ...data }));
+        return;
+      }
+      res.statusCode = 404;
+      res.end(JSON.stringify({ ok: false, error: 'not found' }));
+    } catch (err) {
+      res.statusCode = 500;
+      res.setHeader('content-type', 'application/json');
+      res.end(
+        JSON.stringify({ ok: false, error: err instanceof Error ? err.message : String(err) }),
+      );
+    }
+  })();
+});
+
+server.listen(PORT, () => {
+  console.log(`Trotxi live demo → http://localhost:${PORT}`);
+});

--- a/services/api/scripts/demo-server.ts
+++ b/services/api/scripts/demo-server.ts
@@ -1,10 +1,10 @@
 // Live investor-demo runner. Boots the real Trotxi API in-process (in-memory)
-// and serves the animated walkthrough (demo/index.html) plus a small set of
-// /demo/* endpoints. Each endpoint drives ONE beat of the real hybrid-model loop
-// through the actual API (via inject) and returns the real numbers — the ride
-// entitlement, the daily PIN, the deduction, the credit conversion — so the
-// front-end animates live data, not a script. Everything runs locally so a
-// pitch never waits on a cold start. Run: `pnpm --filter @trotxi/api demo`.
+// and serves the animated walkthrough (demo/index.html) plus a set of /demo/*
+// endpoints. Each endpoint drives one beat of the hybrid-model loop for a whole
+// fleet of riders through the ACTUAL API, then reads back real aggregates — the
+// rider journey (Ama) and the operator economics are both computed by the real
+// code, not scripted. Everything runs locally so a pitch never waits on a cold
+// start. Run: `pnpm --filter @trotxi/api demo`.
 
 import { createServer } from 'node:http';
 import { readFile } from 'node:fs/promises';
@@ -16,7 +16,10 @@ import { InMemoryKvStore } from '../src/kv/kv.store';
 import { FakeObjectStore } from '../src/storage/object-store';
 import { createJwtService, DEV_AUTH_CONFIG } from '../src/modules/auth/jwt';
 import { InMemoryUserRepository } from '../src/modules/users/user.repository';
-import { InMemorySubscriptionRepository } from '../src/modules/subscriptions/subscription.repository';
+import {
+  InMemorySubscriptionRepository,
+  type SubscriptionRepository,
+} from '../src/modules/subscriptions/subscription.repository';
 import { InMemoryRouteRepository } from '../src/modules/mobility/route.repository';
 import { InMemoryStopRepository } from '../src/modules/mobility/stop.repository';
 import { InMemoryRouteStopRepository } from '../src/modules/mobility/route-stop.repository';
@@ -24,39 +27,62 @@ import { InMemoryTripRepository } from '../src/modules/mobility/trip.repository'
 import { InMemoryVehicleRepository } from '../src/modules/mobility/vehicle.repository';
 import { InMemoryDriverRepository } from '../src/modules/mobility/driver.repository';
 import { InMemoryScanEventRepository } from '../src/modules/boarding/scan-event.repository';
-import { InMemoryEntitlementLedgerRepository } from '../src/modules/entitlements/entitlement-ledger.repository';
-import { InMemoryCreditLedgerRepository } from '../src/modules/entitlements/credit-ledger.repository';
-import { InMemoryReservationRepository } from '../src/modules/reservations/reservation.repository';
+import {
+  InMemoryEntitlementLedgerRepository,
+  type EntitlementLedgerRepository,
+} from '../src/modules/entitlements/entitlement-ledger.repository';
+import {
+  InMemoryCreditLedgerRepository,
+  type CreditLedgerRepository,
+} from '../src/modules/entitlements/credit-ledger.repository';
+import {
+  InMemoryReservationRepository,
+  type ReservationRepository,
+} from '../src/modules/reservations/reservation.repository';
 import { BoardingService } from '../src/modules/boarding/boarding.service';
 import { FakePaystackClient, paystackSignature } from '../src/modules/payments/paystack.client';
 import { InMemoryPaymentRepository } from '../src/modules/payments/payment.repository';
-import {
-  PaymentsService,
-  PLACEHOLDER_RIDES_PER_PERIOD,
-  SUBSCRIPTION_FEES_PESEWAS,
-} from '../src/modules/payments/payments.service';
+import { PaymentsService } from '../src/modules/payments/payments.service';
 
-const PAYSTACK_SECRET = 'fake-paystack-secret';
+// Illustrative pilot pricing (the API's own fees are placeholders too). The
+// MECHANICS below are the real API; only these figures are demo-tuned.
+const FEE = { monthly: 20000, annual: 200000 }; // GHS 200 / 2000 (pesewas)
+const RIDES_PER_PERIOD = 44;
+const CREDIT_PER_RIDE = 450; // GHS 4.50 (pesewas)
+const FLEET = 40;
+const CONFIRM = 34; // of the fleet, confirm the morning; the rest decline
+const BOARD = 31; // of the confirmed, actually board; the remaining are no-shows
+const CAPACITY = 36; // seats on the corridor's morning run (for occupancy)
+
 const jwt = createJwtService(DEV_AUTH_CONFIG);
-const day = (offset: number) => new Date(Date.now() + offset * 864e5).toISOString().slice(0, 10);
+const PAYSTACK_SECRET = 'fake-paystack-secret';
+const day = (o: number) => new Date(Date.now() + o * 864e5).toISOString().slice(0, 10);
 
-interface DemoState {
-  app: FastifyInstance;
-  riderToken: string;
-  driverToken: string;
-  adminToken: string;
-  riderId: string;
-  routeId: string;
-  tripId: string;
+interface Rider {
+  id: string;
+  token: string;
   reservationId?: string;
   pin?: string;
+}
+interface DemoState {
+  app: FastifyInstance;
+  subs: SubscriptionRepository;
+  ents: EntitlementLedgerRepository;
+  creds: CreditLedgerRepository;
+  resv: ReservationRepository;
+  riders: Rider[];
+  driverToken: string;
+  adminToken: string;
+  routeId: string;
+  tripId: string;
+  travelDate: string;
 }
 
 let S: DemoState | undefined;
 
 async function build(): Promise<DemoState> {
   const users = new InMemoryUserRepository();
-  const subscriptions = new InMemorySubscriptionRepository();
+  const subs = new InMemorySubscriptionRepository();
   const routes = new InMemoryRouteRepository();
   const stops = new InMemoryStopRepository();
   const routeStops = new InMemoryRouteStopRepository();
@@ -64,50 +90,49 @@ async function build(): Promise<DemoState> {
   const vehicles = new InMemoryVehicleRepository();
   const drivers = new InMemoryDriverRepository();
   const scanEvents = new InMemoryScanEventRepository();
-  const entitlements = new InMemoryEntitlementLedgerRepository();
-  const credits = new InMemoryCreditLedgerRepository();
-  const reservations = new InMemoryReservationRepository();
+  const ents = new InMemoryEntitlementLedgerRepository();
+  const creds = new InMemoryCreditLedgerRepository();
+  const resv = new InMemoryReservationRepository();
   const payments = new InMemoryPaymentRepository();
   const kv = new InMemoryKvStore();
-  const objectStore = new FakeObjectStore();
 
   const boardingService = new BoardingService({
     scanEvents,
     kv,
-    reservations,
-    entitlements,
+    reservations: resv,
+    entitlements: ents,
     secret: DEV_AUTH_CONFIG.secret,
     passTtlSeconds: 60,
   });
   const paymentsService = new PaymentsService({
     payments,
-    subscriptions,
-    entitlements,
+    subscriptions: subs,
+    entitlements: ents,
     paystack: new FakePaystackClient(PAYSTACK_SECRET),
-    subscriptionFees: SUBSCRIPTION_FEES_PESEWAS,
-    ridesPerPeriod: PLACEHOLDER_RIDES_PER_PERIOD,
+    subscriptionFees: FEE,
+    ridesPerPeriod: RIDES_PER_PERIOD,
   });
 
   const app = await buildApp({
     users,
-    subscriptions,
+    subscriptions: subs,
     routes,
     stops,
     routeStops,
     trips,
     vehicles,
     drivers,
-    entitlements,
-    credits,
-    reservations,
+    entitlements: ents,
+    credits: creds,
+    reservations: resv,
     boardingService,
     paymentsService,
+    creditPesewasPerRide: CREDIT_PER_RIDE,
     kv,
-    objectStore,
+    objectStore: new FakeObjectStore(),
     auth: DEV_AUTH_CONFIG,
   });
 
-  const rider = await users.create({ displayName: 'Ama Mensah' });
   const route = await routes.create({ name: 'Circle ⇄ Madina', description: 'Pilot corridor' });
   const driver = await drivers.create({ fullName: 'Kwame Boateng', userId: 'demo-driver' });
   const trip = await trips.create({
@@ -115,15 +140,25 @@ async function build(): Promise<DemoState> {
     assignedDriverId: driver.id,
     scheduledAt: new Date(`${day(1)}T06:30:00Z`),
   });
+  const names = ['Ama Mensah', 'Kofi Owusu', 'Efua Sarpong', 'Yaw Darko', 'Adjoa Nkrumah'];
+  const riders: Rider[] = [];
+  for (let n = 0; n < FLEET; n++) {
+    const u = await users.create({ displayName: names[n % names.length] });
+    riders.push({ id: u.id, token: await jwt.signAccessToken({ userId: u.id, role: 'commuter' }) });
+  }
 
   return {
     app,
-    riderToken: await jwt.signAccessToken({ userId: rider.id, role: 'commuter' }),
+    subs,
+    ents,
+    creds,
+    resv,
+    riders,
     driverToken: await jwt.signAccessToken({ userId: 'demo-driver', role: 'driver' }),
     adminToken: await jwt.signAccessToken({ userId: 'demo-admin', role: 'admin' }),
-    riderId: rider.id,
     routeId: route.id,
     tripId: trip.id,
+    travelDate: day(1),
   };
 }
 
@@ -133,7 +168,7 @@ async function call(
   url: string,
   token: string,
   body?: unknown,
-): Promise<{ status: number; json: Record<string, unknown> }> {
+): Promise<Record<string, unknown>> {
   const headers: Record<string, string> = { authorization: `Bearer ${token}` };
   if (body !== undefined) headers['content-type'] = 'application/json';
   const res = await s.app.inject({
@@ -142,75 +177,107 @@ async function call(
     headers,
     ...(body === undefined ? {} : { payload: JSON.stringify(body) }),
   });
-  let json: Record<string, unknown> = {};
   try {
-    json = res.json();
+    return res.json() as Record<string, unknown>;
   } catch {
-    json = { raw: res.body };
+    return {};
   }
-  return { status: res.statusCode, json };
 }
 
-async function rides(s: DemoState): Promise<{ rides: number; credits: number }> {
-  const { json } = await call(s, 'GET', '/me/rides', s.riderToken);
-  return { rides: Number(json.remainingRides ?? 0), credits: Number(json.creditPesewas ?? 0) };
+async function subscribeRider(s: DemoState, r: Rider): Promise<void> {
+  // Idempotent: the in-memory repo doesn't enforce one-active-per-user, so guard
+  // against re-entering the beat (which would double-count members).
+  if (await s.subs.findActiveByUser(r.id)) return;
+  const init = await call(s, 'POST', '/payments/subscribe', r.token, {
+    plan: 'monthly',
+    routeId: s.routeId,
+  });
+  const webhookBody = JSON.stringify({
+    event: 'charge.success',
+    data: { reference: String(init.reference) },
+  });
+  await s.app.inject({
+    method: 'POST',
+    url: '/webhooks/paystack',
+    headers: {
+      'content-type': 'application/json',
+      'x-paystack-signature': paystackSignature(webhookBody, PAYSTACK_SECRET),
+    },
+    payload: webhookBody,
+  });
 }
 
-type StepResult = Record<string, unknown>;
+async function metrics(s: DemoState): Promise<Record<string, unknown>> {
+  const active = await s.subs.findAllActive();
+  let remaining = 0;
+  let liability = 0;
+  for (const r of s.riders) {
+    remaining += await s.ents.remainingRides(r.id);
+    liability += await s.creds.balancePesewas(r.id);
+  }
+  const rows = await s.resv.listForTrip(s.tripId);
+  const count = (st: string) => rows.filter((x) => x.status === st).length;
+  const boarded = count('boarded');
+  const allocated = active.length * RIDES_PER_PERIOD;
+  const ama = s.riders[0];
+  return {
+    subscribers: active.length,
+    ridesAllocated: allocated,
+    ridesRemaining: remaining,
+    ridesConsumed: Math.max(0, allocated - remaining),
+    confirmed: count('reserved') + boarded,
+    declined: count('declined'),
+    boarded,
+    noShow: count('no_show'),
+    capacity: CAPACITY,
+    occupancy: CAPACITY ? Math.round((boarded / CAPACITY) * 100) : 0,
+    subRevenue: active.length * FEE.monthly,
+    creditLiability: liability,
+    ama: {
+      rides: await s.ents.remainingRides(ama.id),
+      credits: await s.creds.balancePesewas(ama.id),
+      pin: ama.pin ?? null,
+    },
+  };
+}
 
-const STEPS: Record<string, (s: DemoState) => Promise<StepResult>> = {
+const STEPS: Record<string, (s: DemoState) => Promise<void>> = {
   async subscribe(s) {
-    const init = await call(s, 'POST', '/payments/subscribe', s.riderToken, {
-      plan: 'monthly',
-      routeId: s.routeId,
-    });
-    const reference = String((init.json as { reference?: string }).reference);
-    const webhookBody = JSON.stringify({ event: 'charge.success', data: { reference } });
-    await s.app.inject({
-      method: 'POST',
-      url: '/webhooks/paystack',
-      headers: {
-        'content-type': 'application/json',
-        'x-paystack-signature': paystackSignature(webhookBody, PAYSTACK_SECRET),
-      },
-      payload: webhookBody,
-    });
-    return { reference, ...(await rides(s)) };
+    for (const r of s.riders) await subscribeRider(s, r);
   },
   async confirm(s) {
-    const { json } = await call(s, 'POST', '/me/reservations', s.riderToken, {
-      tripId: s.tripId,
-      travelDate: day(1),
-      direction: 'morning',
-      travelling: true,
-    });
-    s.reservationId = String(json.id);
-    s.pin = String(json.pin);
-    return { pin: s.pin, reservationId: s.reservationId, ...(await rides(s)) };
+    for (let n = 0; n < s.riders.length; n++) {
+      const r = s.riders[n]!;
+      const travelling = n < CONFIRM;
+      const out = await call(s, 'POST', '/me/reservations', r.token, {
+        tripId: s.tripId,
+        travelDate: s.travelDate,
+        direction: 'morning',
+        travelling,
+      });
+      if (travelling) {
+        r.reservationId = String(out.id);
+        r.pin = String(out.pin);
+      }
+    }
   },
   async board(s) {
-    const { json } = await call(s, 'POST', '/boarding/verify-pin', s.driverToken, {
-      reservationId: s.reservationId,
-      pin: s.pin,
-    });
-    return { deducted: json.deducted === true, ...(await rides(s)) };
+    for (let n = 0; n < BOARD; n++) {
+      const r = s.riders[n]!;
+      await call(s, 'POST', '/boarding/verify-pin', s.driverToken, {
+        reservationId: r.reservationId,
+        pin: r.pin,
+      });
+    }
   },
   async noshow(s) {
-    await call(s, 'POST', '/me/reservations', s.riderToken, {
-      tripId: s.tripId,
-      travelDate: day(2),
-      direction: 'morning',
-      travelling: true,
-    });
-    const { json } = await call(s, 'POST', '/admin/resolve-no-shows', s.adminToken, {
-      travelDate: day(2),
+    await call(s, 'POST', '/admin/resolve-no-shows', s.adminToken, {
+      travelDate: s.travelDate,
       direction: 'morning',
     });
-    return { noShows: Number(json.noShows ?? 0), ...(await rides(s)) };
   },
   async convert(s) {
-    const { json } = await call(s, 'POST', '/admin/convert-credits', s.adminToken);
-    return { converted: Number(json.ridesConverted ?? 0), ...(await rides(s)) };
+    await call(s, 'POST', '/admin/convert-credits', s.adminToken);
   },
 };
 
@@ -231,15 +298,15 @@ const server = createServer((req, res) => {
       if (url === '/demo/reset' && req.method === 'POST') {
         S = await build();
         res.setHeader('content-type', 'application/json');
-        res.end(JSON.stringify({ ok: true, rides: 0, credits: 0 }));
+        res.end(JSON.stringify({ ok: true, ...(await metrics(S)) }));
         return;
       }
       const name = url.startsWith('/demo/') ? url.slice('/demo/'.length) : '';
       if (STEPS[name] && req.method === 'POST') {
         if (!S) S = await build();
-        const data = await STEPS[name](S);
+        await STEPS[name]!(S);
         res.setHeader('content-type', 'application/json');
-        res.end(JSON.stringify({ ok: true, ...data }));
+        res.end(JSON.stringify({ ok: true, ...(await metrics(S)) }));
         return;
       }
       res.statusCode = 404;

--- a/services/api/scripts/demo-server.ts
+++ b/services/api/scripts/demo-server.ts
@@ -140,10 +140,34 @@ async function build(): Promise<DemoState> {
     assignedDriverId: driver.id,
     scheduledAt: new Date(`${day(1)}T06:30:00Z`),
   });
-  const names = ['Ama Mensah', 'Kofi Owusu', 'Efua Sarpong', 'Yaw Darko', 'Adjoa Nkrumah'];
+  const firsts = [
+    'Ama',
+    'Kofi',
+    'Efua',
+    'Yaw',
+    'Adjoa',
+    'Kwabena',
+    'Akosua',
+    'Kojo',
+    'Abena',
+    'Fiifi',
+  ];
+  const lasts = [
+    'Mensah',
+    'Owusu',
+    'Sarpong',
+    'Darko',
+    'Nkrumah',
+    'Asante',
+    'Agyeman',
+    'Addo',
+    'Quaye',
+    'Tetteh',
+  ];
   const riders: Rider[] = [];
   for (let n = 0; n < FLEET; n++) {
-    const u = await users.create({ displayName: names[n % names.length] });
+    const name = `${firsts[n % firsts.length]} ${lasts[(n * 7) % lasts.length]}`;
+    const u = await users.create({ displayName: name });
     riders.push({ id: u.id, token: await jwt.signAccessToken({ userId: u.id, role: 'commuter' }) });
   }
 
@@ -219,7 +243,24 @@ async function metrics(s: DemoState): Promise<Record<string, unknown>> {
   const count = (st: string) => rows.filter((x) => x.status === st).length;
   const boarded = count('boarded');
   const allocated = active.length * RIDES_PER_PERIOD;
-  const ama = s.riders[0];
+  const ama = s.riders[0]!;
+
+  // The driver's real manifest (the assigned driver's view). Trimmed to a few
+  // rows for the demo device; Ama is flagged so the UI can highlight her.
+  const man = await call(s, 'GET', `/boarding/manifest?tripId=${s.tripId}`, s.driverToken);
+  const manRiders = (Array.isArray(man.riders) ? man.riders : []) as {
+    userId: string;
+    name?: string;
+    boarded: boolean;
+  }[];
+  const manifest = {
+    total: manRiders.length,
+    boarded,
+    riders: [...manRiders]
+      .sort((a, b) => (a.userId === ama.id ? -1 : b.userId === ama.id ? 1 : 0))
+      .slice(0, 7)
+      .map((r) => ({ name: r.name ?? 'Rider', boarded: r.boarded, isAma: r.userId === ama.id })),
+  };
   return {
     subscribers: active.length,
     ridesAllocated: allocated,
@@ -233,6 +274,7 @@ async function metrics(s: DemoState): Promise<Record<string, unknown>> {
     occupancy: CAPACITY ? Math.round((boarded / CAPACITY) * 100) : 0,
     subRevenue: active.length * FEE.monthly,
     creditLiability: liability,
+    manifest,
     ama: {
       rides: await s.ents.remainingRides(ama.id),
       credits: await s.creds.balancePesewas(ama.id),

--- a/services/api/src/app.ts
+++ b/services/api/src/app.ts
@@ -1,3 +1,4 @@
+import fastifyCors from '@fastify/cors';
 import fastifySwagger from '@fastify/swagger';
 import fastifySwaggerUi from '@fastify/swagger-ui';
 import Fastify, { type FastifyInstance } from 'fastify';
@@ -130,6 +131,8 @@ export interface AppDeps {
   paymentsService?: PaymentsService;
   /** Rate-limit thresholds (from env). Defaults applied when unset. */
   rateLimit?: RateLimitConfig;
+  /** CORS origin allowlist (from CORS_ORIGINS). Empty/unset -> reflect any origin. */
+  corsOrigins?: string[];
   /** Prometheus /metrics exposure. Defaults to unprotected (dev/tests). */
   metrics?: Partial<MetricsOptions>;
   logger?: boolean;
@@ -145,6 +148,17 @@ export interface AppDeps {
  */
 export async function buildApp(deps: AppDeps = {}): Promise<FastifyInstance> {
   const app = Fastify({ logger: deps.logger ?? false });
+
+  // CORS for browser clients (the live demo page, a future web dashboard).
+  // Registered first so preflight is handled for every route. A specific
+  // allowlist when configured; otherwise reflect any origin — safe because auth
+  // is a bearer token, not cookies, so a cross-site call can't ride ambient
+  // credentials. `credentials: false` for the same reason.
+  await app.register(fastifyCors, {
+    origin: deps.corsOrigins && deps.corsOrigins.length > 0 ? deps.corsOrigins : true,
+    credentials: false,
+    methods: ['GET', 'POST', 'PATCH', 'PUT', 'DELETE', 'OPTIONS'],
+  });
 
   // zod is the single source for validation AND the OpenAPI spec (ADR-0008):
   // route schemas are zod, compiled here and rendered into the docs by

--- a/services/api/src/config/env.ts
+++ b/services/api/src/config/env.ts
@@ -32,6 +32,11 @@ const envSchema = z
     R2_ACCESS_KEY_ID: z.string().optional(),
     R2_SECRET_ACCESS_KEY: z.string().optional(),
     R2_BUCKET: z.string().optional(),
+    // CORS allowlist for browser clients (comma-separated origins), e.g. the
+    // live demo page or a web dashboard. Unset -> reflect any origin, which is
+    // safe here because auth is a bearer token (no cookies/ambient credentials
+    // for a cross-site request to ride on). Set to lock down to known origins.
+    CORS_ORIGINS: z.string().optional(),
     // Rate limiting (fixed window). Tunable without a code change.
     RATE_LIMIT_MAX: z.coerce.number().int().positive().default(100),
     RATE_LIMIT_WINDOW_SECONDS: z.coerce.number().int().positive().default(60),

--- a/services/api/src/server.ts
+++ b/services/api/src/server.ts
@@ -299,6 +299,11 @@ async function main(): Promise<void> {
     windowSeconds: env.RATE_LIMIT_WINDOW_SECONDS,
   };
 
+  // CORS allowlist (comma-separated origins). Unset -> reflect any origin.
+  const corsOrigins = env.CORS_ORIGINS?.split(',')
+    .map((o) => o.trim())
+    .filter(Boolean);
+
   const app = await buildApp({
     users,
     subscriptions,
@@ -324,6 +329,7 @@ async function main(): Promise<void> {
     isReady,
     auth,
     rateLimit,
+    corsOrigins,
     // /metrics: protected by a token when set; disabled in prod when unset.
     metrics: { token: env.METRICS_TOKEN, allowUnprotected: env.NODE_ENV !== 'production' },
     logger: true,

--- a/services/api/tests/cors.test.ts
+++ b/services/api/tests/cors.test.ts
@@ -1,0 +1,49 @@
+// CORS for browser clients (the live demo page, a web dashboard). Auth is a
+// bearer token, not cookies, so reflecting any origin is safe; an allowlist
+// locks it down when configured.
+
+import { describe, expect, it } from 'vitest';
+import { buildApp } from '../src/app';
+
+describe('CORS', () => {
+  it('reflects any origin by default (bearer auth, no credentials)', async () => {
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'OPTIONS',
+      url: '/routes',
+      headers: { origin: 'https://demo.example', 'access-control-request-method': 'GET' },
+    });
+    expect(res.headers['access-control-allow-origin']).toBe('https://demo.example');
+    // no cookies ride along
+    expect(res.headers['access-control-allow-credentials']).toBeUndefined();
+  });
+
+  it('sets the CORS header on an actual GET', async () => {
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/healthz',
+      headers: { origin: 'https://demo.example' },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['access-control-allow-origin']).toBe('https://demo.example');
+  });
+
+  it('restricts to the allowlist when configured', async () => {
+    const app = await buildApp({ corsOrigins: ['https://allowed.app'] });
+    const ok = await app.inject({
+      method: 'GET',
+      url: '/healthz',
+      headers: { origin: 'https://allowed.app' },
+    });
+    expect(ok.headers['access-control-allow-origin']).toBe('https://allowed.app');
+
+    const blocked = await app.inject({
+      method: 'GET',
+      url: '/healthz',
+      headers: { origin: 'https://evil.app' },
+    });
+    // origin not echoed back for a disallowed site
+    expect(blocked.headers['access-control-allow-origin']).toBeUndefined();
+  });
+});


### PR DESCRIPTION
The animated investor walkthrough, but **live** — every number on screen (the ride entitlement, the daily PIN, each deduction, the converted credit) is returned by the **real Trotxi API**, not scripted.

Run it:
```bash
pnpm --filter @trotxi/api demo   # → http://localhost:4319, press Play
```

## How it's live
The polished animation can't call APIs from Claude's sandbox, so this is a standalone page fed by a tiny local runner:
- **`services/api/scripts/demo-server.ts`** boots the real API **in-process** (in-memory, zero infra) and serves `demo/index.html` plus `POST /demo/*` endpoints. Each beat drives one step of the hybrid-model loop through the actual API and returns the real result:

| Beat | Real call behind it |
| --- | --- |
| Subscribe | `/payments/subscribe` + the signed Paystack webhook → **44 rides** allocated |
| Confirm | `POST /me/reservations` → the daily **boarding PIN** |
| Board | `POST /boarding/verify-pin` → one ride deducted (**44 → 43**) |
| No-show | `POST /admin/resolve-no-shows` → a held-but-unused seat deducted |
| Month-end | `POST /admin/convert-credits` → unused rides → **Ride Credits** |

Runs locally so a pitch never waits on a cold start. The front-end (`demo/index.html`) is same-origin, so it needs zero config; the ledger, PIN, and credit animate to the live responses.

## CORS
Browser pages can only call a deployed API with CORS, which the API didn't send. Added **`@fastify/cors`** — safe here because auth is a **bearer token, not cookies** (`credentials: false`), so a cross-site call can't ride ambient credentials. Reflects any origin by default; lock down via `CORS_ORIGINS`. Wired in `app.ts` + `server.ts` + `env.ts`, with tests (reflect / allowlist / no-credentials). This also unblocks any future web client.

## Verification
Driven end-to-end in a real browser: subscribe → 44, confirm → PIN `1473`, board → 43, no-show → 42, convert → **GHS 18.90** (`POST /demo/convert · 200 · 16 ms`). **321 tests** (incl. CORS), typecheck + lint + build clean.

> Pricing figures are illustrative placeholders until the pilot pricing is locked; the mechanics are the real API.