### PR TITLE
chore(deps): clear the two moderate advisories in production paths

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,8 @@ overrides:
   fast-uri: '>=3.1.4'
   fast-xml-parser: '>=5.10.1'
   find-my-way: '>=9.6.1'
+  uuid: ^11.1.1
+  protobufjs: ^7.6.5
 
 importers:
 
@@ -1295,8 +1297,8 @@ packages:
   '@protobufjs/pool@1.1.0':
     resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
 
-  '@protobufjs/utf8@1.1.1':
-    resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
+  '@protobufjs/utf8@1.1.2':
+    resolution: {integrity: sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==}
 
   '@rollup/rollup-android-arm-eabi@4.62.2':
     resolution: {integrity: sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==}
@@ -2943,8 +2945,8 @@ packages:
     resolution: {integrity: sha512-E1sbAYg3aEbXrq0n1ojJkRHQJGE1kaE/O6GLA94y8rnJBfgvOPTOd1b9hOceQK1FFZI9qMh1vBERCyO2ifubcw==}
     engines: {node: '>=18'}
 
-  protobufjs@7.6.4:
-    resolution: {integrity: sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==}
+  protobufjs@7.6.5:
+    resolution: {integrity: sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==}
     engines: {node: '>=12.0.0'}
 
   proxy-agent-negotiate@1.1.0:
@@ -3397,9 +3399,8 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  uuid@9.0.1:
-    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
 
   vite@7.3.6:
@@ -4108,7 +4109,7 @@ snapshots:
       fast-deep-equal: 3.1.3
       functional-red-black-tree: 1.0.1
       google-gax: 5.0.7
-      protobufjs: 7.6.4
+      protobufjs: 7.6.5
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -4155,7 +4156,7 @@ snapshots:
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.3.2
-      protobufjs: 7.6.4
+      protobufjs: 7.6.5
       yargs: 17.7.3
 
   '@humanfs/core@0.19.2':
@@ -4771,7 +4772,7 @@ snapshots:
 
   '@protobufjs/pool@1.1.0': {}
 
-  '@protobufjs/utf8@1.1.1': {}
+  '@protobufjs/utf8@1.1.2': {}
 
   '@rollup/rollup-android-arm-eabi@4.62.2':
     optional: true
@@ -5818,7 +5819,7 @@ snapshots:
       https-proxy-agent: 7.0.6
       is-stream: 2.0.1
       node-fetch: 2.7.0
-      uuid: 9.0.1
+      uuid: 11.1.1
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -5968,7 +5969,7 @@ snapshots:
       node-fetch: 3.3.2
       object-hash: 3.0.0
       proto3-json-serializer: 3.0.4
-      protobufjs: 7.6.4
+      protobufjs: 7.6.5
       retry-request: 8.0.3
       rimraf: 5.0.10
     transitivePeerDependencies:
@@ -6597,10 +6598,10 @@ snapshots:
 
   proto3-json-serializer@3.0.4:
     dependencies:
-      protobufjs: 7.6.4
+      protobufjs: 7.6.5
     optional: true
 
-  protobufjs@7.6.4:
+  protobufjs@7.6.5:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2
@@ -6610,7 +6611,7 @@ snapshots:
       '@protobufjs/float': 1.0.2
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
-      '@protobufjs/utf8': 1.1.1
+      '@protobufjs/utf8': 1.1.2
       '@types/node': 26.0.1
       long: 5.3.2
 
@@ -6970,7 +6971,7 @@ snapshots:
       https-proxy-agent: 5.0.1
       node-fetch: 2.7.0
       stream-events: 1.0.5
-      uuid: 9.0.1
+      uuid: 11.1.1
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -7104,7 +7105,7 @@ snapshots:
   util-deprecate@1.0.2:
     optional: true
 
-  uuid@9.0.1:
+  uuid@11.1.1:
     optional: true
 
   vite@7.3.6(@types/node@26.0.1)(tsx@4.22.4)(yaml@2.9.0):

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,16 +3,24 @@ packages:
   - 'e2e'
 
 # Security overrides: force patched versions of transitive dependencies whose
-# direct parents still pin a vulnerable range. Each entry clears a high-severity
-# advisory that `pnpm audit --prod` fails CI on. All are patch/minor bumps within
-# the same major, so they are drop-in. Remove an entry once the parent's own
-# range has moved past it.
+# direct parents still pin a vulnerable range. Each entry clears an advisory
+# that `pnpm audit --prod` reports. All are patch/minor bumps within the same
+# major, so they are drop-in. Remove an entry once the parent's own range has
+# moved past it.
 overrides:
   brace-expansion: '>=5.0.8' # DoS via unbounded expansion length
   '@opentelemetry/propagator-jaeger': '>=2.9.0' # DoS in the Jaeger propagator
   fast-uri: '>=3.1.4' # host confusion via literal/IDN parsing (@fastify/swagger)
   fast-xml-parser: '>=5.10.1' # DOCTYPE entity-expansion reset (firebase-admin)
   find-my-way: '>=9.6.1' # HTTP/2 DDoS (fastify router)
+  # Moderate, and in production paths: uuid ships with the FCM push sender and
+  # protobufjs with the OTLP exporter, so both run in prod even though the
+  # `--audit-level=high` gate stays quiet about them.
+  # Pinned to the same major the parents expect: an unbounded `>=` floats to the
+  # next major (uuid 14, protobufjs 8), which our unit tests would not catch —
+  # they use the fake notification sender and never load the real SDKs.
+  uuid: '^11.1.1' # missing buffer bounds check in v3/v5/v6 (firebase-admin)
+  protobufjs: '^7.6.5' # DoS via infinite loop (@opentelemetry/sdk-node)
 
 # pnpm blocks dependency build scripts by default (supply-chain safety).
 # esbuild (used by tsup + vitest) needs its postinstall to fetch its binary.


### PR DESCRIPTION
`pnpm audit --prod` reports two **moderate** advisories our CI gate stays silent about, because it runs at `--audit-level=high`:

| Package | Advisory | Reaches production via |
|---|---|---|
| `uuid` <11.1.1 | missing buffer bounds check in v3/v5/v6 | `firebase-admin` → **FCM push sender** |
| `protobufjs` ≤7.6.4 | DoS via infinite loop | `@opentelemetry/sdk-node` → **OTLP trace exporter** |

Both sit in code that actually runs in production, so they're worth clearing rather than leaving under the threshold. Same pnpm-overrides mechanism already used for the five high-severity entries.

## The `^` vs `>=` detail — worth a look

I first wrote `>=11.1.1` / `>=7.6.5`, matching the neighbouring entries. That silently resolved to **uuid 14** and **protobufjs 8** — both major bumps.

Our unit suite would not have caught a break: the tests use `FakeNotificationSender` and never load the real Firebase or OTel SDKs, so all 325 passed against the majors. Pinned to `^` instead, which keeps them within the parents' major and genuinely drop-in, as the surrounding comment promises.

## Verification

Beyond the usual gate, I loaded the **real SDK paths** the overrides affect:

```
firebase-admin init: true | sendEachForMulticast: true
OTLP proto exporter (protobufjs): true
```

- Resolved: `uuid@11.1.1`, `protobufjs@7.6.5`
- `pnpm audit --prod --audit-level=moderate` → **no known vulnerabilities**
- 325 tests pass; typecheck, lint, build clean

## Follow-up worth considering

Should the audit gate move to `--audit-level=moderate` for production deps? High-only means we only learn about these when they've already escalated. Happy to do it in a separate PR — it's a policy change, not a fix.