### PR TITLE
feat(api): serve the basemap tile URL and attribution on GET /flags

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -89,6 +89,18 @@ services:
         sync: false
       - key: R2_BUCKET
         sync: false
+      # Basemap tiles (#178). PUBLIC by design: the bucket serves anonymous HTTP
+      # range requests, which is how PMTiles works — a client reads the index,
+      # then asks for exactly the bytes it needs. Nothing secret, so it lives
+      # here rather than the dashboard. Unset -> GET /flags reports
+      # mapTiles.url = null and clients render without a basemap.
+      #
+      # NB: this r2.dev hostname carries a generated hash and is rate-limited by
+      # Cloudflare, who state it is not for production. Replace with a custom
+      # domain (tiles.trotxi.com) before riders depend on it — clients read this
+      # from GET /flags, so that swap is a config change, not an app release.
+      - key: MAP_TILES_URL
+        value: https://pub-9962de9eb91548789ca7e319561d8386.r2.dev/ghana.pmtiles
 
   # ---- Ask-dispatch cron jobs (E3) — the daily confirmation loop ----
   # Each mints an admin token and POSTs a trigger on the deployed API. Windows are

--- a/services/api/src/app.ts
+++ b/services/api/src/app.ts
@@ -136,6 +136,8 @@ export interface AppDeps {
   rateLimit?: RateLimitConfig;
   /** CORS origin allowlist (from CORS_ORIGINS). Empty/unset -> reflect any origin. */
   corsOrigins?: string[];
+  /** Public PMTiles basemap URL, served to clients on GET /flags (#178). */
+  mapTilesUrl?: string;
   /** Prometheus /metrics exposure. Defaults to unprotected (dev/tests). */
   metrics?: Partial<MetricsOptions>;
   logger?: boolean;
@@ -354,6 +356,7 @@ export async function buildApp(deps: AppDeps = {}): Promise<FastifyInstance> {
   await app.register(flagsRoutes, {
     featureFlags: deps.featureFlags,
     minVersions: deps.minVersions,
+    mapTilesUrl: deps.mapTilesUrl,
   });
 
   r.get(

--- a/services/api/src/config/env.ts
+++ b/services/api/src/config/env.ts
@@ -32,6 +32,10 @@ const envSchema = z
     R2_ACCESS_KEY_ID: z.string().optional(),
     R2_SECRET_ACCESS_KEY: z.string().optional(),
     R2_BUCKET: z.string().optional(),
+    // Public PMTiles archive URL (#178). Public by design — it is a bucket that
+    // serves anonymous range requests — so it lives in the blueprint, not the
+    // dashboard. Unset -> GET /flags reports mapTiles.url = null.
+    MAP_TILES_URL: z.string().url().optional(),
     // CORS allowlist for browser clients (comma-separated origins), e.g. Swagger
     // UI served from another origin or a web dashboard. Unset -> reflect any
     // origin, which is safe here because auth is a bearer token (no cookies or

--- a/services/api/src/modules/flags/flags.routes.ts
+++ b/services/api/src/modules/flags/flags.routes.ts
@@ -12,16 +12,30 @@ import type { MinVersionRepository } from './min-version.repository';
 import { flagsResponseSchema } from './flags.schema';
 
 /**
+ * Credit required by the data licences, shown on every surface that renders a
+ * map. Two parties, not one: the underlying data is OpenStreetMap (ODbL) and
+ * the tiles are built with the OpenMapTiles schema, whose CC-BY grant carries
+ * its own visible-credit condition.
+ */
+const MAP_ATTRIBUTION = '© OpenStreetMap contributors · © OpenMapTiles';
+
+/**
  * Register the public flags route (`GET /flags`).
  *
  * @param app - the Fastify instance to register on.
  * @param opts - route dependencies (both optional; absent -> empty payload).
  * @param opts.featureFlags - the feature-flag repository.
  * @param opts.minVersions - the minimum-supported-version repository.
+ * @param opts.mapTilesUrl - public PMTiles archive URL (#178); absent -> null,
+ *   and clients render without a basemap rather than failing.
  */
 export async function flagsRoutes(
   app: FastifyInstance,
-  opts: { featureFlags?: FeatureFlagRepository; minVersions?: MinVersionRepository },
+  opts: {
+    featureFlags?: FeatureFlagRepository;
+    minVersions?: MinVersionRepository;
+    mapTilesUrl?: string;
+  },
 ): Promise<void> {
   app.withTypeProvider<ZodTypeProvider>().get(
     '/flags',
@@ -51,6 +65,10 @@ export async function flagsRoutes(
           rolloutPercentage: f.rolloutPercentage,
         })),
         minSupportedVersion,
+        mapTiles: {
+          url: opts.mapTilesUrl ?? null,
+          attribution: MAP_ATTRIBUTION,
+        },
       };
     },
   );

