### PR TITLE
feat(cron): schedule the no-show sweep (E4)

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -147,6 +147,37 @@ services:
     dockerCommand: node dist/cron/ask-dispatch-cron.js resolve evening
     envVars:
       - fromGroup: trotxi-cron-staging
+  # No-show sweeps (E4). These run AFTER the run has departed and debit riders
+  # who confirmed a seat but never boarded — the seat was held for them, so it
+  # costs a ride. They target the day that just happened, not tomorrow.
+  - type: cron
+    name: trotxi-noshow-morning-staging
+    runtime: docker
+    repo: https://github.com/TROTXI/mobility-core
+    branch: main
+    dockerfilePath: services/api/Dockerfile
+    dockerContext: .
+    plan: free
+    region: frankfurt
+    autoDeploy: false
+    schedule: '0 10 * * *' # 10:00 — after the 06:30 morning run has finished
+    dockerCommand: node dist/cron/ask-dispatch-cron.js noshow morning
+    envVars:
+      - fromGroup: trotxi-cron-staging
+  - type: cron
+    name: trotxi-noshow-evening-staging
+    runtime: docker
+    repo: https://github.com/TROTXI/mobility-core
+    branch: main
+    dockerfilePath: services/api/Dockerfile
+    dockerContext: .
+    plan: free
+    region: frankfurt
+    autoDeploy: false
+    schedule: '0 20 * * *' # 20:00 — after the evening run, still the same UTC day
+    dockerCommand: node dist/cron/ask-dispatch-cron.js noshow evening
+    envVars:
+      - fromGroup: trotxi-cron-staging
 
   # ---- Production (uncomment when going live) ----
   # Needs a paid Postgres plan so data doesn't expire. After applying, set the

--- a/services/api/src/cron/ask-dispatch-cron.ts
+++ b/services/api/src/cron/ask-dispatch-cron.ts
@@ -1,41 +1,55 @@
-// Ask-dispatch cron entrypoint (E3). A Render cron job runs this at each
-// confirmation window: it mints a short-lived admin token from JWT_SECRET (auth
-// is stateless — no user row needed) and POSTs the deployed API's admin trigger.
-// Two actions x two directions (schedules live in render.yaml):
-//   ask morning  (18:00) -> prompt tomorrow-morning riders   cutoff resolve 21:00
-//   ask evening  (12:00) -> prompt this-evening riders        cutoff resolve 14:00
+// Daily-loop cron entrypoint (E3/E4). A Render cron job runs this at each point
+// in the day: it mints a short-lived admin token from JWT_SECRET (auth is
+// stateless — no user row needed) and POSTs the deployed API's admin trigger.
+// Three actions x two directions (schedules live in render.yaml):
+//   ask     morning (18:00) -> prompt tomorrow-morning riders  cutoff resolve 21:00
+//   ask     evening (12:00) -> prompt this-evening riders      cutoff resolve 14:00
+//   noshow  morning (10:00) -> debit confirmed-but-absent seats after the run
+//   noshow  evening (20:00) -> same, after the evening run
 // Ghana runs on UTC (GMT+0), so the cron schedules are plain UTC, no offset.
+//
+// Deliberately NOT scheduled: /admin/convert-credits. Its conversion is keyed by
+// subscription id rather than by billing period, so it can only ever run once per
+// subscription and would zero a rider who subscribed days earlier. It stays a
+// manual admin action until E5b makes it period-aware (#128).
 
 import { createJwtService, type AuthConfig } from '../modules/auth/jwt';
 
-type Action = 'ask' | 'resolve';
+type Action = 'ask' | 'resolve' | 'noshow';
 type Direction = 'morning' | 'evening';
 
 const PATH_FOR: Record<Action, string> = {
   ask: '/admin/ask-dispatch',
   resolve: '/admin/resolve-defaults',
+  noshow: '/admin/resolve-no-shows',
 };
 
