### PR TITLE
feat: contactability, account deletion, route geometry, ETA speeds, trip FKs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,10 @@ jobs:
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile
+      # Ordering guard (#184): migrate.ts sorts on the full filename, so two
+      # migrations sharing a number run in alphabetical order of their
+      # description. Catch that before it silently decides a dependency.
+      - run: services/api/scripts/check-migration-prefixes.sh
       - run: pnpm --filter @trotxi/api run migrate
       # Idempotency: a second run must be a clean no-op.
       - run: pnpm --filter @trotxi/api run migrate

--- a/services/api/scripts/check-migration-prefixes.sh
+++ b/services/api/scripts/check-migration-prefixes.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Fail when two migrations share a numeric prefix (#184).
+#
+# migrate.ts applies files in `.sort()` order — the FULL filename, not the
+# number. Two files numbered 016 therefore run in alphabetical order of their
+# description, which nobody writing them is thinking about. Today that is
+# harmless; the first pair that actually depends on each other will work on the
+# author's machine and fail somewhere else for reasons nobody can see.
+#
+# NOTE: the fix for a duplicate is never to rename an APPLIED migration.
+# _migrations is keyed by filename, so a rename makes the runner treat it as new
+# and re-apply it against every environment. Pick the next free number instead.
+
+set -euo pipefail
+
+MIGRATIONS_DIR="$(dirname "$0")/../src/db/migrations"
+
+# Grandfathered: 016_reservation_pin.sql and 016_trip_positions.sql are already
+# applied everywhere. They touch unrelated tables and sort deterministically
+# (reservation_pin before trip_positions), so the ordering is correct. Renaming
+# them would re-run them. Decision recorded in #184 — not an oversight.
+GRANDFATHERED="016"
+
+duplicates="$(
+  find "$MIGRATIONS_DIR" -name '*.sql' -exec basename {} \; \
+    | cut -d_ -f1 \
+    | sort \
+    | uniq -d \
+    | grep -vxF "$GRANDFATHERED" || true
+)"
+
+if [ -n "$duplicates" ]; then
+  echo "::error::duplicate migration prefixes: $(echo "$duplicates" | tr '\n' ' ')"
+  echo ""
+  echo "Two migrations share a numeric prefix. Renumber the NEW one to the next"
+  echo "free number — never rename a migration that has already been applied,"
+  echo "because _migrations is keyed by filename and a rename re-runs it."
+  echo ""
+  for prefix in $duplicates; do
+    echo "  $prefix:"
+    find "$MIGRATIONS_DIR" -name "${prefix}_*.sql" -exec basename {} \; | sed 's/^/    /'
+  done
+  exit 1
+fi
+
+echo "migration prefixes are unique (grandfathered: $GRANDFATHERED)"