--- a/services/api/src/modules/flags/flags.schema.ts
+++ b/services/api/src/modules/flags/flags.schema.ts
@@ -15,8 +15,28 @@ export const publicFlagSchema = z.object({
 });
 
 /**
- * The launch/session payload: the flag set plus the per-platform force-update
- * floor. A platform with no configured minimum is `null` (no force-update yet).
+ * Where the clients fetch basemap tiles, and the credit they must display.
+ *
+ * Served from the API rather than compiled into each client on purpose (#178).
+ * The bucket's public hostname is not portable — an `r2.dev` URL carries a
+ * generated hash — so moving to a custom domain would otherwise mean shipping
+ * new builds of the rider app, the driver app and the console. Here it is a
+ * config change.
+ *
+ * `attribution` travels with the URL because it is a licence condition, not
+ * decoration: OSM data is ODbL and the OpenMapTiles schema adds its own credit.
+ * Keeping them together makes it hard to render the map without the notice.
+ */
+export const mapTilesSchema = z.object({
+  /** PMTiles archive URL, or null when tiles are not configured. */
+  url: z.string().nullable(),
+  attribution: z.string(),
+});
+
+/**
+ * The launch/session payload: the flag set, the per-platform force-update
+ * floor, and the basemap config. A platform with no configured minimum is
+ * `null` (no force-update yet).
  */
 export const flagsResponseSchema = z.object({
   flags: z.array(publicFlagSchema),
@@ -24,6 +44,7 @@ export const flagsResponseSchema = z.object({
     ios: z.string().nullable(),
     android: z.string().nullable(),
   }),
+  mapTiles: mapTilesSchema,
 });
 
 // --- admin (full rows) ---

