### PR TITLE
fix(api): report the deployed commit from GET /version

### DIFF
--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -19,6 +19,11 @@ RUN pnpm --filter @trotxi/api run build \
 FROM node:24-alpine
 WORKDIR /app
 ENV NODE_ENV=production
+# Stamp the build's commit so GET /version can answer "what is running?".
+# On Render this is unnecessary (RENDER_GIT_COMMIT is injected at runtime); this
+# covers images built anywhere else: docker build --build-arg GIT_SHA=$(git rev-parse HEAD)
+ARG GIT_SHA=""
+ENV GIT_SHA=$GIT_SHA
 COPY --from=build /app/node_modules ./node_modules
 COPY --from=build /app/dist ./dist
 COPY --from=build /app/package.json ./package.json

--- a/services/api/src/app.ts
+++ b/services/api/src/app.ts
@@ -136,6 +136,23 @@ export interface AppDeps {
 }
 
 /**
+ * The commit this instance is running, for `GET /version` — the first question
+ * a rollback asks. `RENDER_GIT_COMMIT` is injected by Render on every deploy,
+ * so hosted environments report their real commit with no build wiring;
+ * `GIT_SHA` overrides it for images built elsewhere (CI, local docker).
+ *
+ * Empty values are treated as absent: the Dockerfile declares `ARG GIT_SHA=""`,
+ * so an unstamped image bakes in an empty string that `??` would otherwise
+ * prefer over the platform value.
+ *
+ * @returns the deployed commit, or `dev` when nothing is stamped.
+ */
+function deployedCommit(): string {
+  const candidates = [process.env['GIT_SHA'], process.env['RENDER_GIT_COMMIT']];
+  return candidates.find((value) => value !== undefined && value.trim() !== '')?.trim() ?? 'dev';
+}
+
+/**
  * Build the Fastify app — registers OpenAPI docs, metrics, guards, and all
  * routes. Dependencies are injected so tests pass in-memory implementations and
  * production wires the real ones.
@@ -354,7 +371,7 @@ export async function buildApp(deps: AppDeps = {}): Promise<FastifyInstance> {
     async () => ({
       name: 'trotxi-api',
       version: '0.1.0',
-      commit: process.env['GIT_SHA'] ?? 'dev',
+      commit: deployedCommit(),
     }),
   );
 

--- a/services/api/tests/app.test.ts
+++ b/services/api/tests/app.test.ts
@@ -55,4 +55,51 @@ describe('app', () => {
       commit: 'dev',
     });
   });
+
+  // Rollback starts with "what is actually running?", so /version must report
+  // the deployed commit. Render injects RENDER_GIT_COMMIT; GIT_SHA overrides it
+  // for images built elsewhere.
+  it.each([
+    { env: 'GIT_SHA', value: 'abc1234', expected: 'abc1234' },
+    { env: 'RENDER_GIT_COMMIT', value: 'def5678', expected: 'def5678' },
+  ])('reports the commit from $env', async ({ env, value, expected }) => {
+    const previous = process.env[env];
+    process.env[env] = value;
+    try {
+      const app = await buildApp();
+      const res = await app.inject({ method: 'GET', url: '/version' });
+      expect(res.json()).toMatchObject({ commit: expected });
+    } finally {
+      if (previous === undefined) delete process.env[env];
+      else process.env[env] = previous;
+    }
+  });
+
+  // The Dockerfile declares ARG GIT_SHA="", so an unstamped image ships an
+  // empty GIT_SHA. It must not mask the platform-injected commit.
+  it('ignores an empty GIT_SHA and falls back to the platform commit', async () => {
+    process.env['GIT_SHA'] = '';
+    process.env['RENDER_GIT_COMMIT'] = 'render123';
+    try {
+      const app = await buildApp();
+      const res = await app.inject({ method: 'GET', url: '/version' });
+      expect(res.json()).toMatchObject({ commit: 'render123' });
+    } finally {
+      delete process.env['GIT_SHA'];
+      delete process.env['RENDER_GIT_COMMIT'];
+    }
+  });
+
+  it('prefers an explicit GIT_SHA over the platform-injected commit', async () => {
+    process.env['GIT_SHA'] = 'explicit';
+    process.env['RENDER_GIT_COMMIT'] = 'platform';
+    try {
+      const app = await buildApp();
+      const res = await app.inject({ method: 'GET', url: '/version' });
+      expect(res.json()).toMatchObject({ commit: 'explicit' });
+    } finally {
+      delete process.env['GIT_SHA'];
+      delete process.env['RENDER_GIT_COMMIT'];
+    }
+  });
 });


### PR DESCRIPTION
`GET /version` reports `commit: "dev"` in every environment — including staging right now. `GIT_SHA` was read but never set anywhere: not in the Dockerfile, not in `render.yaml`. So **we currently cannot tell which commit is running in production**, which is the first question a rollback has to answer.

## Change

- Read **`RENDER_GIT_COMMIT`**, which Render injects into every service at runtime. Hosted environments become self-reporting with **no build wiring or dashboard config**.
- Keep **`GIT_SHA`** as the explicit override for images built elsewhere (CI, local docker), and accept it as a Dockerfile build arg.

## The empty-string trap (worth a look)

`ARG GIT_SHA=""` means an unstamped image ships with `GIT_SHA` set to an empty string. Since `??` only falls through on `null`/`undefined`, the naive version would have preferred `""` over the platform value and reported an **empty** commit — silently defeating the whole change on Render, which builds from this Dockerfile.

`deployedCommit()` treats blank as absent, and there's a test pinning that behaviour so it can't regress.

## Verification

- 322 tests pass (4 new: `GIT_SHA`, `RENDER_GIT_COMMIT`, precedence, empty-string fallback); typecheck, lint, build clean.
- After deploy, `curl https://trotxi-api-staging.onrender.com/version` should return the real SHA instead of `dev`.

Part of release governance — rollback needs to start from a known deployed commit.