### PR TITLE
feat(api): learn route geometry and segment speeds from our own GPS traces

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -211,6 +211,27 @@ services:
   #   staticPublishPath: apps/ops/dist
   #   autoDeploy: false
 
+  # ---- Route learning (E4/#179/#181) — the corridor teaches us its own shape ----
+  # Reads back completed runs' GPS traces and updates each route's derived path
+  # and its observed per-segment speeds. Nightly and deliberately after the
+  # evening no-show sweep (20:00), so the day's runs are settled before we learn
+  # from them. Slow background improvement with no deadline — kept separate from
+  # the ask-dispatch crons, whose timing is critical to the rider loop.
+  - type: cron
+    name: trotxi-route-learning-staging
+    runtime: docker
+    repo: https://github.com/TROTXI/mobility-core
+    branch: main
+    dockerfilePath: services/api/Dockerfile
+    dockerContext: .
+    plan: free
+    region: frankfurt
+    autoDeploy: false
+    schedule: '0 23 * * *' # 23:00 — after the evening sweep, before the next day
+    dockerCommand: node dist/cron/route-learning-cron.js
+    envVars:
+      - fromGroup: trotxi-cron-staging
+
   # ---- Production (uncomment when going live) ----
   # Needs a paid Postgres plan so data doesn't expire. After applying, set the
   # RENDER_PRODUCTION_SERVICE_ID + PRODUCTION_URL GitHub variables to activate

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "dev": "tsx watch src/server.ts",
     "start": "node --import ./dist/observability/tracing.live.js dist/server.js",
-    "build": "tsup src/server.ts src/observability/tracing.live.ts src/cron/ask-dispatch-cron.ts --format esm --clean",
+    "build": "tsup src/server.ts src/observability/tracing.live.ts src/cron/ask-dispatch-cron.ts src/cron/route-learning-cron.ts --format esm --clean",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",

--- a/services/api/src/app.ts
+++ b/services/api/src/app.ts
@@ -12,6 +12,9 @@ import { z } from 'zod';
 import { InMemoryKvStore, type KvStore } from './kv/kv.store';
 import { FakeObjectStore, type ObjectStore } from './storage/object-store';
 import type { AccountDeletionService } from './modules/users/account-deletion.service';
+import type { RouteLearningService } from './modules/mobility/route-learning.service';
+import { routeLearningRoutes } from './modules/mobility/route-learning.routes';
+import type { SegmentSpeedRepository } from './modules/mobility/segment-speed.repository';
 import { userRoutes } from './modules/users/users.routes';
 import {
   InMemoryDeviceTokenRepository,
@@ -138,6 +141,10 @@ export interface AppDeps {
   corsOrigins?: string[];
   /** Public PMTiles basemap URL, served to clients on GET /flags (#178). */
   mapTilesUrl?: string;
+  /** Observed segment speeds (#181). Absent -> ETAs use the cold-start speed. */
+  segmentSpeeds?: SegmentSpeedRepository;
+  /** Derives geometry + speeds from completed runs (#179, #181). */
+  routeLearning?: RouteLearningService;
   /** Prometheus /metrics exposure. Defaults to unprotected (dev/tests). */
   metrics?: Partial<MetricsOptions>;
   logger?: boolean;
@@ -338,7 +345,12 @@ export async function buildApp(deps: AppDeps = {}): Promise<FastifyInstance> {
     routeStops: deps.routeStops,
     stops: deps.stops,
     tripPositions: deps.tripPositions ?? new InMemoryTripPositionRepository(),
+    segmentSpeeds: deps.segmentSpeeds,
     kv,
+    rateLimit: deps.rateLimit ?? DEFAULT_RATE_LIMIT,
+  });
+  await app.register(routeLearningRoutes, {
+    routeLearning: deps.routeLearning,
     rateLimit: deps.rateLimit ?? DEFAULT_RATE_LIMIT,
   });
   await app.register(adminRoutes, {

--- a/services/api/src/cron/route-learning-cron.ts
+++ b/services/api/src/cron/route-learning-cron.ts
@@ -1,0 +1,69 @@
+// Route-learning cron entrypoint (#179, #181). A Render cron runs this nightly:
+// it mints a short-lived admin token from JWT_SECRET (auth is stateless — no
+// user row needed) and POSTs the deployed API's learning trigger, which reads
+// back the day's completed runs and updates each corridor's derived path and
+// observed segment speeds.
+//
+// Deliberately separate from ask-dispatch-cron: that one is the daily rider
+// loop and its actions are time-critical to the minute (ask at 18:00, cut off
+// at 21:00). This is a slow background improvement with no deadline, and a
+// failure here must never be confused with a failure to ask riders about
+// tomorrow.
+//
+// Safe to re-run: geometry is overwritten rather than appended and speeds are
+// replaced per direction, so repeated passes converge instead of compounding.
+
+import { createJwtService, type AuthConfig } from '../modules/auth/jwt';
+
+interface LearnResult {
+  routeId: string;
+  runsUsed: number;
+  geometryUpdated: boolean;
+  segmentsLearned: { morning: number; evening: number };
+}
+
+async function main(): Promise<void> {
+  const secret = process.env.JWT_SECRET;
+  const baseUrl = process.env.API_BASE_URL;
+  if (!secret) throw new Error('JWT_SECRET is required');
+  if (!baseUrl) throw new Error('API_BASE_URL is required');
+
+  const auth: AuthConfig = {
+    secret,
+    accessTtl: '5m',
+    issuer: process.env.JWT_ISSUER ?? 'trotxi',
+    audience: process.env.JWT_AUDIENCE ?? 'trotxi-api',
+  };
+  const token = await createJwtService(auth).signAccessToken({
+    userId: 'cron-route-learning',
+    role: 'admin',
+  });
+
+  const url = `${baseUrl.replace(/\/$/, '')}/admin/learn-routes`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+    // No routeId — learn every corridor that has completed runs.
+    body: JSON.stringify({}),
+  });
+  const body = await res.text();
+  if (!res.ok) {
+    throw new Error(`route learning -> HTTP ${res.status}: ${body}`);
+  }
+
+  // Log per route rather than a bare 200: "learned 3 routes" hides a corridor
+  // that silently found no usable traces for a week.
+  const parsed = JSON.parse(body) as { routes: LearnResult[] };
+  for (const r of parsed.routes) {
+    console.log(
+      `route-learning: ${r.routeId} runs=${r.runsUsed} geometry=${r.geometryUpdated} ` +
+        `segments=${r.segmentsLearned.morning}m/${r.segmentsLearned.evening}e`,
+    );
+  }
+  console.log(`route-learning: ${parsed.routes.length} route(s) processed`);
+}
+
+main().catch((err: unknown) => {
+  console.error('route learning cron failed:', err);
+  process.exit(1);
+});

--- a/services/api/src/modules/mobility/direction.ts
+++ b/services/api/src/modules/mobility/direction.ts
@@ -1,0 +1,27 @@
+// Which service window a trip belongs to (#181, E3/E4).
+//
+// Extracted from ask-dispatch.service.ts, which had this as a private helper
+// with the note "converges when trips carry an explicit direction". A second
+// copy in the ETA path would be exactly the drift that comment anticipates:
+// two definitions of "morning" that agree until one is fixed and the other is
+// not, with the disagreement showing up as riders being asked about one run and
+// charged for another.
+//
+// Ghana runs on UTC (GMT+0), so no offset is applied.
+
+/** A service window. Mirrors the direction CHECK on reservations. */
+export type ServiceWindow = 'morning' | 'evening';
+
+/**
+ * A trip's service window, from its scheduled time.
+ *
+ * Pilot heuristic: before noon is the morning run, otherwise the evening one.
+ * Correct while each corridor runs once each way per day; replace this — in one
+ * place — when trips carry an explicit direction.
+ *
+ * @param scheduledAt - the trip's scheduled departure.
+ * @returns the service window the trip belongs to.
+ */
+export function directionOf(scheduledAt: Date): ServiceWindow {
+  return scheduledAt.getUTCHours() < 12 ? 'morning' : 'evening';
+}

--- a/services/api/src/modules/mobility/positions.routes.ts
+++ b/services/api/src/modules/mobility/positions.routes.ts
@@ -17,7 +17,9 @@ import type { KvStore } from '../../kv/kv.store';
 import { errorResponseSchema } from '../../lib/schemas';
 import type { RateLimitConfig } from '../ratelimit/ratelimit.plugin';
 import type { DriverRepository } from './driver.repository';
+import { directionOf } from './direction';
 import { computeEtas, type RouteStopPoint } from './eta';
+import type { SegmentSpeedRepository } from './segment-speed.repository';
 import {
   livePositionResponseSchema,
   recordedPositionResponseSchema,
@@ -49,6 +51,7 @@ const cacheKey = (tripId: string): string => `trip:position:${tripId}`;
  * @param opts.routeStops - the route's ordered stop placements (for ETA).
  * @param opts.stops - stop coordinates (for ETA).
  * @param opts.tripPositions - durable fix store (source of truth).
+ * @param opts.segmentSpeeds - observed segment speeds (#181); absent -> cold-start speed.
  * @param opts.kv - latest-fix cache (Redis when available).
  * @param opts.rateLimit - per-user rate-limit config.
  */
@@ -60,6 +63,8 @@ export async function positionRoutes(
     routeStops?: RouteStopRepository;
     stops?: StopRepository;
     tripPositions?: TripPositionRepository;
+    /** Observed segment speeds (#181). Absent -> ETAs use the cold-start speed. */
+    segmentSpeeds?: SegmentSpeedRepository;
     kv: KvStore;
     rateLimit: RateLimitConfig;
   },
@@ -184,10 +189,17 @@ export async function positionRoutes(
         )
       ).filter((s): s is RouteStopPoint => s !== null);
 
+      // Observed medians where we have them, cold-start speed everywhere else.
+      // Optional on purpose: a corridor with no run history still returns an
+      // ETA on its first day rather than nothing at all.
+      const speeds = opts.segmentSpeeds
+        ? await opts.segmentSpeeds.findByRoute(trip.routeId, directionOf(trip.scheduledAt))
+        : undefined;
+
       return {
         tripId: trip.id,
         position,
-        etaToStops: computeEtas(position, stopPoints),
+        etaToStops: computeEtas(position, stopPoints, speeds),
       };
     },
   );