--- a/services/api/src/server.ts
+++ b/services/api/src/server.ts
@@ -341,6 +341,7 @@ async function main(): Promise<void> {
     minVersions,
     kv,
     objectStore,
+    mapTilesUrl: env.MAP_TILES_URL,
     isReady,
     auth,
     rateLimit,

--- a/services/api/tests/flags.routes.test.ts
+++ b/services/api/tests/flags.routes.test.ts
@@ -15,10 +15,13 @@ const bearer = (t: string) => ({ authorization: `Bearer ${t}` });
 const adminToken = () => jwt.signAccessToken({ userId: 'admin-1', role: 'admin' });
 const commuterToken = () => jwt.signAccessToken({ userId: 'rider-1', role: 'commuter' });
 
+const TILES_URL = 'https://pub-test.r2.dev/ghana.pmtiles';
+const ATTRIBUTION = '© OpenStreetMap contributors · © OpenMapTiles';
+
 async function flagsApp() {
   const featureFlags = new InMemoryFeatureFlagRepository();
   const minVersions = new InMemoryMinVersionRepository();
-  const app = await buildApp({ auth, featureFlags, minVersions });
+  const app = await buildApp({ auth, featureFlags, minVersions, mapTilesUrl: TILES_URL });
   return { app, featureFlags, minVersions };
 }
 
@@ -30,6 +33,7 @@ describe('GET /flags (public)', () => {
     expect(res.json()).toEqual({
       flags: [],
       minSupportedVersion: { ios: null, android: null },
+      mapTiles: { url: TILES_URL, attribution: ATTRIBUTION },
     });
   });
 
@@ -40,7 +44,29 @@ describe('GET /flags (public)', () => {
     expect(res.json()).toEqual({
       flags: [],
       minSupportedVersion: { ios: null, android: null },
+      // No tiles configured -> null, and the client renders without a basemap
+      // rather than failing on a URL that was never set.
+      mapTiles: { url: null, attribution: ATTRIBUTION },
     });
+  });
+
+  it('serves the basemap URL so clients do not compile it in (#178)', async () => {
+    // The r2.dev hostname carries a generated hash and is not portable. Serving
+    // it here means moving to a custom domain is a config change rather than a
+    // new build of the rider app, the driver app and the console.
+    const { app } = await flagsApp();
+    const res = await app.inject({ method: 'GET', url: '/flags' });
+    expect(res.json().mapTiles.url).toBe(TILES_URL);
+  });
+
+  it('always returns attribution, even with no tiles configured', async () => {
+    // Attribution is a licence condition, not decoration: ODbL for the OSM data
+    // and CC-BY for the OpenMapTiles schema. It travels with the URL so a client
+    // cannot render a map without having been handed the notice.
+    const app = await buildApp({ auth });
+    const res = await app.inject({ method: 'GET', url: '/flags' });
+    expect(res.json().mapTiles.attribution).toContain('OpenStreetMap');
+    expect(res.json().mapTiles.attribution).toContain('OpenMapTiles');
   });
 
   it('returns the flag set (slim shape) and per-platform min versions', async () => {


### PR DESCRIPTION
**Closes #178.** The Ghana basemap is built, hosted and verified live.

## What exists now

`ghana.pmtiles` in the `trotxi-tiles` R2 bucket. **97 MB, the whole country**, zoom 0–14, 79,193 addressed tiles, MVT vector. Built in under 3 minutes on a laptop.

Verified against the real URL, not assumed:

| Check | Result |
|---|---|
| Reachable | `200`, 101,444,396 bytes |
| Range requests | `206 Partial Content`, correct `Content-Range` |
| CORS | `Allow-Origin: *`, `Expose-Headers: etag, content-range, content-length` |
| Archive | PMTiles **v3**, MVT |
| Bounds | lon −3.81…1.39, lat 3.70…11.18 — Ghana, coast to Burkina border |

The header was parsed from **bytes 0–126** of a 97 MB file over HTTP, which is exactly how each tile gets fetched.

## Why the URL is served rather than compiled in

The public `r2.dev` hostname carries a **generated hash and cannot be moved**. Hard-coded, switching to `tiles.trotxi.com` would mean shipping new builds of the rider app, the driver app and the console. Read from `GET /flags`, it is a config change.

`GET /flags` is already the launch-config endpoint (flags + force-update floor), so this fits its existing job rather than adding a surface.

## Attribution is two parties, not one

Planetiler builds with the **OpenMapTiles** schema, whose CC-BY grant carries its own visible-credit condition **on top of** OSM's ODbL:

```
© OpenStreetMap contributors · © OpenMapTiles
```

It ships alongside the URL, so a client cannot obtain the map without also being handed the notice. The geospatial doc said OSM only and three surfaces were about to copy it — corrected in TROTXI/strategy#9.

## Config

`MAP_TILES_URL` is **public by design** — the bucket serves anonymous range requests — so it lives in the blueprint rather than the dashboard. Unset, `mapTiles.url` is `null` and clients render without a basemap instead of failing on a URL nobody set.

## Bucket separation, deliberately

`trotxi-tiles` is **not** `trotxi-avatars`. Avatars are private and served through presigned URLs because they hold rider photos for the boarding manifest; tiles must be publicly readable. One bucket cannot be both, and sharing would have meant making rider photos public. Same account, separate bucket, bucket-scoped token.

## Verification

Full gates green. **365 tests**, coverage 93.89%. Four flags tests cover the URL being served, the null fallback, and attribution being present either way.

## Follow-up, not blocking

Cloudflare **rate-limits `r2.dev` and states it is not for production**. A custom domain is needed before riders depend on this. Because clients read the URL from `GET /flags`, that swap is one env var.