### PR TITLE
docs(demo): interactive auth walkthrough for the app team

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -1,0 +1,33 @@
+# Demo & teaching assets
+
+Static pages for team sessions and API exploration. Nothing here ships to
+production — the Dockerfile only packages `services/api/dist`.
+
+## auth-explainer.html — the authentication walkthrough
+
+Nine interactive slides explaining how a client signs in and stays signed in:
+the three tokens, the sign-in flow, refresh rotation and replay detection,
+sessions, 401 vs 403, and the Dio interceptor contract. The last slide is a
+live playground that calls the running dev API.
+
+```bash
+pnpm --filter @trotxi/api dev   # terminal 1 — API on :3000 (dev verifier)
+pnpm demo:auth                  # terminal 2 — serves this folder on :4174
+# open http://localhost:4174/auth-explainer.html
+```
+
+Navigate with arrow keys. The playground signs in through the dev verifier
+(JSON claims as the idToken), so it works with zero Google configuration —
+staging always requires a real Google-signed token.
+
+## endpoints.html — the endpoint test console
+
+Served by its own runner (boots the real app in-process and executes 91 live
+cases across every endpoint):
+
+```bash
+pnpm --filter @trotxi/api demo:endpoints
+# dashboard on :4400 · live Swagger on :3001/docs
+```
+
+See `ENDPOINTS.md` for details.

