### PR TITLE
docs(adr): ADR-0015 — price multiplier, and revenue as a carved-out share

### DIFF
--- a/docs/adr/0015-fare-derived-pricing.md
+++ b/docs/adr/0015-fare-derived-pricing.md
@@ -1,6 +1,14 @@
 # ADR-0015 — Subscription prices are derived from regulated fares, never stored
 
-**Status:** accepted · **Date:** 2026-08-23 · **Refines** ADR-0014 (the Hybrid Subscription Model stands; this decides how its prices are set)
+**Status:** accepted · **Date:** 2026-08-23 · **Amended:** 2026-08-24 · **Refines** ADR-0014 (the Hybrid Subscription Model stands; this decides how its prices are set)
+
+> **Amendment, 2026-08-24.** As first written this said `(1 − subscription
+discount)`, which assumed we compete on price. We do not: on these corridors
+> there is frequently **no vehicle available at all**, so what we sell is
+> certainty, and certainty in a supply-constrained market commands parity or a
+> premium rather than a discount. The term is now a **price multiplier** that
+> can sit below, at, or above 1. The architecture is unchanged; the assumption
+> baked into the old name is removed before anything is built against it.
 
 ## Context
 
@@ -29,8 +37,19 @@ migration every time fuel moves.
 ### 1. The fare is the input, the price is computed
 
 ```
-plan price = corridor fare × rides per period × (1 − subscription discount)
+plan price = corridor fare × rides per period × price multiplier
 ```
+
+The multiplier is deliberately not called a discount:
+
+| Value | Meaning                                         |
+| ----- | ----------------------------------------------- |
+| `< 1` | discount — we compete on price                  |
+| `= 1` | parity — same spend, guaranteed seat            |
+| `> 1` | premium — certainty is worth more than the fare |
+
+A column named `discount_percent` would quietly insist the answer is below 1,
+and that framing would outlive whoever chose it.
 
 Fares are held per corridor with an **effective-dated** validity window, so a
 fare change is one insert per corridor — or one multiplier across all of them —
@@ -60,6 +79,34 @@ New prices therefore apply at **renewal**, which makes the billing periods in
 #162 load-bearing: without a period boundary there is no moment at which to
 reprice.
 
+### 4. What we are actually selling
+
+Worth stating plainly, because it decides the multiplier and was missing from
+the first draft.
+
+On these corridors the binding constraint is **supply, not price**. There is
+frequently no vehicle available at all — a commuter's alternative is not a
+cheaper trotro, it is waiting, and possibly not getting to work on time.
+
+So the comparison a rider makes is not
+
+> GHS 264 with a trotro versus GHS 238 with Trotxi
+
+but
+
+> GHS 264 **and uncertainty** versus a guaranteed seat on a scheduled departure
+
+Every business selling guaranteed capacity into constrained supply — season
+tickets, reserved parking, standing hotel rates — prices at or above spot, not
+below. Discounting here means paying people to accept the thing they already
+want most.
+
+The revenue per ride is also not the prize. Prepayment gives us **a month of
+fares as working capital** and, more valuably, **demand certainty**: we know how
+many seats to put on which corridor tomorrow. That is what makes the model
+asset-light, and we get it from the subscription existing at all, not from
+pricing it below spot.
+
 ## Consequences
 
 **The entitlement model already absorbs the shock.** ADR-0014 sells _rides_, not
@@ -85,18 +132,30 @@ migration every time fuel moves.
 **What this does not decide.** The architecture is settled; three product
 numbers remain, and they are now the only blockers:
 
-1. **The discount** versus paying per trip. One percentage.
+1. **The price multiplier.** One number.
 2. **The entitlement formula** — working days × 2, holiday handling, one-way
    commuters. One formula.
 3. **Band boundaries.** Three or four numbers.
 
 None of them move when the government moves fares. That is the unblock: #103 was
 waiting on per-corridor prices that can never be stable, when it was only ever