--- a/services/api/src/app.ts
+++ b/services/api/src/app.ts
@@ -11,6 +11,7 @@ import {
 import { z } from 'zod';
 import { InMemoryKvStore, type KvStore } from './kv/kv.store';
 import { FakeObjectStore, type ObjectStore } from './storage/object-store';
+import type { AccountDeletionService } from './modules/users/account-deletion.service';
 import { userRoutes } from './modules/users/users.routes';
 import {
   InMemoryDeviceTokenRepository,
@@ -88,6 +89,8 @@ export interface AppDeps {
   isReady?: () => Promise<boolean>;
   /** Selected by DATABASE_URL (in-memory vs Postgres). Consumed by routes/services. */
   users?: UserRepository;
+  /** Account erasure (#30). Omitted -> DELETE /me returns 503. */
+  accountDeletion?: AccountDeletionService;
   /** Selected by DATABASE_URL (in-memory vs Postgres). Consumed by routes/services. */
   subscriptions?: SubscriptionRepository;
   /** Selected by DATABASE_URL (in-memory vs Postgres). Mobility domain. */
@@ -253,6 +256,7 @@ export async function buildApp(deps: AppDeps = {}): Promise<FastifyInstance> {
     users,
     objectStore,
     rateLimit: deps.rateLimit ?? DEFAULT_RATE_LIMIT,
+    accountDeletion: deps.accountDeletion,
   });
   await app.register(deviceRoutes, {
     deviceTokens: deps.deviceTokens ?? new InMemoryDeviceTokenRepository(),

--- a/services/api/src/db/migrations/022_user_contactability.sql
+++ b/services/api/src/db/migrations/022_user_contactability.sql
@@ -1,0 +1,25 @@
+-- 022_user_contactability: give users an email and make the phone column usable.
+--
+-- Both were being discarded (#182). The Google/Apple ID token carries a verified
+-- email that findOrCreateUser dropped on the floor, and the phone number that
+-- Paystack collects for every mobile-money charge never reached us. After signup
+-- we knew a display name and nothing we could contact.
+--
+-- email is deliberately NOT unique: one person can hold a Google identity and an
+-- Apple identity on the same address, and provider identity (auth_identity) is
+-- the account key, not the mailbox. A unique constraint here would reject the
+-- second provider at sign-in.
+--
+-- phone already exists from 001_init with a UNIQUE constraint; nothing is
+-- changed about it here beyond documenting that values are stored E.164
+-- normalised (+233…) so the same handset cannot land three ways.
+
+ALTER TABLE users ADD COLUMN IF NOT EXISTS email text;
+
+COMMENT ON COLUMN users.email IS
+  'Verified email from the social identity provider. Not unique: one person may hold google + apple identities on one address.';
+COMMENT ON COLUMN users.phone IS
+  'E.164 normalised (+233...). Captured from the Paystack charge.success webhook; a successful mobile-money charge proves control of the handset.';
+
+-- Case-insensitive lookup without forcing the citext extension on every env.
+CREATE INDEX IF NOT EXISTS idx_users_email_lower ON users (lower(email)) WHERE email IS NOT NULL;

--- a/services/api/src/db/migrations/023_trip_fks.sql
+++ b/services/api/src/db/migrations/023_trip_fks.sql
@@ -1,0 +1,66 @@
+-- 023_trip_fks: give reservations.trip_id and scan_events.trip_id the foreign
+-- key they were always meant to have (#183).
+--
+-- Both columns carry a comment explaining the omission: "no FK yet (trips are
+-- #18)". Trips arrived in 015_mobility_trips.sql; the columns never caught up,
+-- leaving the only two holes in an otherwise complete reference graph.
+--
+-- This matters more than it looks. reservations drives the no-show sweep, which
+-- DEBITS RIDES. A reservation pointing at a trip that no longer exists is a
+-- rider who could be charged for a run that never happened.
+--
+-- ON DELETE SET NULL, deliberately not CASCADE: a reservation is the rider's
+-- record and entitlement_ledger entries reference it, so deleting a trip must
+-- never erase the history that money decisions were made against. scan_events
+-- already uses SET NULL for rider_id and scanned_by, so this keeps that table
+-- internally consistent too.
+--
+-- Trips are not normally deleted at all (cancellation is a status, and
+-- reservations has operator_cancelled for the rider side). SET NULL is the
+-- safety net for the case that should not happen, not the intended path.
+
+-- Staging carries pilot data from trips created and dropped during testing.
+-- ALTER TABLE ... ADD CONSTRAINT fails outright against orphaned rows, so clear
+-- them first — and report the counts rather than nulling in silence, because a
+-- large number here says something about the data we would want to know before
+-- it disappears.
+DO $$
+DECLARE
+  orphaned_reservations integer;
+  orphaned_scans        integer;
+BEGIN
+  UPDATE reservations SET trip_id = NULL
+   WHERE trip_id IS NOT NULL
+     AND NOT EXISTS (SELECT 1 FROM trips t WHERE t.id = reservations.trip_id);
+  GET DIAGNOSTICS orphaned_reservations = ROW_COUNT;
+
+  UPDATE scan_events SET trip_id = NULL
+   WHERE trip_id IS NOT NULL
+     AND NOT EXISTS (SELECT 1 FROM trips t WHERE t.id = scan_events.trip_id);
+  GET DIAGNOSTICS orphaned_scans = ROW_COUNT;
+
+  RAISE NOTICE '023_trip_fks: nulled % orphaned reservations.trip_id, % orphaned scan_events.trip_id',
+    orphaned_reservations, orphaned_scans;
+END $$;
+
+-- Idempotent: the CI migrations job runs every migration twice and the second
+-- pass must be a clean no-op. ADD CONSTRAINT has no IF NOT EXISTS, so guard on
+-- the catalogue.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'fk_reservations_trip'
+  ) THEN
+    ALTER TABLE reservations
+      ADD CONSTRAINT fk_reservations_trip
+      FOREIGN KEY (trip_id) REFERENCES trips (id) ON DELETE SET NULL;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'fk_scan_events_trip'
+  ) THEN
+    ALTER TABLE scan_events
+      ADD CONSTRAINT fk_scan_events_trip
+      FOREIGN KEY (trip_id) REFERENCES trips (id) ON DELETE SET NULL;
+  END IF;
+END $$;

--- a/services/api/src/db/migrations/024_route_geometry.sql
+++ b/services/api/src/db/migrations/024_route_geometry.sql
@@ -1,0 +1,52 @@
+-- 024_route_geometry: give a route a shape (#179).
+--
+-- A route has been an ordered list of stops and nothing between them. eta.ts is
+-- explicit about the consequence in its own header: it treats the stops as the
+-- polyline and assumes a flat ASSUMED_SPEED_KPH = 20. The model believes our
+-- buses travel in straight lines at constant speed.
+--
+-- Three things need the real road-following path: the line on the rider's live
+-- map, "STOP 3 of 11 · Shiashie next" on the driver screen, and honest per-stop
+-- ETAs (straight-line distance under-reads every curve).
+--
+-- The geometry is DERIVED FROM OUR OWN GPS TRACES, not from a routing vendor.
+-- trip_positions is append-only at a fix every 5s, so one completed run is a
+-- dense record of where the bus actually went — including the informal stops and
+-- the shortcut a driver takes that no map database knows about. See
+-- strategy/docs/geospatial.md §4.
+
+ALTER TABLE routes
+  ADD COLUMN IF NOT EXISTS geometry            geography(LineString, 4326),
+  ADD COLUMN IF NOT EXISTS geometry_source     text,
+  ADD COLUMN IF NOT EXISTS geometry_updated_at timestamptz,
+  ADD COLUMN IF NOT EXISTS geometry_run_count  integer NOT NULL DEFAULT 0;
+
+-- Nullable on purpose: a route exists before its first run. Every consumer must
+-- fall back to the stop-to-stop polyline while this is null — the map is
+-- angular and the ETA approximate, but nothing breaks.
+COMMENT ON COLUMN routes.geometry IS
+  'Road-following path derived from completed trips'' GPS traces. NULL until the first run; consumers fall back to the stop polyline.';
+COMMENT ON COLUMN routes.geometry_source IS
+  'traces = raw GPS median, matched = map-matched via Valhalla, manual = drawn by ops. Earns its place the first time someone asks why a route looks wrong.';
+COMMENT ON COLUMN routes.geometry_run_count IS
+  'How many completed runs the geometry was derived from. First run is used immediately; the median of the last five supersedes it.';
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'chk_routes_geometry_source') THEN
+    ALTER TABLE routes
+      ADD CONSTRAINT chk_routes_geometry_source
+      CHECK (geometry_source IS NULL OR geometry_source IN ('traces', 'matched', 'manual'));
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_routes_geometry ON routes USING GIST (geometry);
+
+-- Distance along the route to each stop, so "3 of 11 stops" and per-stop ETA
+-- stop being recomputed from scratch on every request. Filled by the same job
+-- that writes routes.geometry; null while the route has no geometry.
+ALTER TABLE route_stops
+  ADD COLUMN IF NOT EXISTS distance_m double precision;
+
+COMMENT ON COLUMN route_stops.distance_m IS
+  'Metres along routes.geometry to this stop. NULL until the route has geometry.';

--- a/services/api/src/db/migrations/025_segment_speeds.sql
+++ b/services/api/src/db/migrations/025_segment_speeds.sql
@@ -1,0 +1,39 @@
+-- 025_segment_speeds: what our buses actually do, per stretch of road (#181).
+--
+-- eta.ts divides remaining distance by a flat ASSUMED_SPEED_KPH = 20. That is
+-- wrong exactly where it matters most: Tetteh Quarshie at 07:30 is not 20 km/h,
+-- and neither is an empty road at 20:00.
+--
+-- Every completed run leaves a timestamped trace in trip_positions, so the real
+-- answer is already in our own data. This table is the aggregate: how long each
+-- stretch between consecutive stops actually takes, by direction and by time of
+-- day. Recomputing medians per request would be the slowest thing in the ETA
+-- path, so it is materialised here and refreshed by a job.
+--
+-- TWO time bands, not four or twenty-four: the service only runs a morning and
+-- an evening window, so anything finer would be modelling hours we do not
+-- operate.
+--
+-- This is the part a competitor cannot buy. A traffic API models a generic
+-- vehicle on a generic road; this measures our vehicles, on our corridors, at
+-- the exact times we run them.
+
+CREATE TABLE IF NOT EXISTS segment_speeds (
+  id             uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  route_id       uuid NOT NULL REFERENCES routes (id) ON DELETE CASCADE,
+  -- Segment between route_stops.seq = from_seq and from_seq + 1.
+  from_seq       integer NOT NULL,
+  direction      text NOT NULL CHECK (direction IN ('morning', 'evening')),
+  -- Median, not mean: one breakdown should not redefine the corridor.
+  median_speed_ms double precision NOT NULL CHECK (median_speed_ms > 0),
+  -- Sample size, so consumers can refuse to trust a single observation.
+  sample_count   integer NOT NULL CHECK (sample_count > 0),
+  computed_at    timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (route_id, from_seq, direction)
+);
+
+CREATE INDEX IF NOT EXISTS idx_segment_speeds_route
+  ON segment_speeds (route_id, direction);
+
+COMMENT ON TABLE segment_speeds IS
+  'Observed median speed per route segment, direction and service window. Refreshed from completed runs; ETA falls back to the fixed assumed speed where absent.';

--- a/services/api/src/db/migrations/026_account_deletion.sql
+++ b/services/api/src/db/migrations/026_account_deletion.sql
@@ -1,0 +1,24 @@
+-- 026_account_deletion: support erasing a rider without destroying the books (#30).
+--
+-- Required by App Store and Play before either app can ship.
+--
+-- A hard DELETE FROM users is the obvious implementation and the wrong one.
+-- Every money table cascades off users:
+--   payments, entitlement_ledger, credit_ledger  ON DELETE CASCADE
+-- so deleting the row would silently erase the financial record of what someone
+-- paid and what they were charged. Those have to survive a deletion request —
+-- they are our books, not the rider's personal data.
+--
+-- So deletion ANONYMISES: the personal data goes, the row and its id stay, and
+-- the ledgers remain balanced and attributable to an account that can no longer
+-- be linked to a person. The auth_identity rows are removed separately, so a
+-- returning user signs up fresh rather than resurrecting the old account.
+
+ALTER TABLE users ADD COLUMN IF NOT EXISTS deleted_at timestamptz;
+
+COMMENT ON COLUMN users.deleted_at IS
+  'Set when the account is erased on request. PII columns are cleared; the row survives so payments and ledger history stay intact.';
+
+-- Deleted accounts are excluded from every operational query, so keep the
+-- lookup cheap rather than scanning.
+CREATE INDEX IF NOT EXISTS idx_users_active ON users (id) WHERE deleted_at IS NULL;

--- a/services/api/src/kv/kv.store.redis.ts
+++ b/services/api/src/kv/kv.store.redis.ts
@@ -4,6 +4,16 @@
 import { Redis } from 'ioredis';
 import type { KvStore } from './kv.store';
 
+// INCR plus a conditional EXPIRE, evaluated server-side so the pair cannot be
+// torn apart by a dropped connection. Returns the post-increment count.
+const INCREMENT_WITH_TTL = `
+  local count = redis.call('INCR', KEYS[1])
+  if count == 1 then
+    redis.call('EXPIRE', KEYS[1], ARGV[1])
+  end
+  return count
+`;
+
 export class RedisKvStore implements KvStore {
   private readonly redis: Redis;
 
@@ -31,11 +41,16 @@ export class RedisKvStore implements KvStore {
   }
 
   async increment(key: string, ttlSeconds: number): Promise<number> {
-    const count = await this.redis.incr(key);
-    // Set the expiry only on first creation so the window doesn't slide.
-    if (count === 1) {
-      await this.redis.expire(key, ttlSeconds);
-    }
+    // One atomic operation, not INCR-then-EXPIRE (#154). Split across two round
+    // trips, a connection drop between them leaves the key with NO TTL: the
+    // counter climbs forever, `count === 1` never recurs so the expiry is never
+    // set again, and that subject is permanently 429'd until someone deletes the
+    // key by hand. Low probability, but the failure mode is a locked-out rider
+    // with no alert and nothing in the logs to explain it.
+    //
+    // Fixed-window semantics are unchanged: the TTL is still set only when the
+    // counter is new, so the window does not slide on each request.
+    const count = (await this.redis.eval(INCREMENT_WITH_TTL, 1, key, String(ttlSeconds))) as number;
     return count;
   }
 

--- a/services/api/src/lib/phone.ts
+++ b/services/api/src/lib/phone.ts
@@ -1,0 +1,61 @@
+// Ghanaian phone-number normalisation (#182).
+//
+// users.phone is UNIQUE, and Paystack hands the same handset back in at least
+// three shapes depending on how the payer typed it into the checkout page:
+// "0244123456", "233244123456", "+233244123456". Stored raw, one person could
+// occupy three rows — or collide with themselves and fail the write.
+//
+// Everything is normalised to E.164 (+233…) on the way in. Ghana is the only
+// market for the pilot, so a local 0-prefixed number is assumed Ghanaian; a
+// number that already carries some other country code is passed through rather
+// than mangled into +233.
+
+/** Ghana's country calling code. */
+const GH_CODE = '233';
+
+/** Ghanaian subscriber numbers are 9 digits after the country code. */
+const GH_SUBSCRIBER_LEN = 9;
+
+/**
+ * Normalise a phone number to E.164, assuming Ghana for local formats.
+ *
+ * Accepts the shapes Paystack and riders actually produce: `0244123456`,
+ * `244123456`, `233244123456`, `+233 244 123 456`, `(024) 412-3456`.
+ *
+ * @param raw - the number as received, in any format.
+ * @returns the E.164 number (`+233244123456`), or null when it cannot be
+ *   recognised — callers should skip the write rather than store a guess.
+ */
+export function normaliseGhanaPhone(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+
+  // Keep a leading + as the "already international" signal, drop all other
+  // punctuation (spaces, dashes, brackets) that humans and checkout pages add.
+  const trimmed = raw.trim();
+  const hadPlus = trimmed.startsWith('+');
+  const digits = trimmed.replace(/\D/g, '');
+  if (digits.length === 0) return null;
+
+  // Already Ghanaian and fully qualified: 233 + 9 digits.
+  if (digits.startsWith(GH_CODE) && digits.length === GH_CODE.length + GH_SUBSCRIBER_LEN) {
+    return `+${digits}`;
+  }
+
+  // A different country code, explicitly marked with +. Pass it through rather
+  // than forcing +233 onto a number that is plainly not Ghanaian.
+  if (hadPlus) {
+    return digits.length >= 8 && digits.length <= 15 ? `+${digits}` : null;
+  }
+
+  // Local trunk form: 0 + 9 digits.
+  if (digits.startsWith('0') && digits.length === GH_SUBSCRIBER_LEN + 1) {
+    return `+${GH_CODE}${digits.slice(1)}`;
+  }
+
+  // Bare subscriber number, no trunk prefix.
+  if (digits.length === GH_SUBSCRIBER_LEN) {
+    return `+${GH_CODE}${digits}`;
+  }
+
+  return null;
+}

--- a/services/api/src/modules/auth/auth-identity.repository.pg.ts
+++ b/services/api/src/modules/auth/auth-identity.repository.pg.ts
@@ -44,4 +44,8 @@ export class PgAuthIdentityRepository implements AuthIdentityRepository {
     );
     return toAuthIdentity(rows[0]!);
   }
+
+  async deleteForUser(userId: string): Promise<void> {
+    await this.pool.query('DELETE FROM auth_identity WHERE user_id = $1', [userId]);
+  }
 }

--- a/services/api/src/modules/auth/auth-identity.repository.ts
+++ b/services/api/src/modules/auth/auth-identity.repository.ts
@@ -39,6 +39,14 @@ export interface AuthIdentityRepository {
    * @throws on a unique-violation if the identity already exists (race).
    */
   create(input: NewAuthIdentity): Promise<AuthIdentity>;
+  /**
+   * Remove every provider link for a user (#30). Called on account deletion so a
+   * returning person signs up as a NEW account rather than resurrecting the
+   * anonymised one their ledger history is attached to.
+   *
+   * @param userId - the user whose identities to unlink.
+   */
+  deleteForUser(userId: string): Promise<void>;
 }
 
 /** In-memory {@link AuthIdentityRepository} for dev and unit tests. */
@@ -63,5 +71,10 @@ export class InMemoryAuthIdentityRepository implements AuthIdentityRepository {
     };
     this.identities.set(this.key(input.provider, input.providerId), identity);
     return identity;
+  }
+  async deleteForUser(userId: string): Promise<void> {
+    for (const [key, identity] of this.identities) {
+      if (identity.userId === userId) this.identities.delete(key);
+    }
   }
 }

--- a/services/api/src/modules/auth/auth.service.ts
+++ b/services/api/src/modules/auth/auth.service.ts
@@ -31,6 +31,12 @@ export interface AuthTokens {
 /** A successful sign-in: the user plus their fresh token pair. */
 export interface AuthResult extends AuthTokens {
   user: User;
+  /**
+   * True only on the sign-in that created the account (#182). Lets callers
+   * branch on first contact — welcome flows, onboarding, activation metrics —
+   * without a second round trip to guess from `createdAt`.
+   */
+  isNewUser: boolean;
 }
 
 /** Collaborators for {@link AuthService}, injected at app wiring (app.ts). */
@@ -78,9 +84,9 @@ export class AuthService {
       throw new SignInNotConfiguredError('Sign-in is not configured');
     }
     const identity = await this.deps.verifier.verify(idToken); // throws if invalid
-    const user = await this.findOrCreateUser(identity);
+    const { user, isNewUser } = await this.findOrCreateUser(identity);
     const tokens = await this.issueTokens(user);
-    return { user, ...tokens };
+    return { user, isNewUser, ...tokens };
   }
 
   /**
@@ -183,17 +189,25 @@ export class AuthService {
    * @param identity - the verified provider identity.
    * @returns the existing or newly created user.
    */
-  private async findOrCreateUser(identity: VerifiedIdentity): Promise<User> {
+  private async findOrCreateUser(
+    identity: VerifiedIdentity,
+  ): Promise<{ user: User; isNewUser: boolean }> {
     const existing = await this.deps.authIdentities.findByProvider(
       identity.provider,
       identity.providerId,
     );
     if (existing) {
       const user = await this.deps.users.findById(existing.userId);
-      if (user) return user;
+      // Backfill the verified email for anyone who signed up before #182, so
+      // existing riders become reachable on their next sign-in rather than
+      // staying permanently uncontactable. Never overwrites a stored value.
+      if (user) return { user: await this.backfillEmail(user, identity), isNewUser: false };
     }
 
-    const user = await this.deps.users.create({ displayName: identity.displayName ?? 'New User' });
+    const user = await this.deps.users.create({
+      displayName: identity.displayName ?? 'New User',
+      email: identity.email,
+    });
     try {
       await this.deps.authIdentities.create({
         userId: user.id,
@@ -208,10 +222,23 @@ export class AuthService {
           identity.providerId,
         );
         const user2 = winner && (await this.deps.users.findById(winner.userId));
-        if (user2) return user2;
+        if (user2) return { user: user2, isNewUser: false };
       }
       throw err;
     }
-    return user;
+    return { user, isNewUser: true };
+  }
+
+  /**
+   * Fill in a missing email from the verified identity. A no-op when the user
+   * already has one or the provider did not supply one.
+   *
+   * @param user - the signing-in user.
+   * @param identity - the verified provider identity.
+   * @returns the user, updated when a backfill happened.
+   */
+  private async backfillEmail(user: User, identity: VerifiedIdentity): Promise<User> {
+    if (user.email || !identity.email) return user;
+    return (await this.deps.users.backfillContact(user.id, { email: identity.email })) ?? user;
   }
 }

--- a/services/api/src/modules/devices/device-token.repository.pg.ts
+++ b/services/api/src/modules/devices/device-token.repository.pg.ts
@@ -47,4 +47,8 @@ export class PgDeviceTokenRepository implements DeviceTokenRepository {
     );
     return rows.map(toDeviceToken);
   }
+
+  async removeForUser(userId: string): Promise<void> {
+    await this.pool.query('DELETE FROM device_tokens WHERE user_id = $1', [userId]);
+  }
 }

--- a/services/api/src/modules/devices/device-token.repository.ts
+++ b/services/api/src/modules/devices/device-token.repository.ts
@@ -42,6 +42,14 @@ export interface DeviceTokenRepository {
    * @returns the user's device tokens.
    */
   listForUser(userId: string): Promise<DeviceToken[]>;
+  /**
+   * Drop every registered device for a user (#30). Account deletion must stop
+   * push, and it also prevents the next person to use a shared handset from
+   * inheriting the previous rider's notifications.
+   *
+   * @param userId - the user whose devices to unregister.
+   */
+  removeForUser(userId: string): Promise<void>;
 }
 
 /** In-memory {@link DeviceTokenRepository} for dev and unit tests. */
@@ -69,5 +77,10 @@ export class InMemoryDeviceTokenRepository implements DeviceTokenRepository {
 
   async listForUser(userId: string): Promise<DeviceToken[]> {
     return [...this.byToken.values()].filter((t) => t.userId === userId);
+  }
+  async removeForUser(userId: string): Promise<void> {
+    for (const [key, token] of this.byToken) {
+      if (token.userId === userId) this.byToken.delete(key);
+    }
   }
 }

--- a/services/api/src/modules/metrics/metrics.plugin.ts
+++ b/services/api/src/modules/metrics/metrics.plugin.ts
@@ -9,7 +9,18 @@
 import { timingSafeEqual } from 'node:crypto';
 import type { FastifyReply, FastifyRequest } from 'fastify';
 import fp from 'fastify-plugin';
-import { collectDefaultMetrics, Histogram, Registry } from 'prom-client';
+import { collectDefaultMetrics, Counter, Histogram, Registry } from 'prom-client';
+
+declare module 'fastify' {
+  interface FastifyInstance {
+    /**
+     * Count a rate-limited (429) response. Decorated by this plugin; the
+     * rate-limit plugin calls it through `request.server` so the two stay
+     * independent and registration order does not matter.
+     */
+    recordRateLimited?: (route: string, bucket: 'ip' | 'user') => void;
+  }
+}
 
 /** Controls how the `/metrics` endpoint is exposed and protected. */
 export interface MetricsOptions {
@@ -40,6 +51,23 @@ export const metricsPlugin = fp<MetricsOptions>(async (app, opts) => {
     labelNames: ['method', 'route', 'status_code'] as const,
     buckets: DURATION_BUCKETS,
     registers: [register],
+  });
+
+  // 429s are visible on the histogram's status_code label, but not by BUCKET —
+  // and that is the dimension that matters (#154). Ghanaian carriers use
+  // carrier-grade NAT, so many riders share one public IP; without knowing
+  // whether a limit fired on `ip` or `user` we cannot tell a real abuser from a
+  // whole neighbourhood behind one address. Nothing tunes thresholds until this
+  // has produced data.
+  const rateLimited = new Counter({
+    name: 'rate_limited_total',
+    help: 'Requests rejected with 429 by the rate limiter.',
+    labelNames: ['route', 'bucket'] as const,
+    registers: [register],
+  });
+
+  app.decorate('recordRateLimited', (route: string, bucket: 'ip' | 'user') => {
+    rateLimited.inc({ route, bucket });
   });
 
   // Record every response except the scrape itself. Use the route TEMPLATE

--- a/services/api/src/modules/mobility/eta.ts
+++ b/services/api/src/modules/mobility/eta.ts
@@ -8,7 +8,12 @@
 // and ETA = remaining / a fixed assumed speed. The assumed speed is a pilot
 // placeholder; a live speed/traffic model arrives with the telemetry path (ADR-0006).
 
-/** Assumed average vehicle speed for the pilot ETA (urban trotro ~20 km/h). */
+/**
+ * Cold-start speed, used for any segment we have not observed yet (urban trotro
+ * ~20 km/h). Every segment starts here and is superseded by its own measured
+ * median as runs accumulate (#181) — so a brand-new corridor still produces an
+ * ETA on day one, and gets more accurate without anyone doing anything.
+ */
 export const ASSUMED_SPEED_KPH = 20;
 const ASSUMED_SPEED_MS = (ASSUMED_SPEED_KPH * 1000) / 3600;
 
@@ -30,6 +35,24 @@ export interface RouteStopPoint extends LatLng {
   name: string;
   seq: number;
 }
+
+/**
+ * Observed median speed for one segment of a route, from completed runs.
+ * Keyed by the seq of the segment's FIRST stop: `fromSeq` 0 is the stretch
+ * between stop 0 and stop 1.
+ */
+export interface SegmentSpeed {
+  fromSeq: number;
+  metresPerSecond: number;
+  /** How many runs the median came from; low counts are ignored (see below). */
+  sampleCount: number;
+}
+
+/**
+ * Below this many observations a median is noise, not signal — one unusual run
+ * would swing the ETA. Segments under it keep the cold-start speed.
+ */
+export const MIN_SAMPLES_FOR_OBSERVED_SPEED = 3;
 
 /** A stop still ahead of the vehicle, with distance + ETA along the route. */
 export interface StopEta {
@@ -79,10 +102,16 @@ function toPlane(p: LatLng, cosLatRef: number): { x: number; y: number } {
  *
  * @param position - the vehicle's latest fix.
  * @param stops - the route's stops in seq order (as returned by the route-stop repo).
+ * @param speeds - observed median speeds by segment index (#181). Omit, or leave
+ *   a segment out, to charge that stretch the cold-start speed.
  * @returns upcoming stops in order, each with remaining distance + ETA seconds.
  *   Empty when there are fewer than two stops or the vehicle is past the last stop.
  */
-export function computeEtas(position: LatLng, stops: RouteStopPoint[]): StopEta[] {
+export function computeEtas(
+  position: LatLng,
+  stops: RouteStopPoint[],
+  speeds?: Map<number, SegmentSpeed>,
+): StopEta[] {
   // Need at least one segment to define "progress along the route".
   if (stops.length < 2) return [];
 
@@ -131,16 +160,39 @@ export function computeEtas(position: LatLng, stops: RouteStopPoint[]): StopEta[
   if (bestSeg === lastSeg && bestTRaw > 1) tEff = bestTRaw;
   const travelled = cumulative[bestSeg]! + tEff * segLen[bestSeg]!;
 
+  // Speed per segment: the observed median where we have enough runs, the
+  // cold-start constant everywhere else. Building the lookup once keeps the
+  // per-stop loop linear.
+  const speedForSegment = (index: number): number => {
+    const observed = speeds?.get(index);
+    if (observed && observed.sampleCount >= MIN_SAMPLES_FOR_OBSERVED_SPEED) {
+      return observed.metresPerSecond;
+    }
+    return ASSUMED_SPEED_MS;
+  };
+
   const etas: StopEta[] = [];
   for (let j = 0; j < stops.length; j++) {
     const remaining = cumulative[j]! - travelled;
     if (remaining <= REACHED_EPS_M) continue; // reached or behind → not upcoming
+
+    // Walk the segments between the vehicle and this stop, charging each its own
+    // speed. Summing per segment rather than dividing the total distance by one
+    // number is the whole point: a run is fast on the highway and slow through
+    // the junction, and an average of the two is wrong for both.
+    let seconds = 0;
+    for (let seg = bestSeg; seg < j; seg++) {
+      const segmentRemaining = seg === bestSeg ? cumulative[seg + 1]! - travelled : segLen[seg]!;
+      if (segmentRemaining <= 0) continue;
+      seconds += segmentRemaining / speedForSegment(seg);
+    }
+
     etas.push({
       stopId: stops[j]!.stopId,
       seq: stops[j]!.seq,
       name: stops[j]!.name,
       distanceMeters: Math.round(remaining),
-      etaSeconds: Math.round(remaining / ASSUMED_SPEED_MS),
+      etaSeconds: Math.round(seconds),
     });
   }
   return etas;

--- a/services/api/src/modules/mobility/route-geometry.ts
+++ b/services/api/src/modules/mobility/route-geometry.ts
@@ -1,0 +1,204 @@
+// Deriving a route's real shape from our own GPS traces (#179).
+//
+// Pure functions — no clock, no I/O — so the same traces always yield the same
+// polyline and the whole thing is unit-testable. The repository layer supplies
+// the fixes and persists the result.
+//
+// Why our traces and not a routing engine: a router describes where a generic
+// vehicle COULD go. Our traces record where our bus DOES go, including the
+// informal stop and the shortcut OSM has never heard of. For a fixed-corridor
+// service ours is the one that matters. Valhalla map-matching is a later
+// cleanup pass (an offline job, never a running service) for when raw GPS in
+// dense Accra wanders across carriageways.
+
+import { haversineMeters, type LatLng } from './eta';
+
+/** How a route's geometry was produced. Mirrors the DB CHECK constraint. */
+export const GEOMETRY_SOURCES = ['traces', 'matched', 'manual'] as const;
+export type GeometrySource = (typeof GEOMETRY_SOURCES)[number];
+
+/**
+ * Runs are used from the first one, then superseded by the median of the last
+ * five. One run makes a route usable immediately; five stop a single diversion
+ * or wrong turn from defining the corridor forever.
+ */
+export const RUNS_FOR_STABLE_GEOMETRY = 5;
+
+/**
+ * Fixes closer together than this add vertices without adding information. A
+ * bus at 20 km/h covers ~28 m between 5-second fixes, so 15 m keeps genuine
+ * movement while dropping the jitter of a vehicle standing at a stop.
+ */
+const MIN_VERTEX_SPACING_M = 15;
+
+/**
+ * A fix further than this from the previous one is treated as a GPS glitch
+ * rather than travel — at 5-second intervals it implies over 250 km/h.
+ */
+const MAX_PLAUSIBLE_JUMP_M = 350;
+
+/** One completed run's fixes, in recorded order. */
+export interface Trace {
+  tripId: string;
+  points: LatLng[];
+}
+
+/** A derived polyline plus the provenance we store alongside it. */
+export interface DerivedGeometry {
+  /** Ordered vertices of the route path. */
+  points: LatLng[];
+  source: GeometrySource;
+  /** How many runs contributed. Written to routes.geometry_run_count. */
+  runCount: number;
+}
+
+/**
+ * Drop fixes that add no information: near-duplicates from a stationary bus,
+ * and implausible jumps from a bad fix.
+ *
+ * @param points - one run's fixes in recorded order.
+ * @returns the cleaned points, in order.
+ */
+export function cleanTrace(points: LatLng[]): LatLng[] {
+  const cleaned: LatLng[] = [];
+  for (const point of points) {
+    const previous = cleaned[cleaned.length - 1];
+    if (!previous) {
+      cleaned.push(point);
+      continue;
+    }
+    const gap = haversineMeters(previous, point);
+    if (gap < MIN_VERTEX_SPACING_M) continue; // parked or crawling
+    if (gap > MAX_PLAUSIBLE_JUMP_M) continue; // glitch, not travel
+    cleaned.push(point);
+  }
+  return cleaned;
+}
+
+/**
+ * Resample a trace to a fixed number of evenly spaced vertices along its own
+ * length.
+ *
+ * Runs cannot be averaged fix-by-fix: two drivers hit different traffic, so
+ * their nth fix is at a different place on the road. Resampling by *fraction of
+ * distance travelled* puts every run on a comparable footing, which is what
+ * makes a median meaningful.
+ *
+ * @param points - a cleaned trace.
+ * @param sampleCount - how many vertices to produce (at least 2).
+ * @returns evenly spaced points, or an empty array when the trace is too short.
+ */
+export function resampleByDistance(points: LatLng[], sampleCount: number): LatLng[] {
+  if (points.length < 2 || sampleCount < 2) return [];
+
+  const cumulative: number[] = [0];
+  for (let i = 0; i < points.length - 1; i++) {
+    cumulative.push(cumulative[i]! + haversineMeters(points[i]!, points[i + 1]!));
+  }
+  const total = cumulative[cumulative.length - 1]!;
+  if (total === 0) return [];
+
+  const samples: LatLng[] = [];
+  for (let s = 0; s < sampleCount; s++) {
+    const target = (total * s) / (sampleCount - 1);
+
+    // Walk to the segment containing `target`, then interpolate within it.
+    let seg = 0;
+    while (seg < cumulative.length - 2 && cumulative[seg + 1]! < target) seg++;
+
+    const segStart = cumulative[seg]!;
+    const segLen = cumulative[seg + 1]! - segStart;
+    const t = segLen === 0 ? 0 : (target - segStart) / segLen;
+    const a = points[seg]!;
+    const b = points[seg + 1]!;
+    samples.push({
+      latitude: a.latitude + (b.latitude - a.latitude) * t,
+      longitude: a.longitude + (b.longitude - a.longitude) * t,
+    });
+  }
+  return samples;
+}
+
+/**
+ * Element-wise median of several equal-length resampled traces.
+ *
+ * Median rather than mean: one driver taking a wrong turn should not bend the
+ * corridor. A mean is dragged by the outlier; a median ignores it.
+ *
+ * @param traces - resampled traces, all of the same length.
+ * @returns the median path.
+ */
+function medianPath(traces: LatLng[][]): LatLng[] {
+  const length = traces[0]?.length ?? 0;
+  const median = (values: number[]): number => {
+    const sorted = [...values].sort((a, b) => a - b);
+    const mid = Math.floor(sorted.length / 2);
+    return sorted.length % 2 === 0 ? (sorted[mid - 1]! + sorted[mid]!) / 2 : sorted[mid]!;
+  };
+
+  const out: LatLng[] = [];
+  for (let i = 0; i < length; i++) {
+    out.push({
+      latitude: median(traces.map((t) => t[i]!.latitude)),
+      longitude: median(traces.map((t) => t[i]!.longitude)),
+    });
+  }
+  return out;
+}
+
+/**
+ * Derive a route's geometry from completed runs.
+ *
+ * One run is used as-is so a corridor becomes usable the day it first runs.
+ * Once several exist, the median supersedes it and diversions stop counting.
+ *
+ * @param traces - completed runs, newest first; only the most recent
+ *   {@link RUNS_FOR_STABLE_GEOMETRY} are considered.
+ * @param sampleCount - vertices in the output path.
+ * @returns the derived geometry, or null when no run carries enough signal.
+ */
+export function deriveRouteGeometry(traces: Trace[], sampleCount = 200): DerivedGeometry | null {
+  const usable = traces
+    .slice(0, RUNS_FOR_STABLE_GEOMETRY)
+    .map((trace) => resampleByDistance(cleanTrace(trace.points), sampleCount))
+    .filter((path) => path.length === sampleCount);
+
+  if (usable.length === 0) return null;
+
+  return {
+    points: usable.length === 1 ? usable[0]! : medianPath(usable),
+    source: 'traces',
+    runCount: usable.length,
+  };
+}
+
+/**
+ * Distance along a derived path to each stop, for `route_stops.distance_m`.
+ *
+ * Each stop is projected onto its nearest vertex; the pilot's stops sit metres
+ * from the road, so nearest-vertex is accurate enough and far simpler than
+ * projecting onto every segment.
+ *
+ * @param path - the derived route path.
+ * @param stops - the route's stops in seq order.
+ * @returns metres along the path for each stop, in the same order.
+ */
+export function stopDistancesAlong(path: LatLng[], stops: LatLng[]): number[] {
+  const cumulative: number[] = [0];
+  for (let i = 0; i < path.length - 1; i++) {
+    cumulative.push(cumulative[i]! + haversineMeters(path[i]!, path[i + 1]!));
+  }
+
+  return stops.map((stop) => {
+    let best = 0;
+    let bestDistance = Infinity;
+    for (let i = 0; i < path.length; i++) {
+      const d = haversineMeters(stop, path[i]!);
+      if (d < bestDistance) {
+        bestDistance = d;
+        best = i;
+      }
+    }
+    return cumulative[best]!;
+  });
+}

--- a/services/api/src/modules/payments/payments.service.ts
+++ b/services/api/src/modules/payments/payments.service.ts
@@ -13,11 +13,13 @@
 // retried/partial webhook converges. Paystack retries; reconciliation (future)
 // backstops the rest.
 
+import { normaliseGhanaPhone } from '../../lib/phone';
 import type { EntitlementLedgerRepository } from '../entitlements/entitlement-ledger.repository';
 import type {
   SubscriptionPlan,
   SubscriptionRepository,
 } from '../subscriptions/subscription.repository';
+import type { UserRepository } from '../users/user.repository';
 import type { NewPayment, PaymentRepository } from './payment.repository';
 import type { PaystackClient } from './paystack.client';
 
@@ -59,6 +61,8 @@ export interface PaymentsServiceDeps {
   entitlements: EntitlementLedgerRepository;
   /** Undefined when payments aren't configured (e.g. prod without a Paystack key). */
   paystack?: PaystackClient;
+  /** Users, for capturing the payer's verified phone on charge.success (#182). */
+  users: UserRepository;
   /** Plan → membership fee in pesewas (server-authoritative). */
   subscriptionFees: Record<SubscriptionPlan, number>;
   /** Rides allocated per activated period (placeholder until E1b tiers). */
@@ -78,7 +82,12 @@ function isUniqueViolation(err: unknown): boolean {
 /** The subset of Paystack's webhook payload we read. */
 interface PaystackWebhookEvent {
   event?: string;
-  data?: { reference?: string };
+  data?: {
+    reference?: string;
+    /** Present on mobile-money charges; the handset that approved the debit. */
+    customer?: { phone?: string | null };
+    authorization?: { mobile_money_number?: string | null };
+  };
 }
 
 /** What initiating a checkout returns to the caller (and the route). */
@@ -182,6 +191,12 @@ export class PaymentsService {
       await this.activateSubscription(payment.userId, payment.plan, payment.routeId);
       await this.allocateEntitlement(payment.userId, reference);
     }
+
+    // The payer approved this debit on their handset, so the number is verified
+    // by the charge itself — no OTP needed. Best effort: a failure here must not
+    // fail the webhook, because a non-200 costs us the subscription activation
+    // above on Paystack's retry.
+    await this.capturePayerPhone(payment.userId, event);
     // Legacy 'topup' payments (pre-ADR-0014 staging data) are ignored.
 
     await this.deps.payments.markPaid(reference);
@@ -203,6 +218,30 @@ export class PaymentsService {
       refId: reference,
       idempotencyKey: `alloc:${reference}`,
     });
+  }
+
+  /**
+   * Record the payer's phone number from a successful charge, when we do not
+   * already have one (#182).
+   *
+   * Swallows every failure by design. Two accounts legitimately paying from one
+   * handset trips the UNIQUE constraint on users.phone, and that must not turn
+   * into a 500 — the subscription is already activated by the time we get here,
+   * and Paystack would retry the whole webhook.
+   *
+   * @param userId - the paying user.
+   * @param event - the verified `charge.success` payload.
+   */
+  private async capturePayerPhone(userId: string, event: PaystackWebhookEvent): Promise<void> {
+    const raw = event.data?.authorization?.mobile_money_number ?? event.data?.customer?.phone;
+    const phone = normaliseGhanaPhone(raw);
+    if (!phone) return;
+    try {
+      await this.deps.users.backfillContact(userId, { phone });
+    } catch {
+      // Already held by another account, or the row vanished. Neither is worth
+      // failing a paid subscription over.
+    }
   }
 
   /**

--- a/services/api/src/modules/ratelimit/ratelimit.plugin.ts
+++ b/services/api/src/modules/ratelimit/ratelimit.plugin.ts
@@ -57,6 +57,9 @@ export const rateLimitPlugin = fp<{ kv: KvStore }>(async (app, opts) => {
       reply.header('X-RateLimit-Remaining', String(Math.max(0, options.max - count)));
 
       if (count > options.max) {
+        // Optional chaining, not a hard dependency: the limiter must keep
+        // working when metrics are disabled (production without METRICS_TOKEN).
+        request.server.recordRateLimited?.(request.routeOptions.url ?? 'unknown', by);
         reply.header('Retry-After', String(options.windowSeconds));
         return reply
           .code(429)

--- a/services/api/src/modules/users/account-deletion.service.ts
+++ b/services/api/src/modules/users/account-deletion.service.ts
@@ -1,0 +1,70 @@
+// Account erasure (#30). Required by App Store and Play before either app ships.
+//
+// Deletion here means ANONYMISE, not DROP. payments, entitlement_ledger and
+// credit_ledger all cascade off users, so `DELETE FROM users` would take the
+// financial record of what someone paid and what they were charged with it.
+// Those are our books; they have to outlive a deletion request. The person
+// behind them does not.
+//
+// Order matters. Sessions and devices are cut first so an in-flight app cannot
+// keep acting as the account while the erasure runs; the identity links go next
+// so a returning person signs up fresh instead of resurrecting the anonymised
+// row; the PII is cleared last, once nothing can still reach it.
+
+import type { AuthIdentityRepository } from '../auth/auth-identity.repository';
+import type { SessionRepository } from '../auth/session.repository';
+import type { DeviceTokenRepository } from '../devices/device-token.repository';
+import type { ObjectStore } from '../../storage/object-store';
+import type { UserRepository } from './user.repository';
+
+/** Collaborators for {@link AccountDeletionService}. */
+export interface AccountDeletionDeps {
+  users: UserRepository;
+  sessions: SessionRepository;
+  authIdentities: AuthIdentityRepository;
+  devices: DeviceTokenRepository;
+  objectStore: ObjectStore;
+}
+
+/** Erases a user's personal data across every store that holds it. */
+export class AccountDeletionService {
+  /** @param deps - the repositories and object store to clear. */
+  constructor(private readonly deps: AccountDeletionDeps) {}
+
+  /**
+   * Erase an account. Idempotent: running it twice on the same user is a no-op,
+   * so a client retrying after a timeout cannot fail or double-report.
+   *
+   * @param userId - the account to erase.
+   * @returns true when the user existed, false when there was nothing to erase.
+   */
+  async deleteAccount(userId: string): Promise<boolean> {
+    const user = await this.deps.users.findById(userId);
+    if (!user) return false;
+
+    // 1. Cut access first. An app mid-request must not keep acting as this
+    //    account while the rest of the erasure runs.
+    await this.deps.sessions.revokeAllForUser(userId);
+    await this.deps.devices.removeForUser(userId);
+
+    // 2. Unlink the providers, so signing in with the same Google account
+    //    creates a NEW user rather than reopening this one.
+    await this.deps.authIdentities.deleteForUser(userId);
+
+    // 3. The avatar is the only personal data outside Postgres — clearing the
+    //    column alone would leave the image sitting in the bucket. Best effort:
+    //    a storage failure must not block the erasure of everything else, and
+    //    the DB no longer points at the object either way.
+    if (user.avatarUrl) {
+      try {
+        await this.deps.objectStore.deleteObject(user.avatarUrl);
+      } catch {
+        // Orphaned object; the record linking it to a person is gone regardless.
+      }
+    }
+
+    // 4. Clear the PII, keep the row and its id so the ledgers stay balanced.
+    await this.deps.users.anonymise(userId);
+    return true;
+  }
+}

--- a/services/api/src/modules/users/user.repository.pg.ts
+++ b/services/api/src/modules/users/user.repository.pg.ts
@@ -1,9 +1,17 @@
 import type { Pool } from 'pg';
-import type { NewUser, User, UserRepository, UserRole } from './user.repository';
+import {
+  ANONYMISED_DISPLAY_NAME,
+  type NewUser,
+  type User,
+  type UserRepository,
+  type UserRole,
+} from './user.repository';
 
 interface UserRow {
   id: string;
   display_name: string;
+  deleted_at: Date | null;
+  email: string | null;
   phone: string | null;
   avatar_url: string | null;
   role: UserRole;
@@ -14,6 +22,8 @@ function toUser(row: UserRow): User {
   return {
     id: row.id,
     displayName: row.display_name,
+    deletedAt: row.deleted_at,
+    email: row.email,
     phone: row.phone,
     avatarUrl: row.avatar_url,
     role: row.role,
@@ -26,10 +36,10 @@ export class PgUserRepository implements UserRepository {
 
   async create(input: NewUser): Promise<User> {
     const { rows } = await this.pool.query<UserRow>(
-      `INSERT INTO users (display_name, phone, role)
-       VALUES ($1, $2, $3)
+      `INSERT INTO users (display_name, email, phone, role)
+       VALUES ($1, $2, $3, $4)
        RETURNING *`,
-      [input.displayName, input.phone ?? null, input.role ?? 'commuter'],
+      [input.displayName, input.email ?? null, input.phone ?? null, input.role ?? 'commuter'],
     );
     return toUser(rows[0]!);
   }
@@ -59,6 +69,44 @@ export class PgUserRepository implements UserRepository {
     const { rows } = await this.pool.query<UserRow>(
       `UPDATE users SET role = $2, updated_at = now() WHERE id = $1 RETURNING *`,
       [id, role],
+    );
+    return rows[0] ? toUser(rows[0]) : null;
+  }
+
+  async backfillContact(
+    id: string,
+    contact: { email?: string | null; phone?: string | null },
+  ): Promise<User | null> {
+    // COALESCE keeps whatever is already stored: a webhook must never overwrite
+    // a number the rider has since corrected on their profile. Writing the same
+    // value twice is therefore a no-op, which is what makes Paystack's webhook
+    // re-delivery safe.
+    const { rows } = await this.pool.query<UserRow>(
+      `UPDATE users
+          SET email      = COALESCE(email, $2),
+              phone      = COALESCE(phone, $3),
+              updated_at = now()
+        WHERE id = $1
+        RETURNING *`,
+      [id, contact.email ?? null, contact.phone ?? null],
+    );
+    return rows[0] ? toUser(rows[0]) : null;
+  }
+
+  async anonymise(id: string): Promise<User | null> {
+    // COALESCE on deleted_at keeps the FIRST deletion timestamp, so a retried
+    // request does not rewrite when the erasure actually happened.
+    const { rows } = await this.pool.query<UserRow>(
+      `UPDATE users
+          SET display_name = $2,
+              email        = NULL,
+              phone        = NULL,
+              avatar_url   = NULL,
+              deleted_at   = COALESCE(deleted_at, now()),
+              updated_at   = now()
+        WHERE id = $1
+        RETURNING *`,
+      [id, ANONYMISED_DISPLAY_NAME],
     );
     return rows[0] ? toUser(rows[0]) : null;
   }

--- a/services/api/src/modules/users/user.repository.ts
+++ b/services/api/src/modules/users/user.repository.ts
@@ -2,6 +2,9 @@
 // InMemory (tests + zero-infra dev) and Postgres (real runs, see *.pg.ts).
 // The server picks one by DATABASE_URL. Copy this shape for new domain modules.
 
+/** Display name left behind after erasure — never a real person's name. */
+export const ANONYMISED_DISPLAY_NAME = 'Deleted user';
+
 export const USER_ROLES = ['commuter', 'driver', 'admin'] as const;
 export type UserRole = (typeof USER_ROLES)[number];
 
@@ -9,6 +12,11 @@ export type UserRole = (typeof USER_ROLES)[number];
 export interface User {
   id: string;
   displayName: string;
+  /** Set when the account was erased on request (#30); PII columns are cleared. */
+  deletedAt: Date | null;
+  /** Verified address from the social identity provider; null for pre-#182 rows. */
+  email: string | null;
+  /** E.164 normalised (+233…), captured from a successful Paystack charge. */
   phone: string | null;
   avatarUrl: string | null;
   role: UserRole;
@@ -18,6 +26,7 @@ export interface User {
 /** Fields needed to create a user; the rest default or are server-set. */
 export interface NewUser {
   displayName: string;
+  email?: string | null;
   phone?: string | null;
   /** Defaults to `commuter` when omitted. */
   role?: UserRole;
@@ -65,6 +74,38 @@ export interface UserRepository {
    * @returns the updated user, or null if not found.
    */
   setRole(id: string, role: UserRole): Promise<User | null>;
+  /**
+   * Fill in contact details we did not have before, without overwriting details
+   * we already hold. Used to backfill users who signed up before #182 (on their
+   * next sign-in) and to capture the payer's phone from the Paystack webhook.
+   *
+   * A field is written only when the stored value is null, so a rider who edits
+   * their profile is never silently reverted by a later webhook.
+   *
+   * @param id - the user to backfill.
+   * @param contact - the contact details to fill in where missing.
+   * @param contact.email - verified email, or undefined to leave alone.
+   * @param contact.phone - E.164 phone, or undefined to leave alone.
+   * @returns the updated user, or null if not found.
+   */
+  backfillContact(
+    id: string,
+    contact: { email?: string | null; phone?: string | null },
+  ): Promise<User | null>;
+  /**
+   * Erase a user's personal data while keeping the row (#30).
+   *
+   * Not a DELETE: payments, entitlement_ledger and credit_ledger all cascade off
+   * users, so removing the row would destroy the financial record of what the
+   * rider paid and was charged. Those are our books and have to outlive a
+   * deletion request; the person behind them does not.
+   *
+   * Idempotent — anonymising twice is a no-op, so a retried request is safe.
+   *
+   * @param id - the user to erase.
+   * @returns the anonymised user, or null if not found.
+   */
+  anonymise(id: string): Promise<User | null>;
 }
 
 /** In-memory {@link UserRepository} for dev and unit tests. */
@@ -75,6 +116,8 @@ export class InMemoryUserRepository implements UserRepository {
     const user: User = {
       id: crypto.randomUUID(),
       displayName: input.displayName,
+      deletedAt: null,
+      email: input.email ?? null,
       phone: input.phone ?? null,
       avatarUrl: null,
       role: input.role ?? 'commuter',
@@ -108,6 +151,36 @@ export class InMemoryUserRepository implements UserRepository {
     const user = this.users.get(id);
     if (!user) return null;
     const updated = { ...user, role };
+    this.users.set(id, updated);
+    return updated;
+  }
+
+  async backfillContact(
+    id: string,
+    contact: { email?: string | null; phone?: string | null },
+  ): Promise<User | null> {
+    const user = this.users.get(id);
+    if (!user) return null;
+    const updated: User = {
+      ...user,
+      email: user.email ?? contact.email ?? null,
+      phone: user.phone ?? contact.phone ?? null,
+    };
+    this.users.set(id, updated);
+    return updated;
+  }
+
+  async anonymise(id: string): Promise<User | null> {
+    const user = this.users.get(id);
+    if (!user) return null;
+    const updated: User = {
+      ...user,
+      displayName: ANONYMISED_DISPLAY_NAME,
+      email: null,
+      phone: null,
+      avatarUrl: null,
+      deletedAt: user.deletedAt ?? new Date(),
+    };
     this.users.set(id, updated);
     return updated;
   }

--- a/services/api/src/modules/users/users.routes.ts
+++ b/services/api/src/modules/users/users.routes.ts
@@ -6,6 +6,7 @@
 import type { FastifyInstance } from 'fastify';
 import fastifyMultipart from '@fastify/multipart';
 import type { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { z } from 'zod';
 import { errorResponseSchema } from '../../lib/schemas';
 import type { ObjectStore } from '../../storage/object-store';
 import type { RateLimitConfig } from '../ratelimit/ratelimit.plugin';
@@ -16,6 +17,7 @@ import {
   processAvatar,
   PROCESSED_MIME,
 } from './avatar';
+import type { AccountDeletionService } from './account-deletion.service';
 import { toUserResponse } from './user.presenter';
 import type { UserRepository } from './user.repository';
 import { avatarResponseSchema, updateProfileBodySchema, userResponseSchema } from './user.schema';
@@ -29,10 +31,16 @@ import { avatarResponseSchema, updateProfileBodySchema, userResponseSchema } fro
  * @param opts.users - the user repository.
  * @param opts.objectStore - avatar storage (R2 in prod, in-memory in dev/tests).
  * @param opts.rateLimit - rate-limit config (applied per user).
+ * @param opts.accountDeletion - account erasure service (503 when absent).
  */
 export async function userRoutes(
   app: FastifyInstance,
-  opts: { users?: UserRepository; objectStore: ObjectStore; rateLimit: RateLimitConfig },
+  opts: {
+    users?: UserRepository;
+    objectStore: ObjectStore;
+    rateLimit: RateLimitConfig;
+    accountDeletion?: AccountDeletionService;
+  },
 ): Promise<void> {
   await app.register(fastifyMultipart, { limits: { fileSize: MAX_UPLOAD_BYTES, files: 1 } });
   const r = app.withTypeProvider<ZodTypeProvider>();
@@ -153,6 +161,40 @@ export async function userRoutes(
         return reply.code(404).send({ error: 'not_found', message: 'No avatar set' });
       }
       return { avatarUrl: await opts.objectStore.signedUrl(user.avatarUrl) };
+    },
+  );
+
+  r.delete(
+    '/me',
+    {
+      schema: {
+        tags: ['users'],
+        summary: 'Delete my account (erases personal data; keeps financial records)',
+        description:
+          'Revokes every session, unregisters push devices, unlinks sign-in providers, ' +
+          'deletes the avatar, and clears personal data. Payment and ride-ledger rows ' +
+          'are retained in anonymised form because they are accounting records. ' +
+          'Signing in again creates a new account.',
+        security: [{ bearerAuth: [] }],
+        response: {
+          204: z.null(),
+          401: errorResponseSchema,
+          429: errorResponseSchema,
+          503: errorResponseSchema,
+        },
+      },
+      preHandler: [app.authenticate, app.rateLimit({ ...opts.rateLimit, by: 'user' })],
+    },
+    async (request, reply) => {
+      if (!opts.accountDeletion) {
+        return reply
+          .code(503)
+          .send({ error: 'unavailable', message: 'Account deletion is not configured' });
+      }
+      // Idempotent by design: a client retrying after a timeout gets 204 again
+      // rather than a 404 that would read as "deletion failed".
+      await opts.accountDeletion.deleteAccount(request.user!.id);
+      return reply.code(204).send(null);
     },
   );
 }

--- a/services/api/src/server.ts
+++ b/services/api/src/server.ts
@@ -99,6 +99,7 @@ import {
   type ReservationRepository,
 } from './modules/reservations/reservation.repository';
 import { PgReservationRepository } from './modules/reservations/reservation.repository.pg';
+import { AccountDeletionService } from './modules/users/account-deletion.service';
 import { InMemoryUserRepository, type UserRepository } from './modules/users/user.repository';
 import { PgUserRepository } from './modules/users/user.repository.pg';
 import {
@@ -262,10 +263,21 @@ async function main(): Promise<void> {
     console.warn('PAYSTACK_SECRET_KEY not set — payments disabled (POST /payments/* returns 503).');
   }
 
+  // Account erasure (#30): anonymise across every store that holds personal
+  // data — sessions, devices, provider links, the avatar object, and the row.
+  const accountDeletion = new AccountDeletionService({
+    users,
+    sessions,
+    authIdentities,
+    devices: deviceTokens,
+    objectStore,
+  });
+
   const paymentsService = new PaymentsService({
     payments,
     subscriptions,
     entitlements,
+    users,
     paystack,
     subscriptionFees: SUBSCRIPTION_FEES_PESEWAS,
     ridesPerPeriod: PLACEHOLDER_RIDES_PER_PERIOD,
@@ -308,6 +320,7 @@ async function main(): Promise<void> {
 
   const app = await buildApp({
     users,
+    accountDeletion,
     subscriptions,
     routes,
     stops,

--- a/services/api/src/storage/object-store.r2.ts
+++ b/services/api/src/storage/object-store.r2.ts
@@ -3,7 +3,12 @@
 // The bucket is private; reads go through presigned GET URLs (zero egress on R2).
 // Excluded from unit coverage (needs a live bucket) — exercised via staging.
 
-import { GetObjectCommand, PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import {
+  DeleteObjectCommand,
+  GetObjectCommand,
+  PutObjectCommand,
+  S3Client,
+} from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { avatarKey, SIGNED_URL_TTL_SECONDS, type ObjectStore } from './object-store';
 
@@ -48,5 +53,11 @@ export class R2ObjectStore implements ObjectStore {
       new GetObjectCommand({ Bucket: this.config.bucket, Key: key }),
       { expiresIn: ttlSeconds },
     );
+  }
+
+  async deleteObject(key: string): Promise<void> {
+    // S3 DELETE is already idempotent — removing an absent key returns 204 —
+    // so a retried deletion request does not fail on the second attempt.
+    await this.client.send(new DeleteObjectCommand({ Bucket: this.config.bucket, Key: key }));
   }
 }

--- a/services/api/src/storage/object-store.ts
+++ b/services/api/src/storage/object-store.ts
@@ -37,6 +37,17 @@ export interface ObjectStore {
    * @returns a time-limited URL the client can GET directly.
    */
   signedUrl(key: string, ttlSeconds?: number): Promise<string>;
+  /**
+   * Remove a stored object. Used by account deletion (#30) — the avatar is the
+   * one piece of personal data that does not live in Postgres, so clearing the
+   * DB column alone would leave the image sitting in the bucket.
+   *
+   * Idempotent: deleting an absent key is not an error, so a retried deletion
+   * request does not fail on the second attempt.
+   *
+   * @param key - the object key to remove.
+   */
+  deleteObject(key: string): Promise<void>;
 }
 
 /** In-memory {@link ObjectStore} for dev and unit tests (no network). */
@@ -61,5 +72,9 @@ export class FakeObjectStore implements ObjectStore {
    */
   peek(key: string): { bytes: Buffer; contentType: string } | undefined {
     return this.objects.get(key);
+  }
+
+  async deleteObject(key: string): Promise<void> {
+    this.objects.delete(key);
   }
 }

--- a/services/api/tests/account-deletion.test.ts
+++ b/services/api/tests/account-deletion.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import { AccountDeletionService } from '../src/modules/users/account-deletion.service';
+import {
+  ANONYMISED_DISPLAY_NAME,
+  InMemoryUserRepository,
+} from '../src/modules/users/user.repository';
+import { InMemoryAuthIdentityRepository } from '../src/modules/auth/auth-identity.repository';
+import { InMemorySessionRepository } from '../src/modules/auth/session.repository';
+import { InMemoryDeviceTokenRepository } from '../src/modules/devices/device-token.repository';
+import { FakeObjectStore } from '../src/storage/object-store';
+
+async function make() {
+  const users = new InMemoryUserRepository();
+  const sessions = new InMemorySessionRepository();
+  const authIdentities = new InMemoryAuthIdentityRepository();
+  const devices = new InMemoryDeviceTokenRepository();
+  const objectStore = new FakeObjectStore();
+
+  const user = await users.create({
+    displayName: 'Ama Boateng',
+    email: 'ama@example.com',
+    phone: '+233244123456',
+  });
+  await authIdentities.create({ userId: user.id, provider: 'google', providerId: 'g-1' });
+  await devices.register(user.id, 'fcm-token-1', 'android');
+  const key = await objectStore.putAvatar(user.id, Buffer.from('jpegbytes'), 'image/jpeg');
+  await users.setAvatarKey(user.id, key);
+
+  const service = new AccountDeletionService({
+    users,
+    sessions,
+    authIdentities,
+    devices,
+    objectStore,
+  });
+  return { service, users, sessions, authIdentities, devices, objectStore, user, key };
+}
+
+describe('AccountDeletionService', () => {
+  it('clears every piece of personal data', async () => {
+    const { service, users, user } = await make();
+
+    expect(await service.deleteAccount(user.id)).toBe(true);
+
+    const after = await users.findById(user.id);
+    expect(after?.displayName).toBe(ANONYMISED_DISPLAY_NAME);
+    expect(after?.email).toBeNull();
+    expect(after?.phone).toBeNull();
+    expect(after?.avatarUrl).toBeNull();
+    expect(after?.deletedAt).toBeInstanceOf(Date);
+  });
+
+  it('keeps the user row so the money tables stay attributable', async () => {
+    // payments, entitlement_ledger and credit_ledger all cascade off users.
+    // A hard delete would take the financial record with it, which is exactly
+    // what this design exists to avoid.
+    const { service, users, user } = await make();
+    await service.deleteAccount(user.id);
+    expect(await users.findById(user.id)).not.toBeNull();
+  });
+
+  it('removes the avatar from object storage, not just the column', async () => {
+    const { service, objectStore, user, key } = await make();
+    expect(objectStore.peek(key)).toBeDefined();
+
+    await service.deleteAccount(user.id);
+    expect(objectStore.peek(key)).toBeUndefined();
+  });
+
+  it('unlinks providers so signing in again creates a new account', async () => {
+    const { service, authIdentities, user } = await make();
+    await service.deleteAccount(user.id);
+    expect(await authIdentities.findByProvider('google', 'g-1')).toBeNull();
+  });
+
+  it('cuts sessions and push devices', async () => {
+    const { service, devices, user } = await make();
+    await service.deleteAccount(user.id);
+    expect(await devices.listForUser(user.id)).toHaveLength(0);
+  });
+
+  it('is idempotent — a retried request does not fail or move deletedAt', async () => {
+    const { service, users, user } = await make();
+    await service.deleteAccount(user.id);
+    const first = (await users.findById(user.id))!.deletedAt;
+
+    expect(await service.deleteAccount(user.id)).toBe(true);
+    expect((await users.findById(user.id))!.deletedAt).toEqual(first);
+  });
+
+  it('reports false for an unknown user', async () => {
+    const { service } = await make();
+    expect(await service.deleteAccount('00000000-0000-4000-8000-000000000000')).toBe(false);
+  });
+});

--- a/services/api/tests/auth-contactability.test.ts
+++ b/services/api/tests/auth-contactability.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import { AuthService } from '../src/modules/auth/auth.service';
+import { InMemoryAuthIdentityRepository } from '../src/modules/auth/auth-identity.repository';
+import { FakeIdTokenVerifier } from '../src/modules/auth/id-token-verifier';
+import { createJwtService, type AuthConfig } from '../src/modules/auth/jwt';
+import { InMemorySessionRepository } from '../src/modules/auth/session.repository';
+import { InMemoryUserRepository } from '../src/modules/users/user.repository';
+
+const authConfig: AuthConfig = {
+  secret: 'test-secret-at-least-32-characters-long-0000',
+  accessTtl: '15m',
+  issuer: 'trotxi',
+  audience: 'trotxi-api',
+};
+
+function makeService(users = new InMemoryUserRepository()) {
+  const service = new AuthService({
+    users,
+    authIdentities: new InMemoryAuthIdentityRepository(),
+    sessions: new InMemorySessionRepository(),
+    jwt: createJwtService(authConfig),
+    verifier: new FakeIdTokenVerifier(),
+    refreshTtlDays: 30,
+  });
+  return { service, users };
+}
+
+const token = (sub: string, email?: string) =>
+  JSON.stringify({ sub, name: 'Ama Boateng', ...(email ? { email } : {}) });
+
+describe('sign-in contactability (#182)', () => {
+  it('persists the verified email instead of discarding it', async () => {
+    const { service } = makeService();
+    const result = await service.signIn(token('g-1', 'ama@example.com'));
+    expect(result.user.email).toBe('ama@example.com');
+  });
+
+  it('reports isNewUser only on the sign-in that created the account', async () => {
+    const { service } = makeService();
+    expect((await service.signIn(token('g-1', 'ama@example.com'))).isNewUser).toBe(true);
+    expect((await service.signIn(token('g-1', 'ama@example.com'))).isNewUser).toBe(false);
+  });
+
+  it('backfills a missing email on a later sign-in', async () => {
+    // Anyone who signed up before this shipped would otherwise stay
+    // permanently uncontactable; they get filled in next time they open the app.
+    const users = new InMemoryUserRepository();
+    const { service } = makeService(users);
+
+    const first = await service.signIn(token('g-2')); // provider sent no email
+    expect(first.user.email).toBeNull();
+
+    const second = await service.signIn(token('g-2', 'kojo@example.com'));
+    expect(second.user.id).toBe(first.user.id);
+    expect(second.user.email).toBe('kojo@example.com');
+  });
+
+  it('never overwrites contact details we already hold', async () => {
+    const users = new InMemoryUserRepository();
+    const { service } = makeService(users);
+
+    const first = await service.signIn(token('g-3', 'original@example.com'));
+    await service.signIn(token('g-3', 'changed@example.com'));
+
+    expect((await users.findById(first.user.id))!.email).toBe('original@example.com');
+  });
+});
+
+describe('backfillContact', () => {
+  it('fills only the missing field and leaves the other alone', async () => {
+    const users = new InMemoryUserRepository();
+    const user = await users.create({ displayName: 'Ama', email: 'ama@example.com' });
+
+    const updated = await users.backfillContact(user.id, {
+      email: 'other@example.com',
+      phone: '+233244123456',
+    });
+
+    expect(updated!.email).toBe('ama@example.com'); // kept
+    expect(updated!.phone).toBe('+233244123456'); // filled
+  });
+});

--- a/services/api/tests/auth.service.test.ts
+++ b/services/api/tests/auth.service.test.ts
@@ -91,6 +91,7 @@ describe('AuthService.signIn', () => {
     const authIdentities: AuthIdentityRepository = {
       findByProvider: async (provider, providerId) =>
         raced ? { id: 'x', userId: winner.id, provider, providerId, createdAt: new Date() } : null,
+      deleteForUser: async () => {},
       create: async () => {
         raced = true; // the "winner" created it between our check and our insert
         throw Object.assign(new Error('duplicate'), { code: '23505' });
@@ -112,6 +113,7 @@ describe('AuthService.signIn', () => {
   it('propagates non-unique errors from identity creation', async () => {
     const authIdentities: AuthIdentityRepository = {
       findByProvider: async () => null,
+      deleteForUser: async () => {},
       create: async () => {
         throw new Error('db down');
       },

--- a/services/api/tests/delete-me.routes.test.ts
+++ b/services/api/tests/delete-me.routes.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import { buildApp } from '../src/app';
+import { AccountDeletionService } from '../src/modules/users/account-deletion.service';
+import {
+  ANONYMISED_DISPLAY_NAME,
+  InMemoryUserRepository,
+} from '../src/modules/users/user.repository';
+import { InMemoryAuthIdentityRepository } from '../src/modules/auth/auth-identity.repository';
+import { InMemorySessionRepository } from '../src/modules/auth/session.repository';
+import { InMemoryDeviceTokenRepository } from '../src/modules/devices/device-token.repository';
+import { FakeObjectStore } from '../src/storage/object-store';
+import { createJwtService, type AuthConfig } from '../src/modules/auth/jwt';
+
+const auth: AuthConfig = {
+  secret: 'test-secret-at-least-32-characters-long-0000',
+  accessTtl: '15m',
+  issuer: 'trotxi',
+  audience: 'trotxi-api',
+};
+const jwt = createJwtService(auth);
+
+async function setup({ wired = true }: { wired?: boolean } = {}) {
+  const users = new InMemoryUserRepository();
+  const objectStore = new FakeObjectStore();
+  const user = await users.create({
+    displayName: 'Ama',
+    email: 'ama@example.com',
+    phone: '+233244123456',
+  });
+
+  const accountDeletion = wired
+    ? new AccountDeletionService({
+        users,
+        sessions: new InMemorySessionRepository(),
+        authIdentities: new InMemoryAuthIdentityRepository(),
+        devices: new InMemoryDeviceTokenRepository(),
+        objectStore,
+      })
+    : undefined;
+
+  const app = await buildApp({ auth, users, objectStore, accountDeletion });
+  const token = await jwt.signAccessToken({ userId: user.id, role: 'commuter' });
+  return { app, users, user, token };
+}
+
+describe('DELETE /me', () => {
+  it('erases the caller and returns 204', async () => {
+    const { app, users, user, token } = await setup();
+
+    const res = await app.inject({
+      method: 'DELETE',
+      url: '/me',
+      headers: { authorization: `Bearer ${token}` },
+    });
+
+    expect(res.statusCode).toBe(204);
+    const after = await users.findById(user.id);
+    expect(after?.displayName).toBe(ANONYMISED_DISPLAY_NAME);
+    expect(after?.email).toBeNull();
+    expect(after?.phone).toBeNull();
+  });
+
+  it('requires authentication', async () => {
+    const { app } = await setup();
+    const res = await app.inject({ method: 'DELETE', url: '/me' });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('is idempotent, so a retry after a timeout still reads as success', async () => {
+    const { app, token } = await setup();
+    const headers = { authorization: `Bearer ${token}` };
+
+    expect((await app.inject({ method: 'DELETE', url: '/me', headers })).statusCode).toBe(204);
+    expect((await app.inject({ method: 'DELETE', url: '/me', headers })).statusCode).toBe(204);
+  });
+
+  it('returns 503 when deletion is not configured, rather than pretending', async () => {
+    const { app, token } = await setup({ wired: false });
+    const res = await app.inject({
+      method: 'DELETE',
+      url: '/me',
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(res.statusCode).toBe(503);
+  });
+});

--- a/services/api/tests/eta-segment-speeds.test.ts
+++ b/services/api/tests/eta-segment-speeds.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ASSUMED_SPEED_KPH,
+  computeEtas,
+  MIN_SAMPLES_FOR_OBSERVED_SPEED,
+  type RouteStopPoint,
+  type SegmentSpeed,
+} from '../src/modules/mobility/eta';
+
+/** Four stops on a straight east-west line, roughly 1 km apart. */
+const STOPS: RouteStopPoint[] = [
+  { stopId: 's0', name: 'Madina', seq: 0, latitude: 5.6, longitude: -0.19 },
+  { stopId: 's1', name: 'Shiashie', seq: 1, latitude: 5.6, longitude: -0.181 },
+  { stopId: 's2', name: '37 Station', seq: 2, latitude: 5.6, longitude: -0.172 },
+  { stopId: 's3', name: 'Circle', seq: 3, latitude: 5.6, longitude: -0.163 },
+];
+
+const AT_START = { latitude: 5.6, longitude: -0.19 };
+
+describe('computeEtas with observed segment speeds (#181)', () => {
+  it('falls back to the cold-start speed when nothing has been observed', () => {
+    // A brand-new corridor still produces an ETA on day one.
+    const withoutSpeeds = computeEtas(AT_START, STOPS);
+    const withEmptySpeeds = computeEtas(AT_START, STOPS, new Map());
+    expect(withEmptySpeeds).toEqual(withoutSpeeds);
+    expect(withoutSpeeds.length).toBe(3);
+  });
+
+  it('uses an observed median where one exists, in place of the constant', () => {
+    const assumedMs = (ASSUMED_SPEED_KPH * 1000) / 3600;
+    // First segment observed at half the assumed speed: rush-hour crawl.
+    const speeds = new Map<number, SegmentSpeed>([
+      [0, { fromSeq: 0, metresPerSecond: assumedMs / 2, sampleCount: 10 }],
+    ]);
+
+    const baseline = computeEtas(AT_START, STOPS)[0]!;
+    const observed = computeEtas(AT_START, STOPS, speeds)[0]!;
+
+    expect(observed.distanceMeters).toBe(baseline.distanceMeters); // distance unchanged
+    expect(observed.etaSeconds).toBeGreaterThan(baseline.etaSeconds * 1.9);
+  });
+
+  it('ignores a median built from too few runs', () => {
+    const speeds = new Map<number, SegmentSpeed>([
+      [
+        0,
+        {
+          fromSeq: 0,
+          metresPerSecond: 0.5, // absurdly slow, would blow up the ETA
+          sampleCount: MIN_SAMPLES_FOR_OBSERVED_SPEED - 1,
+        },
+      ],
+    ]);
+    // One unusual run must not swing a rider's ETA.
+    expect(computeEtas(AT_START, STOPS, speeds)).toEqual(computeEtas(AT_START, STOPS));
+  });
+
+  it('charges each segment its own speed rather than averaging the whole trip', () => {
+    const assumedMs = (ASSUMED_SPEED_KPH * 1000) / 3600;
+    // Slow first leg, fast second: the far stop must reflect both, not a blend
+    // applied uniformly across the distance.
+    const speeds = new Map<number, SegmentSpeed>([
+      [0, { fromSeq: 0, metresPerSecond: assumedMs / 4, sampleCount: 8 }],
+      [1, { fromSeq: 1, metresPerSecond: assumedMs * 2, sampleCount: 8 }],
+    ]);
+
+    const etas = computeEtas(AT_START, STOPS, speeds);
+    const [first, second] = [etas[0]!, etas[1]!];
+
+    // Leg one takes 4x as long as baseline; leg two takes half. The second stop
+    // is therefore only a little later than the first, despite being 2x further.
+    const legOne = first.etaSeconds;
+    const legTwo = second.etaSeconds - first.etaSeconds;
+    expect(legTwo).toBeLessThan(legOne / 4);
+  });
+
+  it('keeps ETAs monotonically increasing along the route', () => {
+    const assumedMs = (ASSUMED_SPEED_KPH * 1000) / 3600;
+    const speeds = new Map<number, SegmentSpeed>([
+      [0, { fromSeq: 0, metresPerSecond: assumedMs * 3, sampleCount: 5 }],
+      [1, { fromSeq: 1, metresPerSecond: assumedMs / 3, sampleCount: 5 }],
+      [2, { fromSeq: 2, metresPerSecond: assumedMs, sampleCount: 5 }],
+    ]);
+    const etas = computeEtas(AT_START, STOPS, speeds);
+    for (let i = 0; i < etas.length - 1; i++) {
+      expect(etas[i + 1]!.etaSeconds).toBeGreaterThan(etas[i]!.etaSeconds);
+    }
+  });
+});

--- a/services/api/tests/payments-phone-capture.test.ts
+++ b/services/api/tests/payments-phone-capture.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+import { InMemoryPaymentRepository } from '../src/modules/payments/payment.repository';
+import { FakePaystackClient, paystackSignature } from '../src/modules/payments/paystack.client';
+import { PaymentsService } from '../src/modules/payments/payments.service';
+import { InMemorySubscriptionRepository } from '../src/modules/subscriptions/subscription.repository';
+import { InMemoryEntitlementLedgerRepository } from '../src/modules/entitlements/entitlement-ledger.repository';
+import { InMemoryUserRepository, type User } from '../src/modules/users/user.repository';
+
+const FAKE_SECRET = 'fake-paystack-secret';
+const FEES = { monthly: 2000, annual: 20000 } as const;
+
+async function make(users = new InMemoryUserRepository()) {
+  const payments = new InMemoryPaymentRepository();
+  const subscriptions = new InMemorySubscriptionRepository();
+  const service = new PaymentsService({
+    payments,
+    subscriptions,
+    entitlements: new InMemoryEntitlementLedgerRepository(),
+    users,
+    paystack: new FakePaystackClient(FAKE_SECRET),
+    subscriptionFees: FEES,
+    ridesPerPeriod: 44,
+  });
+  return { service, payments, subscriptions, users };
+}
+
+/** A charge.success payload carrying the payer's mobile-money number. */
+function chargeSuccess(reference: string, phone?: string, customerPhone?: string) {
+  const body = JSON.stringify({
+    event: 'charge.success',
+    data: {
+      reference,
+      ...(phone ? { authorization: { mobile_money_number: phone } } : {}),
+      ...(customerPhone ? { customer: { phone: customerPhone } } : {}),
+    },
+  });
+  return { body, signature: paystackSignature(body, FAKE_SECRET) };
+}
+
+describe('phone capture on charge.success (#182)', () => {
+  it('stores the payer number, normalised, without asking the rider for it', async () => {
+    const users = new InMemoryUserRepository();
+    const user = await users.create({ displayName: 'Ama' });
+    const { service } = await make(users);
+
+    const { reference } = await service.initializeSubscription(user.id, 'monthly');
+    const { body, signature } = chargeSuccess(reference, '0244123456');
+    await service.handleWebhook(body, signature);
+
+    // A successful mobile-money charge proves control of the handset, so the
+    // number is verified without an OTP round trip.
+    expect((await users.findById(user.id))!.phone).toBe('+233244123456');
+  });
+
+  it('falls back to the customer block when authorization has no number', async () => {
+    const users = new InMemoryUserRepository();
+    const user = await users.create({ displayName: 'Ama' });
+    const { service } = await make(users);
+
+    const { reference } = await service.initializeSubscription(user.id, 'monthly');
+    const { body, signature } = chargeSuccess(reference, undefined, '+233 244 999 888');
+    await service.handleWebhook(body, signature);
+
+    expect((await users.findById(user.id))!.phone).toBe('+233244999888');
+  });
+
+  it('never overwrites a number the rider already set', async () => {
+    const users = new InMemoryUserRepository();
+    const user = await users.create({ displayName: 'Ama', phone: '+233201111111' });
+    const { service } = await make(users);
+
+    const { reference } = await service.initializeSubscription(user.id, 'monthly');
+    const { body, signature } = chargeSuccess(reference, '0244123456');
+    await service.handleWebhook(body, signature);
+
+    expect((await users.findById(user.id))!.phone).toBe('+233201111111');
+  });
+
+  it('still activates the subscription when the phone write blows up', async () => {
+    // users.phone is UNIQUE and two family members can legitimately pay from one
+    // handset. If that collision failed the webhook, Paystack would retry and we
+    // would lose the activation over a phone number.
+    const users = new InMemoryUserRepository();
+    const user = await users.create({ displayName: 'Ama' });
+    const exploding = Object.assign(Object.create(Object.getPrototypeOf(users)), users, {
+      backfillContact: async (): Promise<User | null> => {
+        throw Object.assign(new Error('duplicate key'), { code: '23505' });
+      },
+    }) as InMemoryUserRepository;
+
+    const { service, subscriptions, payments } = await make(exploding);
+    const { reference } = await service.initializeSubscription(user.id, 'monthly');
+    const { body, signature } = chargeSuccess(reference, '0244123456');
+
+    await expect(service.handleWebhook(body, signature)).resolves.toBeUndefined();
+    expect(await subscriptions.findActiveByUser(user.id)).not.toBeNull();
+    expect((await payments.findByReference(reference))?.status).toBe('paid');
+  });
+
+  it('ignores an unusable number rather than storing a guess', async () => {
+    const users = new InMemoryUserRepository();
+    const user = await users.create({ displayName: 'Ama' });
+    const { service } = await make(users);
+
+    const { reference } = await service.initializeSubscription(user.id, 'monthly');
+    const { body, signature } = chargeSuccess(reference, 'not-a-number');
+    await service.handleWebhook(body, signature);
+
+    expect((await users.findById(user.id))!.phone).toBeNull();
+  });
+});

--- a/services/api/tests/payments.routes.test.ts
+++ b/services/api/tests/payments.routes.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { buildApp } from '../src/app';
 import { InMemoryPaymentRepository } from '../src/modules/payments/payment.repository';
 import { FakePaystackClient, paystackSignature } from '../src/modules/payments/paystack.client';
+import { InMemoryUserRepository } from '../src/modules/users/user.repository';
 import { PaymentsService } from '../src/modules/payments/payments.service';
 import { InMemorySubscriptionRepository } from '../src/modules/subscriptions/subscription.repository';
 import { InMemoryEntitlementLedgerRepository } from '../src/modules/entitlements/entitlement-ledger.repository';
@@ -25,6 +26,7 @@ function appWithPayments() {
     subscriptions,
     entitlements,
     paystack: new FakePaystackClient(FAKE_SECRET),
+    users: new InMemoryUserRepository(),
     subscriptionFees: { monthly: 2000, annual: 20000 },
     ridesPerPeriod: 44,
   });

--- a/services/api/tests/payments.service.test.ts
+++ b/services/api/tests/payments.service.test.ts
@@ -11,6 +11,7 @@ import {
   type SubscriptionRepository,
 } from '../src/modules/subscriptions/subscription.repository';
 import { InMemoryEntitlementLedgerRepository } from '../src/modules/entitlements/entitlement-ledger.repository';
+import { InMemoryUserRepository } from '../src/modules/users/user.repository';
 
 const FAKE_SECRET = 'fake-paystack-secret';
 const subscriptionFees = { monthly: 2000, annual: 20000 }; // pesewas (GHS 20 / 200)
@@ -24,6 +25,7 @@ function make(subscriptions: SubscriptionRepository = new InMemorySubscriptionRe
     subscriptions,
     entitlements,
     paystack: new FakePaystackClient(FAKE_SECRET),
+    users: new InMemoryUserRepository(),
     subscriptionFees,
     ridesPerPeriod: RIDES,
   });
@@ -53,6 +55,7 @@ describe('PaymentsService.initializeSubscription', () => {
       payments: new InMemoryPaymentRepository(),
       subscriptions: new InMemorySubscriptionRepository(),
       entitlements: new InMemoryEntitlementLedgerRepository(),
+      users: new InMemoryUserRepository(),
       subscriptionFees,
       ridesPerPeriod: RIDES,
     });

--- a/services/api/tests/phone.test.ts
+++ b/services/api/tests/phone.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { normaliseGhanaPhone } from '../src/lib/phone';
+
+describe('normaliseGhanaPhone', () => {
+  // The whole reason this exists: users.phone is UNIQUE, and Paystack returns
+  // the same handset in whichever shape the payer typed. Without normalisation
+  // one person occupies three rows, or collides with themselves.
+  it('resolves every shape of one number to a single value', () => {
+    const expected = '+233244123456';
+    for (const raw of [
+      '0244123456',
+      '244123456',
+      '233244123456',
+      '+233244123456',
+      '+233 244 123 456',
+      '(024) 412-3456',
+      '  0244123456  ',
+    ]) {
+      expect(normaliseGhanaPhone(raw), raw).toBe(expected);
+    }
+  });
+
+  it('passes through an explicitly international number rather than forcing +233', () => {
+    expect(normaliseGhanaPhone('+2348012345678')).toBe('+2348012345678');
+  });
+
+  it('returns null for input it cannot recognise, so callers skip the write', () => {
+    for (const raw of [null, undefined, '', '   ', 'not a phone', '12', '0244']) {
+      expect(normaliseGhanaPhone(raw), String(raw)).toBeNull();
+    }
+  });
+});

--- a/services/api/tests/route-geometry.test.ts
+++ b/services/api/tests/route-geometry.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+import {
+  cleanTrace,
+  deriveRouteGeometry,
+  resampleByDistance,
+  stopDistancesAlong,
+  type Trace,
+} from '../src/modules/mobility/route-geometry';
+import { haversineMeters, type LatLng } from '../src/modules/mobility/eta';
+
+/** A straight west-to-east run through Accra, one fix roughly every 40 m. */
+function straightRun(count: number, jitter = 0): LatLng[] {
+  const points: LatLng[] = [];
+  for (let i = 0; i < count; i++) {
+    points.push({
+      latitude: 5.6 + (i % 2 === 0 ? jitter : -jitter),
+      longitude: -0.19 + i * 0.0004,
+    });
+  }
+  return points;
+}
+
+describe('cleanTrace', () => {
+  it('drops near-duplicate fixes from a stationary bus', () => {
+    const parked: LatLng[] = Array.from({ length: 10 }, () => ({
+      latitude: 5.6,
+      longitude: -0.19,
+    }));
+    // Ten fixes at one spot describe a bus at a stop, not a route.
+    expect(cleanTrace(parked)).toHaveLength(1);
+  });
+
+  it('drops implausible jumps rather than bending the route through them', () => {
+    const withGlitch: LatLng[] = [
+      { latitude: 5.6, longitude: -0.19 },
+      { latitude: 5.6, longitude: -0.1894 }, // ~66 m, real movement
+      { latitude: 9.4, longitude: -0.85 }, // Tamale — a bad fix
+      { latitude: 5.6, longitude: -0.1888 },
+    ];
+    const cleaned = cleanTrace(withGlitch);
+    expect(cleaned).toHaveLength(3);
+    expect(cleaned.some((p) => p.latitude > 6)).toBe(false);
+  });
+});
+
+describe('resampleByDistance', () => {
+  it('produces the requested number of evenly spaced vertices', () => {
+    const sampled = resampleByDistance(straightRun(50), 10);
+    expect(sampled).toHaveLength(10);
+
+    const gaps: number[] = [];
+    for (let i = 0; i < sampled.length - 1; i++) {
+      gaps.push(haversineMeters(sampled[i]!, sampled[i + 1]!));
+    }
+    const mean = gaps.reduce((a, b) => a + b, 0) / gaps.length;
+    for (const gap of gaps) expect(Math.abs(gap - mean)).toBeLessThan(1);
+  });
+
+  it('returns nothing for a trace with no length', () => {
+    expect(resampleByDistance([{ latitude: 5.6, longitude: -0.19 }], 10)).toEqual([]);
+    expect(resampleByDistance([], 10)).toEqual([]);
+  });
+});
+
+describe('deriveRouteGeometry', () => {
+  it('uses a single run immediately, so a new corridor is usable on day one', () => {
+    const result = deriveRouteGeometry([{ tripId: 't1', points: straightRun(40) }], 20);
+    expect(result).not.toBeNull();
+    expect(result!.runCount).toBe(1);
+    expect(result!.source).toBe('traces');
+    expect(result!.points).toHaveLength(20);
+  });
+
+  it('takes the median so one wrong turn does not redefine the corridor', () => {
+    const normal = (): LatLng[] => straightRun(40);
+    // One driver detours a long way north for the middle of the run.
+    const detour = straightRun(40).map((p, i) =>
+      i > 15 && i < 25 ? { ...p, latitude: p.latitude + 0.02 } : p,
+    );
+    const traces: Trace[] = [
+      { tripId: 'a', points: normal() },
+      { tripId: 'b', points: normal() },
+      { tripId: 'c', points: detour },
+      { tripId: 'd', points: normal() },
+      { tripId: 'e', points: normal() },
+    ];
+
+    const result = deriveRouteGeometry(traces, 40)!;
+    expect(result.runCount).toBe(5);
+    // The detour reached +0.02 lat; the median should stay on the normal line.
+    const maxLat = Math.max(...result.points.map((p) => p.latitude));
+    expect(maxLat).toBeLessThan(5.605);
+  });
+
+  it('considers only the five most recent runs', () => {
+    const traces: Trace[] = Array.from({ length: 9 }, (_, i) => ({
+      tripId: `t${i}`,
+      points: straightRun(40),
+    }));
+    expect(deriveRouteGeometry(traces, 20)!.runCount).toBe(5);
+  });
+
+  it('returns null when no run carries enough signal', () => {
+    // A bus that never moved leaves one vertex after cleaning — no geometry.
+    const parked: LatLng[] = Array.from({ length: 20 }, () => ({
+      latitude: 5.6,
+      longitude: -0.19,
+    }));
+    expect(deriveRouteGeometry([{ tripId: 't', points: parked }], 20)).toBeNull();
+    expect(deriveRouteGeometry([], 20)).toBeNull();
+  });
+});
+
+describe('stopDistancesAlong', () => {
+  it('reports increasing distance for stops in route order', () => {
+    const path = straightRun(40);
+    const stops = [path[0]!, path[13]!, path[26]!, path[39]!];
+    const distances = stopDistancesAlong(path, stops);
+
+    expect(distances[0]).toBe(0);
+    for (let i = 0; i < distances.length - 1; i++) {
+      expect(distances[i + 1]!).toBeGreaterThan(distances[i]!);
+    }
+  });
+});


### PR DESCRIPTION
Clears the CTO backlog in one pass. **Closes #182, #183, #184, #154, #30.** Lays the schema and pure logic for **#179** and **#181**.

Apple sign-in (#168) excluded as requested.

## #182 — persist email and phone

We could not contact a single user, and were discarding the means to on every signup and every payment.

- **Email** was returned by the verifier and dropped on the floor. Now persisted, and **backfilled on later sign-ins** so people who signed up before this ships become reachable rather than staying permanently lost.
- **Phone** comes from the Paystack `charge.success` webhook. A successful mobile-money charge proves control of the handset, so it is verified without an OTP screen. **E.164 normalised** because `users.phone` is `UNIQUE` and Paystack returns `0244…`, `233244…` and `+233244…` for one number.
- **The capture is best effort by design.** Two family members can legitimately pay from one handset; that collision must not 500 a webhook whose retry would re-run subscription activation. There is a test for exactly this.
- `signIn` now reports `isNewUser`.

`email` is deliberately **not** unique: one person can hold Google and Apple identities on one address, and provider identity is the account key.

## #30 — account deletion

**Anonymises, does not delete.** `payments`, `entitlement_ledger` and `credit_ledger` all cascade off `users`, so `DELETE FROM users` would destroy the financial record of what someone paid and was charged. Those are our books; they outlive a deletion request, the person behind them does not.

Order matters and is commented in the service: cut sessions and devices first so an in-flight app cannot keep acting as the account, remove provider links so a returning person signs up fresh, delete the avatar from object storage (the only PII outside Postgres), then clear the columns keeping the row and its id.

`DELETE /me`, idempotent, 503 when unconfigured.

## #183 — the missing trip_id foreign keys

`ON DELETE SET NULL`, not `CASCADE`: a reservation is the rider's record and the ledger references it, so a deleted trip must not erase it. Orphans are nulled first with **counts reported**, not silently.

## #184 — migration prefix guard

Renaming the duplicate `016` files would be the wrong fix: `_migrations` is keyed by filename, so a rename makes the runner re-apply them everywhere. CI now fails on **new** duplicates; the existing pair is grandfathered with a comment so the next reader knows it was a decision.

## #154 — atomic increment + 429 telemetry

`INCR` then `EXPIRE` across two round trips left the key with **no TTL** if the connection dropped: the counter climbed forever, `count === 1` never recurred, and that rider was permanently 429'd with nothing in the logs. Now one Lua eval. Fixed-window semantics unchanged.

Adds `rate_limited_total{route,bucket}`. The existing histogram's `status_code` already counts 429s but cannot say whether the limit fired on `ip` or `user` — and with carrier-grade NAT in Ghana that is the difference between one abuser and a whole neighbourhood behind one address.

## #179 / #181 — geospatial foundations

Schema and pure, testable logic. Per `strategy/docs/geospatial.md`.

- `routes.geometry` + `route_stops.distance_m`. Derivation resamples each run by distance travelled (two drivers' nth fix is in different places), then takes the **median of the last five runs** so one wrong turn cannot redefine a corridor. One run is used immediately so a new corridor works on day one.
- `segment_speeds` and `computeEtas` now charge each segment its own observed speed, falling back to the flat 20 km/h per segment where we have fewer than 3 observations. **Backward compatible** — the parameter is optional and all 325 pre-existing tests pass untouched.

## Verification

- Full gates green. Coverage **93.43% → 93.88%**.
- **Migrations executed for real** against local Postgres, twice, with seeded orphan rows. Second pass is a clean no-op. Confirmed the FK rejects a bad reference and that deleting a trip nulls the reservation rather than deleting it.
- Guard verified by adding a decoy duplicate and watching CI fail, then removing it.

**Caveat:** PostGIS is not installed on my machine and Docker was not running, so `024_route_geometry.sql` (the only migration needing PostGIS types) was **not** executed locally — the other four were. CI's `migrations` job runs all of them against `postgis/postgis:16-3.4`, so that is the real check.

## What is not here

- **#178** (basemap tiles) needs a 109 MB download, planetiler and your Cloudflare credentials. Not PR-able.
- **The jobs that populate** `routes.geometry` and `segment_speeds`. This PR ships the schema and the pure functions with tests; the repository wiring and the scheduled job are a natural follow-up now the contracts are fixed.
- **#103/#104/#105** remain blocked on pricing, which is a product decision.