--- a/demo/auth-explainer.html
+++ b/demo/auth-explainer.html
@@ -1,0 +1,851 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Trotxi — authentication explained</title>
+    <style>
+      :root {
+        --bg: #f6f7f5;
+        --surface: #ffffff;
+        --tile: #f0f1ee;
+        --ink: #16181d;
+        --muted: #6b6f76;
+        --line: #e4e6e2;
+        --green: #0f9d76;
+        --green-ink: #0a5f48;
+        --green-bg: #e4f5ee;
+        --red: #c0392b;
+        --red-bg: #fdecea;
+        --blue: #2a78d6;
+        --blue-bg: #e6f1fb;
+        --blue-ink: #185fa5;
+        --amber: #b9770f;
+        --amber-bg: #faeeda;
+        --mono: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, monospace;
+        --sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #14161a;
+          --surface: #1c1f24;
+          --tile: #22252b;
+          --ink: #f0f1f3;
+          --muted: #9aa0a8;
+          --line: #2b2f36;
+          --green: #2fbd93;
+          --green-ink: #8fe3c9;
+          --green-bg: #123a2e;
+          --red: #e07070;
+          --red-bg: #3a1a1a;
+          --blue: #6aa8f0;
+          --blue-bg: #12233a;
+          --blue-ink: #9cc6f5;
+          --amber: #e0a545;
+          --amber-bg: #3a2e12;
+        }
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--bg);
+        color: var(--ink);
+        font-family: var(--sans);
+        line-height: 1.55;
+      }
+      .wrap {
+        max-width: 880px;
+        margin: 0 auto;
+        padding: 26px 22px 90px;
+      }
+      .slide {
+        display: none;
+        min-height: 60vh;
+      }
+      .slide.on {
+        display: block;
+        animation: fade 0.35s ease;
+      }
+      @keyframes fade {
+        from {
+          opacity: 0;
+          transform: translateY(6px);
+        }
+        to {
+          opacity: 1;
+        }
+      }
+      .eyebrow {
+        font-size: 12px;
+        letter-spacing: 0.07em;
+        text-transform: uppercase;
+        color: var(--green-ink);
+        font-weight: 600;
+      }
+      h1 {
+        font-size: 30px;
+        margin: 6px 0 8px;
+      }
+      h2 {
+        font-size: 23px;
+        margin: 6px 0 14px;
+      }
+      p.lead {
+        font-size: 16px;
+        color: var(--muted);
+        max-width: 640px;
+      }
+      table {
+        border-collapse: collapse;
+        width: 100%;
+        margin: 14px 0;
+        font-size: 13.5px;
+      }
+      th,
+      td {
+        border: 1px solid var(--line);
+        padding: 9px 12px;
+        text-align: left;
+        vertical-align: top;
+      }
+      th {
+        background: var(--tile);
+      }
+      code,
+      .code {
+        font-family: var(--mono);
+        font-size: 12.5px;
+      }
+      .pill {
+        display: inline-block;
+        font-size: 12px;
+        font-weight: 600;
+        padding: 3px 10px;
+        border-radius: 999px;
+      }
+      .pg {
+        background: var(--green-bg);
+        color: var(--green-ink);
+      }
+      .pb {
+        background: var(--blue-bg);
+        color: var(--blue-ink);
+      }
+      .pa {
+        background: var(--amber-bg);
+        color: var(--amber);
+      }
+      .pr {
+        background: var(--red-bg);
+        color: var(--red);
+      }
+      .flow {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+        margin: 16px 0;
+      }
+      .step {
+        display: flex;
+        gap: 12px;
+        align-items: flex-start;
+        background: var(--surface);
+        border: 1px solid var(--line);
+        border-radius: 11px;
+        padding: 11px 14px;
+      }
+      .step .n {
+        width: 26px;
+        height: 26px;
+        border-radius: 8px;
+        background: var(--green-bg);
+        color: var(--green-ink);
+        font-weight: 700;
+        font-size: 13px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        flex: none;
+        margin-top: 1px;
+      }
+      .step b {
+        font-size: 14px;
+      }
+      .step .d {
+        font-size: 13px;
+        color: var(--muted);
+      }
+      .card {
+        background: var(--surface);
+        border: 1px solid var(--line);
+        border-radius: 12px;
+        padding: 14px 16px;
+        margin: 10px 0;
+      }
+      .warn {
+        border-left: 4px solid var(--amber);
+        border-radius: 0 12px 12px 0;
+      }
+      .danger {
+        border-left: 4px solid var(--red);
+        border-radius: 0 12px 12px 0;
+      }
+      .good {
+        border-left: 4px solid var(--green);
+        border-radius: 0 12px 12px 0;
+      }
+      pre {
+        background: var(--tile);
+        border: 1px solid var(--line);
+        border-radius: 10px;
+        padding: 12px 14px;
+        font-family: var(--mono);
+        font-size: 12px;
+        overflow-x: auto;
+        white-space: pre-wrap;
+        word-break: break-word;
+      }
+      .jwt span.h {
+        color: var(--red);
+      }
+      .jwt span.p {
+        color: var(--blue-ink);
+      }
+      .jwt span.s {
+        color: var(--green-ink);
+      }
+      .nav {
+        position: fixed;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        background: var(--surface);
+        border-top: 1px solid var(--line);
+      }
+      .nav .in {
+        max-width: 880px;
+        margin: 0 auto;
+        padding: 10px 22px;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+      }
+      .dots {
+        display: flex;
+        gap: 6px;
+        flex: 1;
+      }
+      .dot {
+        width: 8px;
+        height: 8px;
+        border-radius: 99px;
+        background: var(--line);
+        border: none;
+        padding: 0;
+        cursor: pointer;
+        transition: all 0.25s;
+      }
+      .dot.on {
+        background: var(--green);
+        width: 22px;
+      }
+      button.b {
+        font-family: var(--sans);
+        font-size: 13.5px;
+        font-weight: 500;
+        cursor: pointer;
+        border-radius: 9px;
+        border: 1px solid var(--line);
+        background: var(--surface);
+        color: var(--ink);
+        padding: 7px 14px;
+      }
+      button.b:hover {
+        border-color: var(--green);
+      }
+      button.b.primary {
+        background: var(--green);
+        color: #fff;
+        border-color: var(--green);
+      }
+      button.b:disabled {
+        opacity: 0.45;
+        cursor: default;
+      }
+      .hint {
+        font-size: 12px;
+        color: var(--muted);
+      }
+      .lab {
+        display: grid;
+        grid-template-columns: 210px 1fr;
+        gap: 16px;
+        margin-top: 14px;
+      }
+      @media (max-width: 640px) {
+        .lab {
+          grid-template-columns: 1fr;
+        }
+      }
+      .lab .btns {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
+      .lab .btns button {
+        text-align: left;
+      }
+      .out {
+        background: var(--tile);
+        border: 1px solid var(--line);
+        border-radius: 10px;
+        padding: 12px;
+        font-family: var(--mono);
+        font-size: 11.5px;
+        min-height: 300px;
+        max-height: 420px;
+        overflow-y: auto;
+        white-space: pre-wrap;
+        word-break: break-word;
+      }
+      .tok {
+        font-size: 11px;
+        color: var(--muted);
+        margin-top: 8px;
+        word-break: break-all;
+      }
+      .split {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 12px;
+      }
+      @media (max-width: 640px) {
+        .split {
+          grid-template-columns: 1fr;
+        }
+      }
+      kbd {
+        font-family: var(--mono);
+        font-size: 11px;
+        background: var(--tile);
+        border: 1px solid var(--line);
+        border-bottom-width: 2px;
+        border-radius: 5px;
+        padding: 1px 6px;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="wrap">
+      <!-- 1 · title -->
+      <section class="slide on">
+        <div class="eyebrow">Trotxi engineering · session for the app team</div>
+        <h1>Authentication: how the app signs in and stays signed in</h1>
+        <p class="lead">
+          Google sign-in, our two tokens, refresh rotation, roles, sessions — and the traps we have
+          already hit so you never hit them again.
+        </p>
+        <div class="card good" style="margin-top: 22px">
+          <b>What you'll leave with:</b>
+          <div class="d" style="font-size: 13.5px; color: var(--muted); margin-top: 4px">
+            1 &nbsp;Which token goes where (the #1 source of confusion)<br />
+            2 &nbsp;The exact interceptor logic the app needs<br />
+            3 &nbsp;A live playground against the running API
+          </div>
+        </div>
+        <p class="hint" style="margin-top: 26px">
+          Navigate with <kbd>→</kbd> and <kbd>←</kbd>, or the dots below.
+        </p>
+      </section>
+
+      <!-- 2 · three tokens -->
+      <section class="slide">
+        <div class="eyebrow">1 · The mental model</div>
+        <h2>There are three tokens. They are not interchangeable.</h2>
+        <table>
+          <tr>
+            <th></th>
+            <th><span class="pill pb">Google idToken</span></th>
+            <th><span class="pill pg">accessToken</span></th>
+            <th><span class="pill pa">refreshToken</span></th>
+          </tr>
+          <tr>
+            <td><b>Issued by</b></td>
+            <td>Google (on the phone)</td>
+            <td>Trotxi API</td>
+            <td>Trotxi API</td>
+          </tr>
+          <tr>
+            <td><b>Lifetime</b></td>
+            <td>~1 hour</td>
+            <td><b>15 minutes</b></td>
+            <td>30 days (rotates)</td>
+          </tr>
+          <tr>
+            <td><b>Used for</b></td>
+            <td>The <b>body</b> of <code>POST /auth/google</code> — once</td>
+            <td><code>Authorization: Bearer …</code> on every API call</td>
+            <td>Only <code>POST /auth/refresh</code> and <code>POST /auth/logout</code></td>
+          </tr>
+          <tr>
+            <td><b>Never</b></td>
+            <td>sent as a Bearer header</td>
+            <td>stored anywhere but secure storage</td>
+            <td>sent to any other endpoint</td>
+          </tr>
+        </table>
+        <div class="card danger">
+          <b>Common confusion / mistake:</b> pasting the Google idToken (or a masked copy) where the
+          accessToken belongs. The API rejects it by design — audience separation means a Google
+          token can never act as an API token.
+        </div>
+      </section>
+
+      <!-- 3 · sign-in flow -->
+      <section class="slide">
+        <div class="eyebrow">2 · Sign-in, end to end</div>
+        <h2>One round trip turns a Google identity into a Trotxi account</h2>
+        <div class="flow">
+          <div class="step">
+            <span class="n">1</span>
+            <div>
+              <b>App: Google Sign-In SDK</b>
+              <div class="d">
+                User picks their account. SDK returns an <b>idToken</b> whose audience is our
+                <b>Web client ID</b> (the <code>serverClientId</code> you configure).
+              </div>
+            </div>
+          </div>
+          <div class="step">
+            <span class="n">2</span>
+            <div>
+              <b>App → <code>POST /auth/google</code></b>
+              <div class="d">
+                Body: <code>{ "idToken": "…" }</code>. No auth header needed — this call is how you
+                get one.
+              </div>
+            </div>
+          </div>
+          <div class="step">
+            <span class="n">3</span>
+            <div>
+              <b>API verifies cryptographically</b>
+              <div class="d">
+                Signature against Google's public keys, issuer = accounts.google.com, audience = our
+                client ID. Nothing hand-made can pass — the 401 you saw on staging was this working.
+              </div>
+            </div>
+          </div>
+          <div class="step">
+            <span class="n">4</span>
+            <div>
+              <b>API upserts the user</b>
+              <div class="d">
+                First sign-in creates the account (role <b>commuter</b>). Same Google account later
+                → same user.
+              </div>
+            </div>
+          </div>
+          <div class="step">
+            <span class="n">5</span>
+            <div>
+              <b>API returns <code>{ accessToken, refreshToken, user }</code></b>
+              <div class="d">
+                App saves both to <b>flutter_secure_storage</b> and navigates to Home. Done.
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="card warn">
+          <b>Environment note:</b> locally (no <code>GOOGLE_CLIENT_ID</code>) the API runs a
+          <b>dev verifier</b> that accepts JSON claims as the idToken — that's what the playground
+          here uses. Staging runs the real Google verifier.
+        </div>
+      </section>
+
+      <!-- 4 · inside the JWT -->
+      <section class="slide">
+        <div class="eyebrow">3 · Inside the access token</div>
+        <h2>It's a signed, stateless JWT — the API trusts what's inside it</h2>
+        <pre class="jwt" id="jwtpretty">{
+  <span class="p">"role"</span>: "commuter",      ← RBAC: what you may call
+  <span class="p">"sub"</span>:  "&lt;user id&gt;",     ← who you are
+  <span class="p">"iss"</span>:  "trotxi",         ← minted by us
+  <span class="p">"aud"</span>:  "trotxi-api",     ← for this API only
+  <span class="p">"exp"</span>:  now + 15 min      ← then it's a 401
+}</pre>
+        <div class="split">
+          <div class="card">
+            <b>Stateless means fast…</b>
+            <div class="d" style="color: var(--muted); font-size: 13px">
+              No DB lookup per request. The signature is the proof.
+            </div>
+          </div>
+          <div class="card">
+            <b>…and means role changes wait for refresh</b>
+            <div class="d" style="color: var(--muted); font-size: 13px">
+              Promote a user to driver and their <i>old</i> access token still says commuter for up
+              to 15 min. You watched this live: the manifest 403'd until we refreshed. Not a bug —
+              the design.
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- 5 · refresh -->
+      <section class="slide">
+        <div class="eyebrow">4 · Staying signed in</div>
+        <h2>Refresh rotation — and the trap that signs out every device</h2>
+        <div class="flow">
+          <div class="step">
+            <span class="n">1</span>
+            <div>
+              <b>Access token expires (15 min)</b>
+              <div class="d">Any API call returns <b>401</b>.</div>
+            </div>
+          </div>
+          <div class="step">
+            <span class="n">2</span>
+            <div>
+              <b>App: <code>POST /auth/refresh</code></b>
+              <div class="d">
+                Body: the refreshToken. Response: a <b>new accessToken and a new refreshToken</b>.
+              </div>
+            </div>
+          </div>
+          <div class="step">
+            <span class="n">3</span>
+            <div>
+              <b>The old refresh token is now dead</b>
+              <div class="d">
+                Rotation = the presented token is revoked, a new one issued. Always overwrite what
+                you stored.
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="card danger">
+          <b>Replay detection — read this twice:</b>
+          <div class="d" style="font-size: 13px; color: var(--muted); margin-top: 4px">
+            If an <i>already-rotated</i> refresh token is presented again, the API treats it as
+            theft and <b>revokes every session for that user</b>. So: never retry a refresh with the
+            same token, and if two requests 401 at once, make sure only <b>one</b> refresh runs —
+            queue the rest behind it. A naive interceptor that fires two parallel refreshes will
+            sign the rider out of everything.
+          </div>
+        </div>
+      </section>
+
+      <!-- 6 · sessions -->
+      <section class="slide">
+        <div class="eyebrow">5 · Sessions & sign-out</div>
+        <h2>Each device is a session the rider can see and kill</h2>
+        <table>
+          <tr>
+            <th>Endpoint</th>
+            <th>What it does</th>
+          </tr>
+          <tr>
+            <td><code>GET /me/sessions</code></td>
+            <td>Lists this user's active sessions (one per signed-in device).</td>
+          </tr>
+          <tr>
+            <td><code>DELETE /me/sessions/:id</code></td>
+            <td>Revokes one — that device's refresh token stops working.</td>
+          </tr>
+          <tr>
+            <td><code>POST /auth/logout</code></td>
+            <td>Revokes the presented refreshToken. App also clears secure storage.</td>
+          </tr>
+        </table>
+        <div class="card good">
+          <b>App rule:</b> on logout do both — call the endpoint (server-side revoke) <i>and</i>
+          <code>TokenStorage.clearTokens()</code>. On refresh failure (401), clear storage and route
+          to the sign-in screen; don't loop.
+        </div>
+      </section>
+
+      <!-- 7 · errors -->
+      <section class="slide">
+        <div class="eyebrow">6 · Reading the errors</div>
+        <h2>401 vs 403 — and the traps we've already paid for</h2>
+        <table>
+          <tr>
+            <th>You see</th>
+            <th>It means</th>
+            <th>App should</th>
+          </tr>
+          <tr>
+            <td><span class="pill pr">401</span> on any endpoint</td>
+            <td>No / expired / invalid access token</td>
+            <td>Refresh once, retry once. Still 401 → sign-in screen.</td>
+          </tr>
+          <tr>
+            <td><span class="pill pr">401</span> on <code>/auth/refresh</code></td>
+            <td>Refresh token expired, rotated, or revoked</td>
+            <td>Clear storage → sign-in screen. Never retry.</td>
+          </tr>
+          <tr>
+            <td><span class="pill pa">403</span></td>
+            <td>Valid token, wrong <b>role</b></td>
+            <td>Don't show the feature. Refreshing won't help unless the role just changed.</td>
+          </tr>
+          <tr>
+            <td><span class="pill pr">404</span> on auth paths</td>
+            <td>Probably a URL bug</td>
+            <td>Check the base URL — a trailing slash gave us <code>//auth/google</code>.</td>
+          </tr>
+        </table>
+      </section>
+
+      <!-- 8 · checklist -->
+      <section class="slide">
+        <div class="eyebrow">7 · The app integration contract</div>
+        <h2>What the Dio interceptor must do</h2>
+        <div class="flow">
+          <div class="step">
+            <span class="n">✓</span>
+            <div>
+              <b>Attach</b> <code>Authorization: Bearer &lt;accessToken&gt;</code> to every request
+              except <code>/auth/*</code>.
+            </div>
+          </div>
+          <div class="step">
+            <span class="n">✓</span>
+            <div>
+              <b>On 401:</b> run <i>one</i> refresh (mutex/queue!), overwrite both stored tokens,
+              retry the original request once.
+            </div>
+          </div>
+          <div class="step">
+            <span class="n">✓</span>
+            <div>
+              <b>On refresh 401:</b> clear secure storage, go to sign-in. No loops, no replays.
+            </div>
+          </div>
+          <div class="step">
+            <span class="n">✓</span>
+            <div>
+              <b>Store</b> both tokens only in <code>flutter_secure_storage</code> — never
+              SharedPreferences, never logs.
+            </div>
+          </div>
+          <div class="step">
+            <span class="n">✓</span>
+            <div>
+              <b>Never log tokens</b> — <code>debugPrint(idToken)</code> is in the current branch;
+              remove it before release.
+            </div>
+          </div>
+        </div>
+        <p class="hint">
+          The generated client (<code>trotxi_client</code>) already exposes <code>AuthApi</code>;
+          the interceptor is the only custom piece.
+        </p>
+      </section>
+
+      <!-- 9 · live -->
+      <section class="slide">
+        <div class="eyebrow">8 · Live playground</div>
+        <h2>The real API, right now <span class="hint" id="apistate"></span></h2>
+        <div class="lab">
+          <div class="btns">
+            <button class="b primary" onclick="lab.signin()">1 · Sign in (dev verifier)</button>
+            <button class="b" onclick="lab.decode()">2 · Decode my access token</button>
+            <button class="b" onclick="lab.me()">3 · GET /me</button>
+            <button class="b" onclick="lab.badtoken()">4 · Call with a garbage token → 401</button>
+            <button class="b" onclick="lab.refresh()">5 · Refresh (rotate)</button>
+            <button class="b" onclick="lab.replay()">6 · Replay the OLD refresh token</button>
+            <button class="b" onclick="lab.sessions()">7 · GET /me/sessions</button>
+            <button class="b" onclick="lab.logout()">8 · Logout</button>
+            <div class="tok" id="tokview">no tokens yet</div>
+          </div>
+          <div class="out" id="out">
+            Press 1 to sign in against http://localhost:3000 (dev server, fake Google verifier).
+            Suggested arc for the session: 1 → 2 → 3 sign in, look inside the token, use it 4 see a
+            clean 401 5 rotation: both tokens replaced 6 replay detection: the old token is dead
+            (and why parallel refreshes are dangerous) 7 → 8 sessions, then sign out
+          </div>
+        </div>
+      </section>
+    </div>
+
+    <div class="nav">
+      <div class="in">
+        <div class="dots" id="dots"></div>
+        <button class="b" id="prev">← Back</button>
+        <button class="b primary" id="next">Next →</button>
+      </div>
+    </div>
+
+    <script>
+      const API = 'http://localhost:3000';
+      const slides = [...document.querySelectorAll('.slide')];
+      const dots = document.getElementById('dots');
+      let i = 0;
+      slides.forEach((_, k) => {
+        const d = document.createElement('button');
+        d.className = 'dot' + (k ? '' : ' on');
+        d.onclick = () => go(k);
+        dots.appendChild(d);
+      });
+      function go(k) {
+        i = Math.max(0, Math.min(slides.length - 1, k));
+        slides.forEach((s, x) => s.classList.toggle('on', x === i));
+        [...dots.children].forEach((d, x) => d.classList.toggle('on', x === i));
+      }
+      document.getElementById('next').onclick = () => go(i + 1);
+      document.getElementById('prev').onclick = () => go(i - 1);
+      document.addEventListener('keydown', (e) => {
+        if (e.key === 'ArrowRight') go(i + 1);
+        if (e.key === 'ArrowLeft') go(i - 1);
+      });
+
+      const out = document.getElementById('out');
+      const tokview = document.getElementById('tokview');
+      let access = null,
+        refresh = null,
+        oldRefresh = null;
+      function show(title, req, status, body) {
+        out.textContent = `▶ ${title}\n${req}\n\nHTTP ${status}\n${typeof body === 'string' ? body : JSON.stringify(body, null, 2)}`;
+        tokview.textContent = access
+          ? `access: ${access.slice(0, 24)}…  ·  refresh: ${refresh ? refresh.slice(0, 12) + '…' : '—'}`
+          : 'no tokens yet';
+      }
+      async function call(method, path, { body, bearer } = {}) {
+        const headers = {};
+        if (body) headers['content-type'] = 'application/json';
+        if (bearer) headers['authorization'] = `Bearer ${bearer}`;
+        const r = await fetch(API + path, {
+          method,
+          headers,
+          body: body ? JSON.stringify(body) : undefined,
+        });
+        let j;
+        try {
+          j = await r.json();
+        } catch {
+          j = '(no body)';
+        }
+        return { status: r.status, body: j };
+      }
+      window.lab = {
+        async signin() {
+          const idToken = JSON.stringify({
+            sub: 'g-kojo',
+            name: 'Kojo Fosu',
+            email: 'kojo@trotxi.test',
+          });
+          const r = await call('POST', '/auth/google', { body: { idToken } });
+          if (r.status === 200) {
+            access = r.body.accessToken;
+            refresh = r.body.refreshToken;
+          }
+          show(
+            'POST /auth/google — the ONLY place the idToken goes',
+            `body: { idToken: ${idToken} }`,
+            r.status,
+            r.body,
+          );
+        },
+        decode() {
+          if (!access) return show('decode', 'sign in first (button 1)', 0, '—');
+          const [h, p] = access.split('.');
+          const dec = (s) => JSON.parse(atob(s.replace(/-/g, '+').replace(/_/g, '/')));
+          const payload = dec(p);
+          const mins = Math.round((payload.exp * 1000 - Date.now()) / 60000);
+          show(
+            'Decoded access token (header + payload — the signature is the part you cannot fake)',
+            'no network call: any JWT is readable, only the signature is trusted',
+            200,
+            { header: dec(h), payload, note: `expires in ~${mins} min` },
+          );
+        },
+        async me() {
+          const r = await call('GET', '/me', { bearer: access });
+          show(
+            'GET /me with Bearer accessToken',
+            `authorization: Bearer ${access ? access.slice(0, 20) + '…' : '(none)'}`,
+            r.status,
+            r.body,
+          );
+        },
+        async badtoken() {
+          const r = await call('GET', '/me', { bearer: 'this-is-not-a-jwt' });
+          show(
+            'GET /me with a garbage token — a clean 401, the interceptor case',
+            'authorization: Bearer this-is-not-a-jwt',
+            r.status,
+            r.body,
+          );
+        },
+        async refresh() {
+          if (!refresh) return show('refresh', 'sign in first (button 1)', 0, '—');
+          oldRefresh = refresh;
+          const r = await call('POST', '/auth/refresh', { body: { refreshToken: refresh } });
+          if (r.status === 200) {
+            access = r.body.accessToken;
+            refresh = r.body.refreshToken;
+          }
+          show(
+            'POST /auth/refresh — rotation: BOTH tokens replaced, the old refresh token is now dead',
+            'body: { refreshToken: (stored one) }',
+            r.status,
+            r.body,
+          );
+        },
+        async replay() {
+          if (!oldRefresh)
+            return show(
+              'replay',
+              'refresh first (button 5) so there is an old token to replay',
+              0,
+              '—',
+            );
+          const r = await call('POST', '/auth/refresh', { body: { refreshToken: oldRefresh } });
+          show(
+            'Replaying the CONSUMED refresh token — treated as theft; sessions for this user are revoked. This is why the app must never fire two refreshes in parallel.',
+            'body: { refreshToken: (old, already-rotated) }',
+            r.status,
+            r.body,
+          );
+        },
+        async sessions() {
+          const r = await call('GET', '/me/sessions', { bearer: access });
+          show(
+            'GET /me/sessions — one entry per signed-in device',
+            `authorization: Bearer …`,
+            r.status,
+            r.body,
+          );
+        },
+        async logout() {
+          const r = await call('POST', '/auth/logout', { body: { refreshToken: refresh } });
+          if (r.status < 300) {
+            access = null;
+            refresh = null;
+            oldRefresh = null;
+          }
+          show(
+            'POST /auth/logout — server revoke; the app also clears secure storage',
+            'body: { refreshToken: (stored one) }',
+            r.status,
+            r.body,
+          );
+        },
+      };
+      fetch(API + '/healthz')
+        .then((r) => {
+          document.getElementById('apistate').textContent = r.ok
+            ? '· connected to localhost:3000 ✓'
+            : '';
+        })
+        .catch(() => {
+          document.getElementById('apistate').textContent =
+            '· ⚠ dev server not running — pnpm --filter @trotxi/api dev';
+        });
+    </script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:e2e": "pnpm --filter @trotxi/e2e test",
     "test:e2e:ui": "pnpm --filter @trotxi/e2e run test:ui",
     "coverage": "pnpm --filter @trotxi/api run test:coverage",
+    "demo:auth": "python3 -m http.server 4174 --directory demo",
     "check": "pnpm run format:check && pnpm run typecheck && pnpm run lint && pnpm test",
     "api": "pnpm --filter @trotxi/api dev",
     "migrate": "pnpm --filter @trotxi/api run migrate",


### PR DESCRIPTION
An interactive teaching deck for the session with the app team on how authentication works — written from the **consumer's side**, i.e. exactly what the Flutter apps need to implement.

## What's in it

Nine slides + a live playground (`demo/auth-explainer.html`):

1. The **three-token model** — Google idToken vs accessToken vs refreshToken, and where each one goes (the #1 source of confusion)
2. The sign-in flow end to end, including why hand-made tokens 401 on staging (real signature verification) while the dev verifier accepts JSON claims locally
3. Inside the JWT — statelessness, and why role changes only land on refresh
4. **Refresh rotation + replay detection** — presenting an already-rotated token revokes every session, which is why the app's interceptor must serialise refreshes behind a mutex
5. Sessions (`/me/sessions`, revoke, logout) and the storage rules
6. The 401 vs 403 error contract the Dio interceptor should implement
7. A **live playground** driving the real dev API: sign in → decode → call → force a 401 → rotate → replay the dead token → sessions → logout

## Run it

```bash
pnpm --filter @trotxi/api dev   # API on :3000
pnpm demo:auth                  # deck on :4174 (new root script)
# → http://localhost:4174/auth-explainer.html
```

Works with zero Google configuration — the playground uses the dev verifier. CORS on the API (already on main) is what lets the page call `:3000` cross-origin.

## Verified

Full playground arc exercised against the running dev server: sign-in 200, `/me` 200, refresh 200 (both tokens rotate), **replay of the consumed refresh token → 401**, sessions list, logout. Also includes a `demo/README.md` documenting both demo assets.

Nothing here ships to production — the Dockerfile only packages `services/api/dist`.