-// Morning is asked (and defaulted) the evening BEFORE, for tomorrow; evening is
-// asked midday, for today. So the target travel day is tomorrow for morning and
-// today for evening — the trip's own scheduled time still decides its direction.
-function travelDateFor(direction: Direction, now: Date): string {
+// Which travel day an action targets.
+//
+// ask/resolve run BEFORE travel: morning is asked (and defaulted) the evening
+// before, for tomorrow; evening is asked midday, for today.
+//
+// noshow runs AFTER the run has departed, so it always sweeps the day that just
+// happened — today for both directions. Getting this wrong would sweep a day
+// whose trips have not run yet and debit riders who are not late, they are early.
+// (The trip's own scheduled time still decides its direction.)
+function travelDateFor(action: Action, direction: Direction, now: Date): string {
   const d = new Date(now);
-  if (direction === 'morning') d.setUTCDate(d.getUTCDate() + 1);
+  if (action !== 'noshow' && direction === 'morning') d.setUTCDate(d.getUTCDate() + 1);
   return d.toISOString().slice(0, 10);
 }
 
+const ACTIONS: readonly Action[] = ['ask', 'resolve', 'noshow'];
+const DIRECTIONS: readonly Direction[] = ['morning', 'evening'];
+
 function parseArgs(argv: readonly string[]): { action: Action; direction: Direction } {
   const [action, direction] = argv;
-  if (
-    (action !== 'ask' && action !== 'resolve') ||
-    (direction !== 'morning' && direction !== 'evening')
-  ) {
+  if (!ACTIONS.includes(action as Action) || !DIRECTIONS.includes(direction as Direction)) {
     throw new Error(
-      `usage: ask-dispatch-cron <ask|resolve> <morning|evening> (got: "${argv.join(' ')}")`,
+      `usage: ask-dispatch-cron <${ACTIONS.join('|')}> <${DIRECTIONS.join('|')}> (got: "${argv.join(' ')}")`,
     );
   }
-  return { action, direction };
+  return { action: action as Action, direction: direction as Direction };
 }
 
 async function main(): Promise<void> {
@@ -53,11 +67,11 @@ async function main(): Promise<void> {
     audience: process.env.JWT_AUDIENCE ?? 'trotxi-api',
   };
   const token = await createJwtService(auth).signAccessToken({
-    userId: 'cron-ask-dispatch',
+    userId: 'cron-daily-loop',
     role: 'admin',
   });
 
-  const travelDate = travelDateFor(direction, new Date());
+  const travelDate = travelDateFor(action, direction, new Date());
   const url = `${baseUrl.replace(/\/$/, '')}${PATH_FOR[action]}`;
   const res = await fetch(url, {
     method: 'POST',


### PR DESCRIPTION
`/admin/resolve-no-shows` shipped with E4 but was **never scheduled**. A rider who confirmed a seat and then didn't board was never debited — which is the entire point of honouring a held seat. This adds the missing half of the daily loop.

## The subtle part: no-show sweeps target a different day

The existing actions run **before** travel; a no-show sweep runs **after** the run has departed:

| Action | Direction | Target day |
|---|---|---|
| ask / resolve | morning | **tomorrow** (asked the evening before) |
| ask / resolve | evening | today (asked midday) |
| **noshow** | morning | **today** — the run that already departed |
| **noshow** | evening | today |

Sweeping *tomorrow* for a morning no-show would debit riders whose trip hasn't run yet. `travelDateFor` now takes the action into account, and the reasoning is written down so it can't be "simplified" away later.

## Schedules

- `0 10 * * *` — after the 06:30 morning run
- `0 20 * * *` — after the evening run, still inside the same UTC day (Ghana is UTC)

## Deliberately NOT scheduled: `/admin/convert-credits`

Worth a look, because I nearly automated it. `CreditService.convertAllActive()` keys idempotency on **subscription id**, not billing period:

```ts
const key = `convert:${periodRef}`;   // periodRef = sub.id
```

So a monthly cron would be wrong twice over:
1. It converts **every** active subscriber regardless of their period — someone who subscribed on the 28th would have their rides zeroed on the 1st.
2. It can only ever fire **once per subscription** — month 2 would silently no-op.

It stays a manual admin action until E5b (#128) makes it period-aware. Recorded in the cron script header so the next person doesn't repeat the thought.

## Verification

All six action × direction combinations run end to end against a live server:

```
ask     morning 2026-08-10 -> 200 {"trips":0,"asked":0}
ask     evening 2026-08-09 -> 200 {"trips":0,"asked":0}
resolve morning 2026-08-10 -> 200 {"defaulted":0}
resolve evening 2026-08-09 -> 200 {"defaulted":0}
noshow  morning 2026-08-09 -> 200 {"noShows":0}
noshow  evening 2026-08-09 -> 200 {"noShows":0}
```

325 tests, typecheck, lint, build all clean.

## Still needed to activate (ops, #126)

These cron services don't run until the blueprint is applied and `JWT_SECRET` is set on the `trotxi-cron-staging` env group to match the web service.