--- a/services/api/src/modules/mobility/route-geometry.repository.pg.ts
+++ b/services/api/src/modules/mobility/route-geometry.repository.pg.ts
@@ -1,0 +1,103 @@
+// Postgres route-geometry adapter (#179). The path is stored as PostGIS
+// geography(LineString, 4326); the domain model exposes plain lat/lng points,
+// so conversion happens here at the boundary — same pattern as stops and
+// trip positions.
+//
+// Note the coordinate order: PostGIS is (longitude, latitude), X is longitude
+// and Y is latitude. Getting that backwards puts Accra in the Indian Ocean and
+// the code still runs, so it is worth stating rather than remembering.
+
+import type { Pool } from 'pg';
+import type { LatLng } from './eta';
+import type {
+  RouteGeometry,
+  RouteGeometryRepository,
+  RouteGeometryUpsert,
+} from './route-geometry.repository';
+
+interface RouteGeometryRow {
+  route_id: string;
+  /** GeoJSON string from ST_AsGeoJSON — parsed below. */
+  geojson: string | null;
+  geometry_source: string | null;
+  geometry_run_count: number;
+  geometry_updated_at: Date | null;
+}
+
+/**
+ * Convert a GeoJSON LineString into domain points.
+ *
+ * @param geojson - the ST_AsGeoJSON output.
+ * @returns the ordered points, or an empty array when unparseable.
+ */
+function toPoints(geojson: string): LatLng[] {
+  const parsed = JSON.parse(geojson) as { coordinates?: [number, number][] };
+  return (parsed.coordinates ?? []).map(([lng, lat]) => ({ latitude: lat, longitude: lng }));
+}
+
+export class PgRouteGeometryRepository implements RouteGeometryRepository {
+  constructor(private readonly pool: Pool) {}
+
+  async findByRoute(routeId: string): Promise<RouteGeometry | null> {
+    const { rows } = await this.pool.query<RouteGeometryRow>(
+      `SELECT id AS route_id,
+              ST_AsGeoJSON(geometry::geometry) AS geojson,
+              geometry_source,
+              geometry_run_count,
+              geometry_updated_at
+         FROM routes
+        WHERE id = $1`,
+      [routeId],
+    );
+    const row = rows[0];
+    if (!row?.geojson) return null;
+    return {
+      routeId: row.route_id,
+      points: toPoints(row.geojson),
+      source: row.geometry_source ?? 'traces',
+      runCount: row.geometry_run_count,
+      updatedAt: row.geometry_updated_at ?? new Date(),
+    };
+  }
+
+  async save(input: RouteGeometryUpsert): Promise<void> {
+    const client = await this.pool.connect();
+    try {
+      // One transaction: a path written without its stop distances would leave
+      // "3 of 11 stops" reading against a shape it does not match.
+      await client.query('BEGIN');
+
+      // Build the LineString from a coordinate array rather than string
+      // concatenation — WKT assembled by hand is an injection surface and a
+      // precision loss for no benefit.
+      const lngs = input.points.map((p) => p.longitude);
+      const lats = input.points.map((p) => p.latitude);
+      await client.query(
+        `UPDATE routes
+            SET geometry = (
+                  SELECT ST_MakeLine(ST_MakePoint(lng, lat)::geography::geometry ORDER BY ord)::geography
+                    FROM unnest($2::float8[], $3::float8[]) WITH ORDINALITY AS t(lng, lat, ord)
+                ),
+                geometry_source     = $4,
+                geometry_run_count  = $5,
+                geometry_updated_at = now()
+          WHERE id = $1`,
+        [input.routeId, lngs, lats, input.source, input.runCount],
+      );
+
+      for (const [seq, metres] of input.stopDistances) {
+        await client.query(
+          `UPDATE route_stops SET distance_m = $3 WHERE route_id = $1 AND seq = $2`,
+          [input.routeId, seq, metres],
+        );
+      }
+
+      await client.query('COMMIT');
+    } catch (err) {
+      await client.query('ROLLBACK');
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+}

--- a/services/api/src/modules/mobility/route-geometry.repository.ts
+++ b/services/api/src/modules/mobility/route-geometry.repository.ts
@@ -1,0 +1,70 @@
+// Persistence for a route's derived shape and its per-segment observed speeds
+// (#179, #181). The pure derivation lives in route-geometry.ts; this is the
+// layer that reads traces in and writes results out.
+//
+// Repository pattern (ADR-0009): interface + InMemory here, Postgres in *.pg.ts.
+
+import type { LatLng } from './eta';
+
+/** A route's derived path plus the provenance stored beside it. */
+export interface RouteGeometry {
+  routeId: string;
+  points: LatLng[];
+  /** 'traces' | 'matched' | 'manual' — mirrors the DB CHECK. */
+  source: string;
+  /** How many completed runs the path was derived from. */
+  runCount: number;
+  updatedAt: Date;
+}
+
+/** What to persist after deriving a route's geometry. */
+export interface RouteGeometryUpsert {
+  routeId: string;
+  points: LatLng[];
+  source: string;
+  runCount: number;
+  /** Metres along the path to each stop, by `route_stops.seq`. */
+  stopDistances: Map<number, number>;
+}
+
+/** Persistence for `routes.geometry` and `route_stops.distance_m`. */
+export interface RouteGeometryRepository {
+  /**
+   * Read a route's derived path.
+   *
+   * @param routeId - the route.
+   * @returns the geometry, or null when the route has never been run.
+   */
+  findByRoute(routeId: string): Promise<RouteGeometry | null>;
+  /**
+   * Persist a derived path and its stop distances.
+   *
+   * Idempotent — re-deriving the same route overwrites rather than appending,
+   * because a route has exactly one current shape.
+   *
+   * @param input - the derived path, provenance, and per-stop distances.
+   */
+  save(input: RouteGeometryUpsert): Promise<void>;
+}
+
+/** In-memory {@link RouteGeometryRepository} for dev and unit tests. */
+export class InMemoryRouteGeometryRepository implements RouteGeometryRepository {
+  private readonly geometries = new Map<string, RouteGeometry>();
+  /** routeId -> (seq -> metres). Mirrors route_stops.distance_m. */
+  readonly stopDistances = new Map<string, Map<number, number>>();
+
+  async findByRoute(routeId: string): Promise<RouteGeometry | null> {
+    return this.geometries.get(routeId) ?? null;
+  }
+
+  async save(input: RouteGeometryUpsert): Promise<void> {
+    this.geometries.set(input.routeId, {
+      routeId: input.routeId,
+      points: input.points,
+      source: input.source,
+      runCount: input.runCount,
+      updatedAt: new Date(),
+    });
+    this.stopDistances.set(input.routeId, new Map(input.stopDistances));
+  }
+}

--- a/services/api/src/modules/mobility/route-learning.routes.ts
+++ b/services/api/src/modules/mobility/route-learning.routes.ts
@@ -1,0 +1,88 @@
+// Admin trigger for route learning (#179, #181).
+//
+// Mirrors the other daily-loop admin triggers (/admin/ask-dispatch,
+// /admin/resolve-no-shows): admin-only, idempotent, and callable both by hand
+// and by a Render cron that mints a short-lived admin token.
+
+import type { FastifyInstance } from 'fastify';
+import type { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { z } from 'zod';
+import { errorResponseSchema } from '../../lib/schemas';
+import type { RateLimitConfig } from '../ratelimit/ratelimit.plugin';
+import type { RouteLearningService } from './route-learning.service';
+
+const learnBodySchema = z.object({
+  /** Learn one route; omit to learn every route with completed runs. */
+  routeId: z.string().uuid().optional(),
+});
+
+const learnResultSchema = z.object({
+  routeId: z.string().uuid(),
+  runsUsed: z.number().int(),
+  geometryUpdated: z.boolean(),
+  segmentsLearned: z.object({
+    morning: z.number().int(),
+    evening: z.number().int(),
+  }),
+});
+
+const learnResponseSchema = z.object({
+  routes: z.array(learnResultSchema),
+});
+
+/**
+ * Register `POST /admin/learn-routes`.
+ *
+ * @param app - the Fastify instance to register on.
+ * @param opts - route dependencies.
+ * @param opts.routeLearning - the learning service (503 when absent).
+ * @param opts.rateLimit - rate-limit config (applied per user).
+ */
+export async function routeLearningRoutes(
+  app: FastifyInstance,
+  opts: { routeLearning?: RouteLearningService; rateLimit: RateLimitConfig },
+): Promise<void> {
+  const r = app.withTypeProvider<ZodTypeProvider>();
+
+  r.post(
+    '/admin/learn-routes',
+    {
+      schema: {
+        tags: ['admin'],
+        summary: "Derive route geometry + segment speeds from completed trips' GPS traces",
+        description:
+          'Reads back the traces of recent completed runs and writes the corridor’s real ' +
+          'road-following path and its observed per-segment speeds. Safe to re-run: geometry ' +
+          'is overwritten and speeds are replaced per direction, so repeated passes converge.',
+        security: [{ bearerAuth: [] }],
+        body: learnBodySchema,
+        response: {
+          200: learnResponseSchema,
+          401: errorResponseSchema,
+          403: errorResponseSchema,
+          429: errorResponseSchema,
+          503: errorResponseSchema,
+        },
+      },
+      // authenticate → rate limit → requireRole('admin'), matching the other
+      // admin triggers: throttle before the role check so a flood of
+      // unauthorised calls is cheap to reject.
+      preHandler: [
+        app.authenticate,
+        app.rateLimit({ ...opts.rateLimit, by: 'user' }),
+        app.requireRole('admin'),
+      ],
+    },
+    async (request, reply) => {
+      if (!opts.routeLearning) {
+        return reply
+          .code(503)
+          .send({ error: 'unavailable', message: 'Route learning is not configured' });
+      }
+      const routes = request.body.routeId
+        ? [await opts.routeLearning.learnRoute(request.body.routeId)]
+        : await opts.routeLearning.learnAll();
+      return { routes };
+    },
+  );
+}

--- a/services/api/src/modules/mobility/route-learning.service.ts
+++ b/services/api/src/modules/mobility/route-learning.service.ts
@@ -1,0 +1,230 @@
+// Learning a corridor from the runs we have already driven (#179, #181).
+//
+// Every completed trip leaves a dense timestamped trace in trip_positions —
+// a fix every 5 seconds — which we were storing and never reading back. This
+// service turns that history into the two things the ETA needs: the road the
+// bus actually follows, and how fast it actually moves along each stretch.
+//
+// Both outputs improve on their own as runs accumulate. Nothing here is bought
+// from a vendor, and nothing a competitor can buy replaces it: it measures our
+// vehicles, on our corridors, at the times we run them.
+
+import { directionOf, type ServiceWindow } from './direction';
+import type { RouteStopPoint } from './eta';
+import type { RouteStopRepository } from './route-stop.repository';
+import { deriveRouteGeometry, stopDistancesAlong, type Trace } from './route-geometry';
+import type { RouteGeometryRepository } from './route-geometry.repository';
+import { aggregateSegmentSpeeds, type TimedTrace } from './segment-speed.aggregate';
+import type { SegmentSpeedRepository } from './segment-speed.repository';
+import type { StopRepository } from './stop.repository';
+import type { TripPositionRepository } from './trip-position.repository';
+import type { TripRepository } from './trip.repository';
+
+/**
+ * How many completed runs to read back, **per direction**.
+ *
+ * Per direction, not overall: a corridor running morning and evening would
+ * otherwise have one window starve the other. Five recent evening runs and
+ * three morning ones, sliced to the five newest overall, leaves morning with
+ * two — below the sample threshold — and that window silently keeps the
+ * cold-start speed forever.
+ */
+const RUNS_TO_CONSIDER = 5;
+
+/** Collaborators for {@link RouteLearningService}. */
+export interface RouteLearningDeps {
+  trips: TripRepository;
+  tripPositions: TripPositionRepository;
+  routeStops: RouteStopRepository;
+  stops: StopRepository;
+  geometry: RouteGeometryRepository;
+  segmentSpeeds: SegmentSpeedRepository;
+}
+
+/** What a learning pass produced, for the admin response and the cron log. */
+export interface RouteLearningResult {
+  routeId: string;
+  /** Completed runs found and used. */
+  runsUsed: number;
+  /** True when a path was derived and persisted. */
+  geometryUpdated: boolean;
+  /** Segments that cleared the sample threshold, by direction. */
+  segmentsLearned: Record<ServiceWindow, number>;
+}
+
+/** Derives route geometry and segment speeds from completed trips. */
+export class RouteLearningService {
+  /** @param deps - the trip, position, stop and output repositories. */
+  constructor(private readonly deps: RouteLearningDeps) {}
+
+  /**
+   * Learn one route from its completed runs.
+   *
+   * Safe to re-run: geometry is overwritten rather than appended (a route has
+   * one current shape) and speeds are replaced per direction, so repeating a
+   * pass converges rather than compounding.
+   *
+   * @param routeId - the route to learn.
+   * @returns what the pass found and wrote.
+   */
+  async learnRoute(routeId: string): Promise<RouteLearningResult> {
+    const result: RouteLearningResult = {
+      routeId,
+      runsUsed: 0,
+      geometryUpdated: false,
+      segmentsLearned: { morning: 0, evening: 0 },
+    };
+
+    const stopPoints = await this.resolveStops(routeId);
+    if (stopPoints.length < 2) return result;
+
+    const all = await this.deps.trips.findAll({ routeId, status: 'completed' });
+    if (all.length === 0) return result;
+
+    // Newest first, then take the most recent N of EACH direction: a corridor's
+    // recent shape beats its historical one when a road closes or a stop moves,
+    // and neither window may crowd the other out.
+    const byDirection = new Map<ServiceWindow, typeof all>();
+    for (const window of ['morning', 'evening'] as const) {
+      byDirection.set(
+        window,
+        all
+          .filter((t) => directionOf(t.scheduledAt) === window)
+          .sort((a, b) => b.scheduledAt.getTime() - a.scheduledAt.getTime())
+          .slice(0, RUNS_TO_CONSIDER),
+      );
+    }
+
+    const traces = new Map<ServiceWindow, TimedTrace[]>();
+    for (const [window, trips] of byDirection) {
+      const timed: TimedTrace[] = [];
+      for (const trip of trips) {
+        const fixes = await this.deps.tripPositions.findAllForTrip(trip.id);
+        if (fixes.length < 2) continue;
+        timed.push({
+          tripId: trip.id,
+          fixes: fixes.map((f) => ({
+            latitude: f.latitude,
+            longitude: f.longitude,
+            recordedAt: f.recordedAt,
+          })),
+        });
+      }
+      traces.set(window, timed);
+      result.runsUsed += timed.length;
+    }
+    if (result.runsUsed === 0) return result;
+
+    await this.learnGeometry(routeId, traces, stopPoints, result);
+    await this.learnSpeeds(routeId, traces, stopPoints, result);
+    return result;
+  }
+
+  /**
+   * Learn every route that has completed runs. Used by the scheduled pass.
+   *
+   * @returns one result per route touched.
+   */
+  async learnAll(): Promise<RouteLearningResult[]> {
+    const trips = await this.deps.trips.findAll({ status: 'completed' });
+    const routeIds = [...new Set(trips.map((t) => t.routeId))];
+    const results: RouteLearningResult[] = [];
+    for (const routeId of routeIds) {
+      results.push(await this.learnRoute(routeId));
+    }
+    return results;
+  }
+
+  /**
+   * Resolve a route's stops in seq order with their coordinates.
+   *
+   * @param routeId - the route.
+   * @returns the ordered stop points; unresolvable stops are dropped.
+   */
+  private async resolveStops(routeId: string): Promise<RouteStopPoint[]> {
+    const routeStops = await this.deps.routeStops.findByRoute(routeId);
+    const resolved = await Promise.all(
+      routeStops.map(async (rs): Promise<RouteStopPoint | null> => {
+        const stop = await this.deps.stops.findById(rs.stopId);
+        return stop
+          ? {
+              stopId: stop.id,
+              name: stop.name,
+              seq: rs.seq,
+              latitude: stop.latitude,
+              longitude: stop.longitude,
+            }
+          : null;
+      }),
+    );
+    return resolved.filter((s): s is RouteStopPoint => s !== null);
+  }
+
+  /**
+   * Derive and persist the route's path plus each stop's distance along it.
+   *
+   * @param routeId - the route.
+   * @param byDirection - completed runs grouped by service window.
+   * @param stopPoints - the route's stops in seq order.
+   * @param result - mutated with what was written.
+   */
+  private async learnGeometry(
+    routeId: string,
+    byDirection: Map<ServiceWindow, TimedTrace[]>,
+    stopPoints: RouteStopPoint[],
+    result: RouteLearningResult,
+  ): Promise<void> {
+    // Derive from ONE direction's runs, the one with the most data. Where a
+    // corridor's two windows travel opposite ways along the same road, mixing
+    // them would median a forward traversal against a reverse one and produce a
+    // path that matches neither.
+    const richest = [...byDirection.values()].sort((a, b) => b.length - a.length)[0] ?? [];
+    if (richest.length === 0) return;
+
+    const traces: Trace[] = richest.map((t) => ({
+      tripId: t.tripId,
+      points: t.fixes.map((f) => ({ latitude: f.latitude, longitude: f.longitude })),
+    }));
+
+    const derived = deriveRouteGeometry(traces);
+    if (!derived) return;
+
+    const distances = stopDistancesAlong(derived.points, stopPoints);
+    await this.deps.geometry.save({
+      routeId,
+      points: derived.points,
+      source: derived.source,
+      runCount: derived.runCount,
+      stopDistances: new Map(stopPoints.map((s, i) => [s.seq, distances[i]!])),
+    });
+    result.geometryUpdated = true;
+  }
+
+  /**
+   * Aggregate and persist observed segment speeds, per direction.
+   *
+   * Morning and evening are learned separately and never pooled: the whole
+   * point is that the same stretch of road is a different road at 07:30 than at
+   * 18:00, and averaging the two would erase exactly the signal we want.
+   *
+   * @param routeId - the route.
+   * @param byDirection - completed runs grouped by service window.
+   * @param stopPoints - the route's stops in seq order.
+   * @param result - mutated with what was written.
+   */
+  private async learnSpeeds(
+    routeId: string,
+    byDirection: Map<ServiceWindow, TimedTrace[]>,
+    stopPoints: RouteStopPoint[],
+    result: RouteLearningResult,
+  ): Promise<void> {
+    for (const direction of ['morning', 'evening'] as const) {
+      const forDirection = byDirection.get(direction) ?? [];
+      if (forDirection.length === 0) continue;
+
+      const segments = aggregateSegmentSpeeds(forDirection, stopPoints);
+      await this.deps.segmentSpeeds.replace(routeId, direction, segments);
+      result.segmentsLearned[direction] = segments.length;
+    }
+  }
+}

--- a/services/api/src/modules/mobility/segment-speed.aggregate.ts
+++ b/services/api/src/modules/mobility/segment-speed.aggregate.ts
@@ -1,0 +1,130 @@
+// Turning completed runs into per-segment observed speeds (#181).
+//
+// Pure functions — no clock, no I/O — so the same traces always produce the
+// same medians and this is testable without a database.
+//
+// The model: for each pair of adjacent stops, find when the vehicle passed the
+// first and when it passed the second, and divide the distance between them by
+// the time it took. Do that across several runs and take the median.
+//
+// Median rather than mean throughout. One breakdown, one driver waiting for a
+// police check, one run in a downpour — a mean carries all of that into every
+// future ETA, a median ignores it.
+
+import { haversineMeters, type LatLng, type RouteStopPoint } from './eta';
+
+/** One timestamped fix from a completed run. */
+export interface TimedFix extends LatLng {
+  recordedAt: Date;
+}
+
+/** One completed run: its fixes in recorded order. */
+export interface TimedTrace {
+  tripId: string;
+  fixes: TimedFix[];
+}
+
+/** An aggregated observation, shaped for SegmentSpeedRepository.replace. */
+export interface AggregatedSegment {
+  fromSeq: number;
+  medianSpeedMs: number;
+  sampleCount: number;
+}
+
+/**
+ * A speed this far outside plausible urban travel is a data problem, not
+ * traffic — a GPS glitch, a stopped clock, or a bus that never actually left.
+ * Observations outside the band are discarded rather than dragging a median.
+ */
+const MIN_PLAUSIBLE_MS = 0.5; // ~1.8 km/h — slower than walking pace
+const MAX_PLAUSIBLE_MS = 33; // ~120 km/h — implausible on an Accra corridor
+
+/**
+ * The median of a list. Assumes a non-empty input.
+ *
+ * @param values - the numbers to reduce.
+ * @returns the median value.
+ */
+function median(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[mid - 1]! + sorted[mid]!) / 2 : sorted[mid]!;
+}
+
+/**
+ * When the vehicle was closest to a stop, as a timestamp.
+ *
+ * Nearest-approach rather than a radius test: a radius has to be tuned per stop
+ * (a kerbside stop and a terminus are not the same size) and silently returns
+ * nothing when a driver passes wide.
+ *
+ * @param fixes - the run's fixes in order.
+ * @param stop - the stop to find.
+ * @returns the time of closest approach, or null when there are no fixes.
+ */
+function passedAt(fixes: readonly TimedFix[], stop: LatLng): Date | null {
+  let best: TimedFix | null = null;
+  let bestDistance = Infinity;
+  for (const fix of fixes) {
+    const d = haversineMeters(fix, stop);
+    if (d < bestDistance) {
+      bestDistance = d;
+      best = fix;
+    }
+  }
+  return best?.recordedAt ?? null;
+}
+
+/**
+ * Observed speed for each segment of a route, from a set of completed runs.
+ *
+ * @param traces - completed runs for this route and direction.
+ * @param stops - the route's stops in seq order.
+ * @param minSamples - discard segments with fewer observations than this; a
+ *   median of one run is noise, and the ETA falls back to the cold-start speed.
+ * @returns one entry per segment that cleared the sample threshold.
+ */
+export function aggregateSegmentSpeeds(
+  traces: readonly TimedTrace[],
+  stops: readonly RouteStopPoint[],
+  minSamples = 3,
+): AggregatedSegment[] {
+  if (stops.length < 2) return [];
+
+  const out: AggregatedSegment[] = [];
+
+  for (let i = 0; i < stops.length - 1; i++) {
+    const from = stops[i]!;
+    const to = stops[i + 1]!;
+    const distance = haversineMeters(from, to);
+    if (distance <= 0) continue;
+
+    const speeds: number[] = [];
+    for (const trace of traces) {
+      if (trace.fixes.length < 2) continue;
+
+      const departed = passedAt(trace.fixes, from);
+      const arrived = passedAt(trace.fixes, to);
+      if (!departed || !arrived) continue;
+
+      const seconds = (arrived.getTime() - departed.getTime()) / 1000;
+      // Non-positive means the bus reached the later stop first — a trace
+      // recorded in the opposite direction, or fixes out of order. Either way
+      // it is not an observation of this segment.
+      if (seconds <= 0) continue;
+
+      const speed = distance / seconds;
+      if (speed < MIN_PLAUSIBLE_MS || speed > MAX_PLAUSIBLE_MS) continue;
+      speeds.push(speed);
+    }
+
+    if (speeds.length < minSamples) continue;
+    out.push({
+      fromSeq: from.seq,
+      medianSpeedMs: median(speeds),
+      sampleCount: speeds.length,
+    });
+  }
+
+  return out;
+}

--- a/services/api/src/modules/mobility/segment-speed.repository.pg.ts
+++ b/services/api/src/modules/mobility/segment-speed.repository.pg.ts
@@ -1,0 +1,74 @@
+// Postgres segment-speed adapter (#181). Plain rows — no PostGIS here; the
+// geometry lives on routes and this only records how fast we travel each
+// stretch of it.
+
+import type { Pool } from 'pg';
+import type { SegmentSpeed } from './eta';
+import type {
+  SegmentSpeedRepository,
+  SegmentSpeedRow,
+  ServiceDirection,
+} from './segment-speed.repository';
+
+interface Row {
+  from_seq: number;
+  median_speed_ms: number;
+  sample_count: number;
+}
+
+export class PgSegmentSpeedRepository implements SegmentSpeedRepository {
+  constructor(private readonly pool: Pool) {}
+
+  async findByRoute(
+    routeId: string,
+    direction: ServiceDirection,
+  ): Promise<Map<number, SegmentSpeed>> {
+    const { rows } = await this.pool.query<Row>(
+      `SELECT from_seq, median_speed_ms, sample_count
+         FROM segment_speeds
+        WHERE route_id = $1 AND direction = $2`,
+      [routeId, direction],
+    );
+    return new Map(
+      rows.map((r) => [
+        r.from_seq,
+        {
+          fromSeq: r.from_seq,
+          metresPerSecond: Number(r.median_speed_ms),
+          sampleCount: r.sample_count,
+        },
+      ]),
+    );
+  }
+
+  async replace(
+    routeId: string,
+    direction: ServiceDirection,
+    rows: readonly Omit<SegmentSpeedRow, 'routeId' | 'direction' | 'computedAt'>[],
+  ): Promise<void> {
+    const client = await this.pool.connect();
+    try {
+      // Delete-then-insert inside one transaction. A reader mid-aggregation
+      // must never see a half-populated route: some segments recomputed, others
+      // still on the previous window's medians.
+      await client.query('BEGIN');
+      await client.query('DELETE FROM segment_speeds WHERE route_id = $1 AND direction = $2', [
+        routeId,
+        direction,
+      ]);
+      for (const row of rows) {
+        await client.query(
+          `INSERT INTO segment_speeds (route_id, from_seq, direction, median_speed_ms, sample_count)
+           VALUES ($1, $2, $3, $4, $5)`,
+          [routeId, row.fromSeq, direction, row.medianSpeedMs, row.sampleCount],
+        );
+      }
+      await client.query('COMMIT');
+    } catch (err) {
+      await client.query('ROLLBACK');
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+}

--- a/services/api/src/modules/mobility/segment-speed.repository.ts
+++ b/services/api/src/modules/mobility/segment-speed.repository.ts
@@ -1,0 +1,90 @@
+// Observed median speed per route segment, direction and service window (#181).
+//
+// This is what replaces the flat ASSUMED_SPEED_KPH in eta.ts. Aggregated from
+// completed runs rather than bought from a traffic vendor: a traffic API models
+// a generic vehicle on a generic road, this measures our vehicles on our
+// corridors at the exact times we run them.
+//
+// Repository pattern (ADR-0009): interface + InMemory here, Postgres in *.pg.ts.
+
+import type { SegmentSpeed } from './eta';
+
+/** Which service window an observation belongs to. Mirrors the DB CHECK. */
+export type ServiceDirection = 'morning' | 'evening';
+
+/** A persisted observation for one segment of one route. */
+export interface SegmentSpeedRow {
+  routeId: string;
+  /** Segment between route_stops.seq = fromSeq and fromSeq + 1. */
+  fromSeq: number;
+  direction: ServiceDirection;
+  medianSpeedMs: number;
+  sampleCount: number;
+  computedAt: Date;
+}
+
+/** Persistence for `segment_speeds`. */
+export interface SegmentSpeedRepository {
+  /**
+   * Speeds for one route and direction, keyed by segment index for
+   * {@link computeEtas}.
+   *
+   * Returns a Map rather than an array because the ETA path does a lookup per
+   * segment on every position read — the hottest query we have during a run.
+   *
+   * @param routeId - the route.
+   * @param direction - the service window.
+   * @returns segment index -> observed speed. Empty when nothing is known yet,
+   *   in which case every segment falls back to the cold-start speed.
+   */
+  findByRoute(routeId: string, direction: ServiceDirection): Promise<Map<number, SegmentSpeed>>;
+  /**
+   * Replace the observations for a route and direction.
+   *
+   * A full replace, not a merge: the aggregation recomputes every segment from
+   * the same window of runs, so a partial update could leave one segment's
+   * median from a different sample than its neighbour's.
+   *
+   * @param routeId - the route.
+   * @param direction - the service window.
+   * @param rows - the recomputed observations.
+   */
+  replace(
+    routeId: string,
+    direction: ServiceDirection,
+    rows: readonly Omit<SegmentSpeedRow, 'routeId' | 'direction' | 'computedAt'>[],
+  ): Promise<void>;
+}
+
+/** In-memory {@link SegmentSpeedRepository} for dev and unit tests. */
+export class InMemorySegmentSpeedRepository implements SegmentSpeedRepository {
+  private readonly rows = new Map<string, SegmentSpeedRow[]>();
+
+  private key(routeId: string, direction: ServiceDirection): string {
+    return `${routeId}:${direction}`;
+  }
+
+  async findByRoute(
+    routeId: string,
+    direction: ServiceDirection,
+  ): Promise<Map<number, SegmentSpeed>> {
+    const found = this.rows.get(this.key(routeId, direction)) ?? [];
+    return new Map(
+      found.map((r) => [
+        r.fromSeq,
+        { fromSeq: r.fromSeq, metresPerSecond: r.medianSpeedMs, sampleCount: r.sampleCount },
+      ]),
+    );
+  }
+
+  async replace(
+    routeId: string,
+    direction: ServiceDirection,
+    rows: readonly Omit<SegmentSpeedRow, 'routeId' | 'direction' | 'computedAt'>[],
+  ): Promise<void> {
+    this.rows.set(
+      this.key(routeId, direction),
+      rows.map((r) => ({ ...r, routeId, direction, computedAt: new Date() })),
+    );
+  }
+}

--- a/services/api/src/modules/mobility/trip-position.repository.pg.ts
+++ b/services/api/src/modules/mobility/trip-position.repository.pg.ts
@@ -56,4 +56,18 @@ export class PgTripPositionRepository implements TripPositionRepository {
     );
     return rows[0] ? toTripPosition(rows[0]) : null;
   }
+
+  async findAllForTrip(tripId: string): Promise<TripPosition[]> {
+    const { rows } = await this.pool.query<TripPositionRow>(
+      `SELECT id, trip_id,
+              ST_Y(location::geometry) AS latitude,
+              ST_X(location::geometry) AS longitude,
+              recorded_at
+         FROM trip_positions
+        WHERE trip_id = $1
+        ORDER BY recorded_at ASC`,
+      [tripId],
+    );
+    return rows.map(toTripPosition);
+  }
 }

--- a/services/api/src/modules/mobility/trip-position.repository.ts
+++ b/services/api/src/modules/mobility/trip-position.repository.ts
@@ -37,6 +37,17 @@ export interface TripPositionRepository {
    * @returns the latest fix, or null if none has been reported.
    */
   findLatest(tripId: string): Promise<TripPosition | null>;
+  /**
+   * Every fix for a trip, oldest first — the run's full trace.
+   *
+   * Read back by route learning (#179, #181) to derive the corridor's real
+   * shape and its per-segment speeds. The table has been append-only since #25
+   * specifically so this history would exist when we came to need it.
+   *
+   * @param tripId - the trip id.
+   * @returns the trip's fixes in recorded order (empty when none).
+   */
+  findAllForTrip(tripId: string): Promise<TripPosition[]>;
 }
 
 /** In-memory {@link TripPositionRepository} for dev and unit tests. */
@@ -64,5 +75,10 @@ export class InMemoryTripPositionRepository implements TripPositionRepository {
       if (!latest || p.recordedAt.getTime() >= latest.recordedAt.getTime()) latest = p;
     }
     return latest;
+  }
+  async findAllForTrip(tripId: string): Promise<TripPosition[]> {
+    return this.positions
+      .filter((p) => p.tripId === tripId)
+      .sort((a, b) => a.recordedAt.getTime() - b.recordedAt.getTime());
   }
 }

