### PR TITLE
feat(api): enable CORS so browser clients can call the API

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
       '@aws-sdk/s3-request-presigner':
         specifier: ^3.1079.0
         version: 3.1079.0
+      '@fastify/cors':
+        specifier: ^11.3.0
+        version: 11.3.0
       '@fastify/multipart':
         specifier: ^10.1.0
         version: 10.1.0
@@ -639,6 +642,9 @@ packages:
 
   '@fastify/busboy@3.2.0':
     resolution: {integrity: sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==}
+
+  '@fastify/cors@11.3.0':
+    resolution: {integrity: sha512-ggQGua+xHv1MvePbPr0v//xLYEsCXbWspquXCJS9Ot5YoRXq8J8ZWzHnxDBVnbtXosvistXo6LtNzOJswf64Fw==}
 
   '@fastify/deepmerge@3.2.1':
     resolution: {integrity: sha512-N5Oqvltoa2r9z1tbx4xjky0oRR60v+T47Ic4J1ukoVQcptLOrIdRnCSdTGmOmajZuHVKlTnfcmrjyqsGEW1ztA==}
@@ -3982,6 +3988,11 @@ snapshots:
       fast-uri: 4.1.2
 
   '@fastify/busboy@3.2.0': {}
+
+  '@fastify/cors@11.3.0':
+    dependencies:
+      fastify-plugin: 6.0.0
+      toad-cache: 3.7.1
 
   '@fastify/deepmerge@3.2.1': {}
 

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1079.0",
     "@aws-sdk/s3-request-presigner": "^3.1079.0",
+    "@fastify/cors": "^11.3.0",
     "@fastify/multipart": "^10.1.0",
     "@fastify/swagger": "^9.8.1",
     "@fastify/swagger-ui": "^6.1.1",

--- a/services/api/src/app.ts
+++ b/services/api/src/app.ts
@@ -1,3 +1,4 @@
+import fastifyCors from '@fastify/cors';
 import fastifySwagger from '@fastify/swagger';
 import fastifySwaggerUi from '@fastify/swagger-ui';
 import Fastify, { type FastifyInstance } from 'fastify';
@@ -130,6 +131,8 @@ export interface AppDeps {
   paymentsService?: PaymentsService;
   /** Rate-limit thresholds (from env). Defaults applied when unset. */
   rateLimit?: RateLimitConfig;
+  /** CORS origin allowlist (from CORS_ORIGINS). Empty/unset -> reflect any origin. */
+  corsOrigins?: string[];
   /** Prometheus /metrics exposure. Defaults to unprotected (dev/tests). */
   metrics?: Partial<MetricsOptions>;
   logger?: boolean;
@@ -162,6 +165,17 @@ function deployedCommit(): string {
  */
 export async function buildApp(deps: AppDeps = {}): Promise<FastifyInstance> {
   const app = Fastify({ logger: deps.logger ?? false });
+
+  // CORS for browser clients (Swagger UI served from another origin, a future
+  // web dashboard). Registered first so preflight is handled for every route.
+  // A specific allowlist when configured; otherwise reflect any origin — safe
+  // because auth is a bearer token, not cookies, so a cross-site call cannot
+  // ride ambient credentials. `credentials: false` for the same reason.
+  await app.register(fastifyCors, {
+    origin: deps.corsOrigins && deps.corsOrigins.length > 0 ? deps.corsOrigins : true,
+    credentials: false,
+    methods: ['GET', 'POST', 'PATCH', 'PUT', 'DELETE', 'OPTIONS'],
+  });
 
   // zod is the single source for validation AND the OpenAPI spec (ADR-0008):
   // route schemas are zod, compiled here and rendered into the docs by

--- a/services/api/src/config/env.ts
+++ b/services/api/src/config/env.ts
@@ -32,6 +32,11 @@ const envSchema = z
     R2_ACCESS_KEY_ID: z.string().optional(),
     R2_SECRET_ACCESS_KEY: z.string().optional(),
     R2_BUCKET: z.string().optional(),
+    // CORS allowlist for browser clients (comma-separated origins), e.g. Swagger
+    // UI served from another origin or a web dashboard. Unset -> reflect any
+    // origin, which is safe here because auth is a bearer token (no cookies or
+    // ambient credentials for a cross-site request to ride on).
+    CORS_ORIGINS: z.string().optional(),
     // Rate limiting (fixed window). Tunable without a code change.
     RATE_LIMIT_MAX: z.coerce.number().int().positive().default(100),
     RATE_LIMIT_WINDOW_SECONDS: z.coerce.number().int().positive().default(60),

--- a/services/api/src/server.ts
+++ b/services/api/src/server.ts
@@ -294,6 +294,13 @@ async function main(): Promise<void> {
     return kv.ping();
   };
 
+  // Browser clients only reach the API if it advertises CORS. Unset -> reflect
+  // any origin (bearer auth, so no ambient credentials at risk).
+  const corsOrigins = (env.CORS_ORIGINS ?? '')
+    .split(',')
+    .map((o) => o.trim())
+    .filter((o) => o !== '');
+
   const rateLimit: RateLimitConfig = {
     max: env.RATE_LIMIT_MAX,
     windowSeconds: env.RATE_LIMIT_WINDOW_SECONDS,
@@ -324,6 +331,7 @@ async function main(): Promise<void> {
     isReady,
     auth,
     rateLimit,
+    corsOrigins,
     // /metrics: protected by a token when set; disabled in prod when unset.
     metrics: { token: env.METRICS_TOKEN, allowUnprotected: env.NODE_ENV !== 'production' },
     logger: true,

--- a/services/api/tests/cors.test.ts
+++ b/services/api/tests/cors.test.ts
@@ -1,0 +1,49 @@
+// CORS for browser clients (the live demo page, a web dashboard). Auth is a
+// bearer token, not cookies, so reflecting any origin is safe; an allowlist
+// locks it down when configured.
+
+import { describe, expect, it } from 'vitest';
+import { buildApp } from '../src/app';
+
+describe('CORS', () => {
+  it('reflects any origin by default (bearer auth, no credentials)', async () => {
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'OPTIONS',
+      url: '/routes',
+      headers: { origin: 'https://demo.example', 'access-control-request-method': 'GET' },
+    });
+    expect(res.headers['access-control-allow-origin']).toBe('https://demo.example');
+    // no cookies ride along
+    expect(res.headers['access-control-allow-credentials']).toBeUndefined();
+  });
+
+  it('sets the CORS header on an actual GET', async () => {
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/healthz',
+      headers: { origin: 'https://demo.example' },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['access-control-allow-origin']).toBe('https://demo.example');
+  });
+
+  it('restricts to the allowlist when configured', async () => {
+    const app = await buildApp({ corsOrigins: ['https://allowed.app'] });
+    const ok = await app.inject({
+      method: 'GET',
+      url: '/healthz',
+      headers: { origin: 'https://allowed.app' },
+    });
+    expect(ok.headers['access-control-allow-origin']).toBe('https://allowed.app');
+
+    const blocked = await app.inject({
+      method: 'GET',
+      url: '/healthz',
+      headers: { origin: 'https://evil.app' },
+    });
+    // origin not echoed back for a disallowed site
+    expect(blocked.headers['access-control-allow-origin']).toBeUndefined();
+  });
+});


### PR DESCRIPTION
The API sends **no CORS headers**, so any browser page on a different origin has its requests blocked before they ever leave the browser.

Swagger UI reports this as:

```
Code: Undocumented
TypeError: Type error
```

which reads like a server fault but is the browser refusing to make the call — **the server never sees the request**. Hit today while testing `GET /me` through a proxied Swagger page; the identical request via `curl` returned **200**.

## Change

- Register `@fastify/cors` **before everything else**, so preflight is handled for every route — including `OPTIONS` on authenticated endpoints. This matters: the preflight has to allow the `authorization` header or the real request is never sent.
- `CORS_ORIGINS` (comma-separated) locks it down to known origins.
- Unset, it reflects the requesting origin. That's safe **here specifically** because auth is a bearer token: there are no cookies or ambient credentials for a cross-site request to ride on. `credentials: false` for the same reason.

## Verified live

```
$ curl -D- http://localhost:3000/me -H "Origin: http://localhost:5173"
access-control-allow-origin: http://localhost:5173

$ curl -X OPTIONS ... -H "Access-Control-Request-Headers: authorization"
HTTP/1.1 204 No Content
access-control-allow-methods: GET, POST, PATCH, PUT, DELETE, OPTIONS
access-control-allow-headers: authorization
```

**325 tests pass** (3 CORS cases); typecheck, lint, build clean.

## Note

This was written and tested in #134 and lost when that PR was closed. Picked up here on its own, without the demo page it was bundled with. While cherry-picking I briefly clobbered the `deployedCommit()` fix from #151 — caught by its tests, and re-applied surgically instead, so `/version` behaviour is unchanged.

Unblocks: browser-based API testing, and any future web client (ops dashboard).