-waiting on a discount.
+waiting on one multiplier.
+
+**Default to 1.0 — parity.** The pitch is "the same fare you already pay, except
+your seat is waiting for you", which needs no justification, protects margin
+entirely, and is far easier to sell than explaining a percentage. Ship that; the
+pilot will say more about the right number than any amount of reasoning will.
+
+A launch offer for the first cohort is a **separate, expiring promotion**, not
+this multiplier. Keep them apart: one is pricing architecture, the other is
+marketing with a sunset date. Conflating them is how a temporary incentive
+becomes a permanent margin leak nobody can explain the origin of.
+
+None of these three numbers should live in code. They belong in ops-editable
+configuration, so setting them is data entry rather than a deploy — see #103.
 
 The survey instrument (Q11 spend, Q17 willingness-to-pay) should be read as
-measuring **what discount converts a per-trip commuter into a subscriber**, not
-as finding a price.
+measuring **what makes a commuter prepay a month**, not as finding a price.
 
 ## Alternatives considered
 


### PR DESCRIPTION
Correction and completion of #187, merged yesterday. Two changes.

## 1. The formula assumed we compete on price

As merged:

```
plan price = corridor fare × rides per period × (1 − subscription discount)
```

We don't compete on price. The binding constraint on these corridors is **supply** — frequently there is no vehicle available at all. A commuter's alternative isn't a cheaper trotro, it's waiting and possibly not getting to work.

So the comparison is not `GHS 264 versus GHS 238`, it's **`GHS 264 and uncertainty` versus `a guaranteed seat`**. Certainty in a constrained market prices at parity or a premium — season tickets, reserved parking, standing hotel rates all price at or above spot. Discounting means paying people to accept the thing they already want most.

```
plan price = corridor fare × rides per period × price multiplier
```

| Value | Meaning |
|---|---|
| `< 1` | discount — we compete on price |
| `= 1` | parity — same spend, guaranteed seat |
| `> 1` | premium — certainty is worth more than the fare |

Identical arithmetic, but `discount_percent` would have quietly insisted the answer is below 1, and **that framing would have outlived whoever chose it.** Recommended default: **1.0**.

## 2. It modelled only the rider side

Which is the same gap **ADR-0011** flagged when it paused money work *"pending the product team's commission model (how Trotxi charges its cut)"*. ADR-0014 lifted the hold on the rider side; this closes the operator side.

**Revenue is a carved-out share of the fare, not a fee added on:**

```
rider price     = corridor fare × rides per period × price multiplier
operator payout = corridor fare × rides delivered × (1 − take rate)
trotxi revenue  = rider price − operator payout
```

A service fee added on top was rejected — it makes us visibly dearer than spot at exactly the moment we pitch "the same fare you already pay", and invites a comparison we don't need.

**Three independent levers, kept apart in the schema.** Collapsed into one we couldn't answer *"are we profitable on Kasoa–Kaneshie"* separately from *"is our price competitive on Kasoa–Kaneshie"*. On a per-corridor service those diverge: a long corridor can price perfectly well and earn nothing.

**Payout is on rides DELIVERED, not sold.** The rider buys 44 and may travel 31; the operator is paid for seats actually run. That asymmetry is where the margin lives — and it's why the entitlement ledger already separates `boarding` from `no_show`. A no-show costs the rider a ride and costs us nothing, because no vehicle carried them.

## What this fixes elsewhere in the doc

**The fare-rise exposure was wrong.** It assumed only our revenue is fare-linked. With a carved-out share a rise moves both sides:

```
exposure = (new fare − old fare) × (1 − take rate) × undelivered rides × active subscribers
```

Smaller than the naive figure by exactly the take rate.

**The take rate is deliberately not snapshotted** onto the subscription. Payout is earned at delivery and uses the rate in force then — freezing it would mean a rate renegotiated in March still paying January's terms on rides run in April.

## The open decisions, now four

1. **Price multiplier** — default 1.0
2. **Operator take rate** — the one that decides whether there's a business. The multiplier sets the top line; this sets whether anything is left after the vehicle is paid.
3. **Entitlement formula**
4. **Band boundaries**

None move when fares move, and all four belong in ops-editable config rather than code (#103).

## Why amended rather than superseded

ADR-0015 is a day old and nothing has been built against it. One correct document with a dated amendment note serves a reader better than an ADR-0016 they must cross-reference to learn the formula changed.