--- a/services/api/src/modules/notifications/ask-dispatch.service.ts
+++ b/services/api/src/modules/notifications/ask-dispatch.service.ts
@@ -9,6 +9,7 @@
 // rider↔route model): confirm at subscribe → the route pins the subscription →
 // this targets those subscribers.
 
+import { directionOf } from '../mobility/direction';
 import type { TripRepository } from '../mobility/trip.repository';
 import type {
   ReservationDirection,
@@ -29,13 +30,6 @@ export interface AskDispatchDeps {
 export interface AskDispatchResult {
   trips: number;
   asked: number;
-}
-
-// A trip's direction from its scheduled time — morning before noon, else evening
-// (UTC). Pilot heuristic, consistent with the boarding scan; converges when
-// trips carry an explicit direction.
-function directionOf(scheduledAt: Date): ReservationDirection {
-  return scheduledAt.getUTCHours() < 12 ? 'morning' : 'evening';
 }
 
 /** The daily ask-dispatch + cutoff default-yes (see the file header). */

--- a/services/api/src/server.ts
+++ b/services/api/src/server.ts
@@ -42,6 +42,17 @@ import {
 } from './modules/mobility/trip-position.repository';
 import { PgTripPositionRepository } from './modules/mobility/trip-position.repository.pg';
 import {
+  InMemoryRouteGeometryRepository,
+  type RouteGeometryRepository,
+} from './modules/mobility/route-geometry.repository';
+import { PgRouteGeometryRepository } from './modules/mobility/route-geometry.repository.pg';
+import { RouteLearningService } from './modules/mobility/route-learning.service';
+import {
+  InMemorySegmentSpeedRepository,
+  type SegmentSpeedRepository,
+} from './modules/mobility/segment-speed.repository';
+import { PgSegmentSpeedRepository } from './modules/mobility/segment-speed.repository.pg';
+import {
   InMemoryVehicleRepository,
   type VehicleRepository,
 } from './modules/mobility/vehicle.repository';
@@ -159,6 +170,8 @@ async function main(): Promise<void> {
   let routeStops: RouteStopRepository;
   let trips: TripRepository;
   let tripPositions: TripPositionRepository;
+  let routeGeometry: RouteGeometryRepository;
+  let segmentSpeeds: SegmentSpeedRepository;
   let vehicles: VehicleRepository;
   let drivers: DriverRepository;
   let sessions: SessionRepository;
@@ -180,6 +193,8 @@ async function main(): Promise<void> {
     routeStops = new PgRouteStopRepository(pool);
     trips = new PgTripRepository(pool);
     tripPositions = new PgTripPositionRepository(pool);
+    routeGeometry = new PgRouteGeometryRepository(pool);
+    segmentSpeeds = new PgSegmentSpeedRepository(pool);
     vehicles = new PgVehicleRepository(pool);
     drivers = new PgDriverRepository(pool);
     sessions = new PgSessionRepository(pool);
@@ -201,6 +216,8 @@ async function main(): Promise<void> {
     routeStops = new InMemoryRouteStopRepository();
     trips = new InMemoryTripRepository();
     tripPositions = new InMemoryTripPositionRepository();
+    routeGeometry = new InMemoryRouteGeometryRepository();
+    segmentSpeeds = new InMemorySegmentSpeedRepository();
     vehicles = new InMemoryVehicleRepository();
     drivers = new InMemoryDriverRepository();
     sessions = new InMemorySessionRepository();
@@ -318,6 +335,17 @@ async function main(): Promise<void> {
     windowSeconds: env.RATE_LIMIT_WINDOW_SECONDS,
   };
 
+  // Route learning (#179, #181): reads back completed runs' GPS traces to derive
+  // the corridor's real path and its observed per-segment speeds.
+  const routeLearning = new RouteLearningService({
+    trips,
+    tripPositions,
+    routeStops,
+    stops,
+    geometry: routeGeometry,
+    segmentSpeeds,
+  });
+
   const app = await buildApp({
     users,
     accountDeletion,
@@ -342,6 +370,8 @@ async function main(): Promise<void> {
     kv,
     objectStore,
     mapTilesUrl: env.MAP_TILES_URL,
+    segmentSpeeds,
+    routeLearning,
     isReady,
     auth,
     rateLimit,

--- a/services/api/tests/route-learning.service.test.ts
+++ b/services/api/tests/route-learning.service.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from 'vitest';
+import { RouteLearningService } from '../src/modules/mobility/route-learning.service';
+import { InMemoryRouteGeometryRepository } from '../src/modules/mobility/route-geometry.repository';
+import { InMemorySegmentSpeedRepository } from '../src/modules/mobility/segment-speed.repository';
+import { InMemoryTripPositionRepository } from '../src/modules/mobility/trip-position.repository';
+import { InMemoryTripRepository } from '../src/modules/mobility/trip.repository';
+import { InMemoryRouteStopRepository } from '../src/modules/mobility/route-stop.repository';
+import { InMemoryStopRepository } from '../src/modules/mobility/stop.repository';
+import { InMemoryRouteRepository } from '../src/modules/mobility/route.repository';
+
+/** Build a corridor of `count` stops on a straight line, ~1 km apart. */
+async function corridor(stopsRepo: InMemoryStopRepository, count: number) {
+  const made = [];
+  for (let i = 0; i < count; i++) {
+    made.push(
+      await stopsRepo.create({ name: `Stop ${i}`, latitude: 5.6, longitude: -0.19 + i * 0.009 }),
+    );
+  }
+  return made;
+}
+
+async function setup(stopCount = 4) {
+  const routes = new InMemoryRouteRepository();
+  const stops = new InMemoryStopRepository();
+  const routeStops = new InMemoryRouteStopRepository();
+  const trips = new InMemoryTripRepository();
+  const tripPositions = new InMemoryTripPositionRepository();
+  const geometry = new InMemoryRouteGeometryRepository();
+  const segmentSpeeds = new InMemorySegmentSpeedRepository();
+
+  const route = await routes.create({ name: 'Madina ⇄ Circle' });
+  const made = await corridor(stops, stopCount);
+  for (const [i, s] of made.entries()) {
+    await routeStops.create({ routeId: route.id, stopId: s.id, seq: i });
+  }
+
+  const service = new RouteLearningService({
+    trips,
+    tripPositions,
+    routeStops,
+    stops,
+    geometry,
+    segmentSpeeds,
+  });
+  return { service, route, made, trips, tripPositions, geometry, segmentSpeeds };
+}
+
+/**
+ * Record a completed run as a REAL trace: a fix every 5 seconds, interpolated
+ * between consecutive stops. That density matters — the derivation discards
+ * jumps over 350 m as GPS glitches, so one fix per stop (a kilometre apart)
+ * would correctly be thrown away as noise rather than treated as a route.
+ */
+async function completedRun(
+  ctx: Awaited<ReturnType<typeof setup>>,
+  hourUtc: number,
+  secondsPerLeg: number,
+) {
+  const scheduledAt = new Date(Date.UTC(2026, 7, 24, hourUtc, 0, 0));
+  const trip = await ctx.trips.create({
+    routeId: ctx.route.id,
+    scheduledAt,
+    status: 'completed',
+  });
+
+  const FIX_INTERVAL_S = 5;
+  let elapsed = 0;
+  for (let leg = 0; leg < ctx.made.length - 1; leg++) {
+    const from = ctx.made[leg]!;
+    const to = ctx.made[leg + 1]!;
+    const steps = Math.max(1, Math.round(secondsPerLeg / FIX_INTERVAL_S));
+
+    for (let step = 0; step < steps; step++) {
+      const t = step / steps;
+      const rec = await ctx.tripPositions.record({
+        tripId: trip.id,
+        latitude: from.latitude + (to.latitude - from.latitude) * t,
+        longitude: from.longitude + (to.longitude - from.longitude) * t,
+      });
+      // record() stamps recordedAt itself; override so the trace has real timing.
+      (rec as { recordedAt: Date }).recordedAt = new Date(scheduledAt.getTime() + elapsed * 1000);
+      elapsed += FIX_INTERVAL_S;
+    }
+  }
+
+  // Final fix at the terminus.
+  const last = ctx.made[ctx.made.length - 1]!;
+  const rec = await ctx.tripPositions.record({
+    tripId: trip.id,
+    latitude: last.latitude,
+    longitude: last.longitude,
+  });
+  (rec as { recordedAt: Date }).recordedAt = new Date(scheduledAt.getTime() + elapsed * 1000);
+
+  return trip;
+}
+
+describe('RouteLearningService', () => {
+  it('derives geometry from a single completed run', async () => {
+    const ctx = await setup();
+    await completedRun(ctx, 7, 200);
+
+    const result = await ctx.service.learnRoute(ctx.route.id);
+
+    expect(result.runsUsed).toBe(1);
+    expect(result.geometryUpdated).toBe(true);
+    const saved = await ctx.geometry.findByRoute(ctx.route.id);
+    expect(saved?.source).toBe('traces');
+    expect(saved!.points.length).toBeGreaterThan(1);
+  });
+
+  it('records how far along the path each stop sits', async () => {
+    const ctx = await setup();
+    await completedRun(ctx, 7, 200);
+    await ctx.service.learnRoute(ctx.route.id);
+
+    const distances = ctx.geometry.stopDistances.get(ctx.route.id)!;
+    expect(distances.size).toBe(4);
+    expect(distances.get(0)).toBe(0);
+    // Stops in order must be increasingly far along the route.
+    expect(distances.get(3)!).toBeGreaterThan(distances.get(1)!);
+  });
+
+  it('learns morning and evening separately, never pooled', async () => {
+    const ctx = await setup();
+    // Morning is slow (rush hour), evening is fast. Averaging them would erase
+    // exactly the signal this exists to capture.
+    for (let i = 0; i < 3; i++) await completedRun(ctx, 7, 400);
+    for (let i = 0; i < 3; i++) await completedRun(ctx, 18, 100);
+
+    await ctx.service.learnRoute(ctx.route.id);
+
+    const morning = await ctx.segmentSpeeds.findByRoute(ctx.route.id, 'morning');
+    const evening = await ctx.segmentSpeeds.findByRoute(ctx.route.id, 'evening');
+
+    expect(morning.size).toBeGreaterThan(0);
+    expect(evening.size).toBeGreaterThan(0);
+    expect(evening.get(0)!.metresPerSecond).toBeGreaterThan(morning.get(0)!.metresPerSecond * 3);
+  });
+
+  it('does nothing for a route with no completed runs', async () => {
+    const ctx = await setup();
+    const result = await ctx.service.learnRoute(ctx.route.id);
+
+    expect(result.runsUsed).toBe(0);
+    expect(result.geometryUpdated).toBe(false);
+    expect(await ctx.geometry.findByRoute(ctx.route.id)).toBeNull();
+  });
+
+  it('ignores trips that are scheduled but not completed', async () => {
+    const ctx = await setup();
+    await ctx.trips.create({
+      routeId: ctx.route.id,
+      scheduledAt: new Date(Date.UTC(2026, 7, 24, 7)),
+      status: 'scheduled',
+    });
+    expect((await ctx.service.learnRoute(ctx.route.id)).runsUsed).toBe(0);
+  });
+
+  it('converges rather than compounds when re-run', async () => {
+    const ctx = await setup();
+    for (let i = 0; i < 3; i++) await completedRun(ctx, 7, 200);
+
+    const first = await ctx.service.learnRoute(ctx.route.id);
+    const second = await ctx.service.learnRoute(ctx.route.id);
+
+    expect(second.runsUsed).toBe(first.runsUsed);
+    expect(second.segmentsLearned.morning).toBe(first.segmentsLearned.morning);
+    const speeds = await ctx.segmentSpeeds.findByRoute(ctx.route.id, 'morning');
+    // Replaced, not appended: sample counts must not double.
+    expect(speeds.get(0)!.sampleCount).toBe(3);
+  });
+
+  it('learnAll covers every route that has completed runs', async () => {
+    const ctx = await setup();
+    await completedRun(ctx, 7, 200);
+    const results = await ctx.service.learnAll();
+    expect(results).toHaveLength(1);
+    expect(results[0]!.routeId).toBe(ctx.route.id);
+  });
+});

--- a/services/api/tests/segment-speed.aggregate.test.ts
+++ b/services/api/tests/segment-speed.aggregate.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import {
+  aggregateSegmentSpeeds,
+  type TimedTrace,
+} from '../src/modules/mobility/segment-speed.aggregate';
+import { haversineMeters, type RouteStopPoint } from '../src/modules/mobility/eta';
+
+/** Three stops on a straight line, roughly 1 km apart. */
+const STOPS: RouteStopPoint[] = [
+  { stopId: 's0', name: 'Madina', seq: 0, latitude: 5.6, longitude: -0.19 },
+  { stopId: 's1', name: 'Shiashie', seq: 1, latitude: 5.6, longitude: -0.181 },
+  { stopId: 's2', name: '37 Station', seq: 2, latitude: 5.6, longitude: -0.172 },
+];
+
+const SEG_LEN = haversineMeters(STOPS[0]!, STOPS[1]!);
+
+/**
+ * A run passing each stop at a given number of seconds from the start.
+ * One fix per stop is enough — the aggregator finds nearest approach.
+ */
+function run(tripId: string, secondsAtStop: number[]): TimedTrace {
+  const t0 = Date.parse('2026-08-24T07:00:00Z');
+  return {
+    tripId,
+    fixes: STOPS.map((s, i) => ({
+      latitude: s.latitude,
+      longitude: s.longitude,
+      recordedAt: new Date(t0 + secondsAtStop[i]! * 1000),
+    })),
+  };
+}
+
+describe('aggregateSegmentSpeeds', () => {
+  it('derives speed from how long the bus actually took between stops', () => {
+    // 200s to cover ~1km => ~5 m/s
+    const traces = [run('a', [0, 200, 400]), run('b', [0, 200, 400]), run('c', [0, 200, 400])];
+    const out = aggregateSegmentSpeeds(traces, STOPS);
+
+    expect(out).toHaveLength(2);
+    expect(out[0]!.fromSeq).toBe(0);
+    expect(out[0]!.sampleCount).toBe(3);
+    expect(out[0]!.medianSpeedMs).toBeCloseTo(SEG_LEN / 200, 2);
+  });
+
+  it('takes the median so one breakdown does not redefine the corridor', () => {
+    // Four normal runs and one that took ten times as long.
+    const traces = [
+      run('a', [0, 200, 400]),
+      run('b', [0, 200, 400]),
+      run('c', [0, 2000, 4000]), // stuck
+      run('d', [0, 200, 400]),
+      run('e', [0, 200, 400]),
+    ];
+    const out = aggregateSegmentSpeeds(traces, STOPS);
+    // A mean would be dragged well below the normal speed; the median holds.
+    expect(out[0]!.medianSpeedMs).toBeCloseTo(SEG_LEN / 200, 2);
+  });
+
+  it('ignores segments with too few observations', () => {
+    // Two runs, threshold of three: a median of two is noise, and the ETA
+    // should keep the cold-start speed rather than trust it.
+    const out = aggregateSegmentSpeeds([run('a', [0, 200, 400]), run('b', [0, 200, 400])], STOPS);
+    expect(out).toHaveLength(0);
+  });
+
+  it('discards implausible speeds rather than letting them skew a median', () => {
+    // 1 km in 2 seconds is ~500 m/s — a GPS glitch or a stopped clock.
+    const traces = [
+      run('a', [0, 200, 400]),
+      run('b', [0, 200, 400]),
+      run('c', [0, 2, 4]),
+      run('d', [0, 200, 400]),
+    ];
+    const out = aggregateSegmentSpeeds(traces, STOPS);
+    expect(out[0]!.sampleCount).toBe(3); // the glitch was dropped
+    expect(out[0]!.medianSpeedMs).toBeCloseTo(SEG_LEN / 200, 2);
+  });
+
+  it('skips a run recorded in the opposite direction', () => {
+    // Reaching the later stop first means negative elapsed time — not an
+    // observation of this segment.
+    const backwards = run('rev', [400, 200, 0]);
+    const out = aggregateSegmentSpeeds(
+      [run('a', [0, 200, 400]), run('b', [0, 200, 400]), run('c', [0, 200, 400]), backwards],
+      STOPS,
+    );
+    expect(out[0]!.sampleCount).toBe(3);
+  });
+
+  it('returns nothing for a route with fewer than two stops', () => {
+    expect(aggregateSegmentSpeeds([run('a', [0])], [STOPS[0]!])).toEqual([]);
+  });
+});


### PR DESCRIPTION
**Closes #179, closes #181.** Connects what #185 shipped but left dormant.

## What was dormant

#185 landed the schema and the pure maths and wired neither:

- `routes.geometry` and `segment_speeds` had **migrations but no repositories** — nothing could read or write them
- `computeEtas` gained a `speeds` parameter that **no caller passed**

So every ETA in production was still a flat 20 km/h, and the traces we have been dutifully storing since #25 were never read back.

## What this adds

**Repositories** for both tables, in-memory and Postgres. The PostGIS `LineString` is built from a coordinate array via `unnest … WITH ORDINALITY` rather than hand-assembled WKT — that is an injection surface and a precision loss for no benefit. Geometry and stop distances are written in one transaction, because a path saved without its distances leaves `3 of 11 stops` reading against a shape it does not match.

**`RouteLearningService`** reads back completed runs and derives both outputs. Idempotent: geometry is overwritten and speeds replaced per direction, so repeated passes converge rather than compound.

**`aggregateSegmentSpeeds`** turns traces into per-segment medians. Median throughout — one breakdown, one police check, one downpour would otherwise ride in every future ETA. Implausible speeds (under 1.8 km/h, over 120 km/h) are discarded as data problems rather than traffic, and a run recorded in the opposite direction is skipped rather than producing negative elapsed time.

**`POST /admin/learn-routes`**, admin-only, mirroring the other daily-loop triggers. **A nightly cron at 23:00** — after the evening no-show sweep, so the day is settled before we learn from it. Deliberately separate from `ask-dispatch-cron`, whose timing is critical to the rider loop; a failure here must never look like a failure to ask riders about tomorrow.

**The line that makes it real** is `positions.routes.ts`: `computeEtas` now receives observed medians where they exist and the cold-start speed everywhere else.

## Two design flaws the tests caught

**1. Runs were taken five-at-a-time overall, not per direction.** A corridor with three morning and three evening runs kept all the evening ones and starved morning to two — below the sample threshold — so that window would keep the cold-start speed *forever*. Now `RUNS_TO_CONSIDER` applies per direction.

**2. Geometry could median opposite traversals.** Where a corridor's two windows travel opposite ways along one road, mixing them medians a forward traversal against a reverse one and produces a path matching neither. Geometry now derives from a single direction's runs — whichever has the most data.

Neither was visible from reading the code. Both surfaced from a test asserting morning and evening are learned separately.

## An extraction, not a copy

`directionOf` moves out of `ask-dispatch.service.ts` into `mobility/direction.ts`. Its own comment said *"converges when trips carry an explicit direction"* — a second copy in the ETA path is exactly that drift, and it would show up as riders asked about one run and charged for another.

## Verification

Full gates green. **378 tests** (up from 365), coverage 93.63%. Both cron entrypoints build. Migration guard passes.

Test data is deliberately realistic: a fix every 5 seconds interpolated between stops. My first attempt used one fix per stop and the derivation correctly discarded all of it as GPS glitches — the 350 m jump filter doing its job, and a useful reminder that this only works on dense traces.

## What is still not here

The Valhalla map-matching pass (`geometry_source = 'matched'`). Raw trace medians are good enough to ship and the column already distinguishes them; matching is a refinement for when GPS noise in dense Accra proves it necessary.