### PR TITLE
feat(api): derive prices from corridor fares instead of hardcoded constants

### DIFF
--- a/services/api/src/app.ts
+++ b/services/api/src/app.ts
@@ -11,6 +11,8 @@ import {
 import { z } from 'zod';
 import { InMemoryKvStore, type KvStore } from './kv/kv.store';
 import { FakeObjectStore, type ObjectStore } from './storage/object-store';
+import type { PricingRepository } from './modules/payments/pricing.repository';
+import { pricingRoutes } from './modules/payments/pricing.routes';
 import type { AccountDeletionService } from './modules/users/account-deletion.service';
 import type { RouteLearningService } from './modules/mobility/route-learning.service';
 import { routeLearningRoutes } from './modules/mobility/route-learning.routes';
@@ -145,6 +147,8 @@ export interface AppDeps {
   segmentSpeeds?: SegmentSpeedRepository;
   /** Derives geometry + speeds from completed runs (#179, #181). */
   routeLearning?: RouteLearningService;
+  /** Corridor fares + plan levers (#103); admin-editable, never constants. */
+  pricing?: PricingRepository;
   /** Prometheus /metrics exposure. Defaults to unprotected (dev/tests). */
   metrics?: Partial<MetricsOptions>;
   logger?: boolean;
@@ -347,6 +351,10 @@ export async function buildApp(deps: AppDeps = {}): Promise<FastifyInstance> {
     tripPositions: deps.tripPositions ?? new InMemoryTripPositionRepository(),
     segmentSpeeds: deps.segmentSpeeds,
     kv,
+    rateLimit: deps.rateLimit ?? DEFAULT_RATE_LIMIT,
+  });
+  await app.register(pricingRoutes, {
+    pricing: deps.pricing,
     rateLimit: deps.rateLimit ?? DEFAULT_RATE_LIMIT,
   });
   await app.register(routeLearningRoutes, {

--- a/services/api/src/db/migrations/027_pricing.sql
+++ b/services/api/src/db/migrations/027_pricing.sql
@@ -1,0 +1,113 @@
+-- 027_pricing: move the money numbers out of code and into ops-editable rows
+-- (#103, ADR-0015).
+--
+-- Until now the amounts charged to real people lived in TypeScript constants:
+--
+--   SUBSCRIPTION_FEES_PESEWAS = { monthly: 2000, annual: 20000 }
+--   PLACEHOLDER_RIDES_PER_PERIOD = 44
+--   PLACEHOLDER_CREDIT_PESEWAS_PER_RIDE = 45
+--
+-- Every one of those was invented to make the flow buildable, and all three are
+-- wired to Paystack. Changing them needs a code review and a deploy, which is
+-- what made "decide the prices" feel like an engineering blocker when it never
+-- was. Here they are data.
+--
+-- The model (ADR-0015 §1, §5):
+--   rider price     = corridor fare x rides per period x price multiplier
+--   operator payout = corridor fare x rides DELIVERED x (1 - take rate)
+--   trotxi revenue  = rider price - operator payout
+--
+-- Rates are stored in BASIS POINTS (10000 = 1.0), never floats. The rest of the
+-- money system is integer pesewas for the same reason (ADR-0011): a rate that
+-- cannot be represented exactly turns into a rounding argument with an operator
+-- about a month of payouts.
+
+-- ---------------------------------------------------------------------------
+-- Corridor fares — the regulated input we do not control
+-- ---------------------------------------------------------------------------
+-- Effective-dated because fares are set by government and the transport unions
+-- and move with fuel. A subscription sold in August has to be explainable in
+-- October, after the fare has moved twice.
+CREATE TABLE IF NOT EXISTS corridor_fares (
+  id             uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  route_id       uuid NOT NULL REFERENCES routes (id) ON DELETE CASCADE,
+  fare_pesewas   integer NOT NULL CHECK (fare_pesewas > 0),
+  -- Half-open interval [effective_from, effective_to). NULL `to` = in force.
+  effective_from timestamptz NOT NULL DEFAULT now(),
+  effective_to   timestamptz,
+  -- Why the fare moved: a union announcement, a fuel adjustment, a correction.
+  note           text,
+  created_at     timestamptz NOT NULL DEFAULT now(),
+  CHECK (effective_to IS NULL OR effective_to > effective_from)
+);
+
+-- Exactly one fare in force per corridor at a time. A partial unique index does
+-- what a plain constraint cannot: it lets history pile up while keeping the
+-- present unambiguous, so "what is the fare right now" can never return two rows.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_corridor_fares_current
+  ON corridor_fares (route_id) WHERE effective_to IS NULL;
+CREATE INDEX IF NOT EXISTS idx_corridor_fares_route
+  ON corridor_fares (route_id, effective_from DESC);
+
+-- ---------------------------------------------------------------------------
+-- Plan pricing — the levers that are ours to choose
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS plan_pricing (
+  plan                    text PRIMARY KEY CHECK (plan IN ('monthly', 'annual')),
+  -- Rides granted per period. Placeholder until the entitlement formula
+  -- (working days x 2, holidays, one-way commuters) is decided.
+  rides_per_period        integer NOT NULL CHECK (rides_per_period > 0),
+  -- What the rider pays relative to spot, in basis points. 10000 = parity.
+  -- Deliberately not called a discount: on these corridors the constraint is
+  -- supply, not price, so parity or a premium is the expected answer and a
+  -- column named discount_percent would insist otherwise (ADR-0015 §4).
+  price_multiplier_bp     integer NOT NULL DEFAULT 10000 CHECK (price_multiplier_bp > 0),
+  -- Our share of the fare, in basis points. The multiplier sets the top line;
+  -- this sets whether anything is left once the vehicle has been paid.
+  take_rate_bp            integer NOT NULL CHECK (take_rate_bp BETWEEN 0 AND 10000),
+  -- What one unused ride converts to at period end (ADR-0014 Ride Credit).
+  credit_pesewas_per_ride integer NOT NULL CHECK (credit_pesewas_per_ride >= 0),
+  updated_at              timestamptz NOT NULL DEFAULT now()
+);
+
+-- Seeded with the values already in code, so this migration changes storage and
+-- not behaviour. They remain placeholders — nobody has approved them — but they
+-- are now a row an admin can correct in seconds rather than a constant needing
+-- a deploy. take_rate_bp starts at 0: charging an operator a share nobody has
+-- agreed would be worse than charging nothing.
+INSERT INTO plan_pricing (plan, rides_per_period, price_multiplier_bp, take_rate_bp, credit_pesewas_per_ride)
+VALUES ('monthly', 44, 10000, 0, 45),
+       ('annual',  528, 10000, 0, 45)
+ON CONFLICT (plan) DO NOTHING;
+
+-- ---------------------------------------------------------------------------
+-- Snapshots — what the rider actually bought
+-- ---------------------------------------------------------------------------
+-- Captured on the PAYMENT at checkout, then copied to the subscription when the
+-- webhook activates it. Not re-derived at activation: minutes pass between
+-- checkout and charge.success, and if a fare moved in that window the rider
+-- would be granted rides priced against a fare they never paid. The amount
+-- charged is fixed the moment Paystack is called, so everything derived
+-- alongside it must be fixed then too.
+ALTER TABLE payments
+  ADD COLUMN IF NOT EXISTS rides_granted           integer,
+  ADD COLUMN IF NOT EXISTS fare_pesewas            integer,
+  ADD COLUMN IF NOT EXISTS credit_pesewas_per_ride integer;
+
+-- Frozen at activation so a fare rise cannot change what an active subscriber
+-- owes, nor revalue credit they already hold (ADR-0015 §3). New prices apply at
+-- renewal, which is why the billing periods in #162 are load-bearing.
+--
+-- The take rate is deliberately NOT snapshotted: operator payout is earned per
+-- ride delivered and uses the rate in force then. Freezing it here would mean a
+-- rate renegotiated in March still paying January's terms on April's rides.
+ALTER TABLE subscriptions
+  ADD COLUMN IF NOT EXISTS price_pesewas           integer,
+  ADD COLUMN IF NOT EXISTS rides_granted           integer,
+  ADD COLUMN IF NOT EXISTS fare_pesewas            integer,
+  ADD COLUMN IF NOT EXISTS credit_pesewas_per_ride integer;
+
+COMMENT ON COLUMN subscriptions.price_pesewas IS
+  'What this rider actually paid, frozen at activation. NULL for pre-#103 rows.';
+COMMENT ON COLUMN subscriptions.fare_pesewas IS
+  'The corridor fare the price was derived from — answers "why did they pay this" after the fare has moved.';

--- a/services/api/src/modules/payments/payment.repository.pg.ts
+++ b/services/api/src/modules/payments/payment.repository.pg.ts
@@ -16,6 +16,9 @@ interface PaymentRow {
   plan: SubscriptionPlan | null;
   route_id: string | null;
   amount: number;
+  rides_granted: number | null;
+  fare_pesewas: number | null;
+  credit_pesewas_per_ride: number | null;
   currency: string;
   status: PaymentStatus;
   created_at: Date;
@@ -31,6 +34,9 @@ function toPayment(row: PaymentRow): Payment {
     plan: row.plan,
     routeId: row.route_id,
     amount: row.amount,
+    ridesGranted: row.rides_granted,
+    farePesewas: row.fare_pesewas,
+    creditPesewasPerRide: row.credit_pesewas_per_ride,
     currency: row.currency,
     status: row.status,
     createdAt: row.created_at,
@@ -43,8 +49,9 @@ export class PgPaymentRepository implements PaymentRepository {
 
   async create(input: NewPayment): Promise<Payment> {
     const { rows } = await this.pool.query<PaymentRow>(
-      `INSERT INTO payments (user_id, reference, purpose, plan, route_id, amount, currency)
-       VALUES ($1, $2, $3, $4, $5, $6, $7)
+      `INSERT INTO payments (user_id, reference, purpose, plan, route_id, amount, currency,
+                             rides_granted, fare_pesewas, credit_pesewas_per_ride)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
        RETURNING *`,
       [
         input.userId,
@@ -54,6 +61,9 @@ export class PgPaymentRepository implements PaymentRepository {
         input.routeId ?? null,
         input.amount,
         input.currency,
+        input.ridesGranted ?? null,
+        input.farePesewas ?? null,
+        input.creditPesewasPerRide ?? null,
       ],
     );
     return toPayment(rows[0]!);

--- a/services/api/src/modules/payments/payment.repository.ts
+++ b/services/api/src/modules/payments/payment.repository.ts
@@ -24,6 +24,12 @@ export interface Payment {
   plan: SubscriptionPlan | null;
   /** The route the rider is subscribing to (E3); carried to the subscription on activation. */
   routeId: string | null;
+  /** Rides this payment buys, frozen at checkout (#103). Null for pre-#103 rows. */
+  ridesGranted: number | null;
+  /** The corridor fare the price was derived from, frozen at checkout. */
+  farePesewas: number | null;
+  /** Ride Credit value per unused ride, frozen at checkout. */
+  creditPesewasPerRide: number | null;
   /** Amount in pesewas (1 GHS = 100 pesewas). */
   amount: number;
   /** ISO 4217 currency code (currently always `GHS`). */
@@ -44,6 +50,12 @@ export interface NewPayment {
   /** Amount in pesewas (1 GHS = 100 pesewas). */
   amount: number;
   currency: string;
+  /** Rides this payment buys, frozen at checkout (#103). Null pre-#103. */
+  ridesGranted?: number | null;
+  /** The corridor fare the price was derived from, frozen at checkout. */
+  farePesewas?: number | null;
+  /** Ride Credit value per unused ride, frozen at checkout. */
+  creditPesewasPerRide?: number | null;
 }
 
 /** Persistence for payments. Backed by Postgres in prod, in-memory in dev/tests. */
@@ -85,6 +97,9 @@ export class InMemoryPaymentRepository implements PaymentRepository {
       routeId: input.routeId ?? null,
       amount: input.amount,
       currency: input.currency,
+      ridesGranted: input.ridesGranted ?? null,
+      farePesewas: input.farePesewas ?? null,
+      creditPesewasPerRide: input.creditPesewasPerRide ?? null,
       status: 'pending',
       createdAt: now,
       updatedAt: now,

--- a/services/api/src/modules/payments/payments.routes.ts
+++ b/services/api/src/modules/payments/payments.routes.ts
@@ -16,6 +16,7 @@ import {
 } from './payments.schema';
 import {
   InvalidWebhookError,
+  NotPricedError,
   PaymentsNotConfiguredError,
   type PaymentsService,
 } from './payments.service';
@@ -52,6 +53,7 @@ export async function paymentRoutes(
         response: {
           200: checkoutResponseSchema,
           401: errorResponseSchema,
+          409: errorResponseSchema,
           429: errorResponseSchema,
           503: errorResponseSchema,
         },
@@ -68,6 +70,12 @@ export async function paymentRoutes(
         );
       } catch (err) {
         if (err instanceof PaymentsNotConfiguredError) return reply.code(503).send(UNAVAILABLE);
+        // 409, not 500: the request is well-formed, the corridor simply has no
+        // fare set yet. Deliberately not falling back to a default — charging a
+        // number nobody chose is what #103 exists to prevent.
+        if (err instanceof NotPricedError) {
+          return reply.code(409).send({ error: 'not_priced', message: err.message });
+        }
         throw err;
       }
     },

--- a/services/api/src/modules/payments/payments.schema.ts
+++ b/services/api/src/modules/payments/payments.schema.ts
@@ -3,13 +3,17 @@ import type { SubscriptionPlan } from '../subscriptions/subscription.repository'
 
 // Single source for the plan values; `satisfies` makes TS error if these drift
 // from the SubscriptionPlan union.
-const PLANS = ['monthly', 'annual'] as const satisfies readonly SubscriptionPlan[];
+export const PLANS = ['monthly', 'annual'] as const satisfies readonly SubscriptionPlan[];
 
 export const subscribeBodySchema = z.object({
   plan: z.enum(PLANS),
-  /** The route/corridor the rider commutes (E3); pins the subscription so the
-   * daily ask-dispatch knows which riders to prompt. Optional for now. */
-  routeId: z.string().uuid().optional(),
+  /**
+   * The corridor the rider commutes. **Required since #103**: the price is
+   * derived from that corridor's regulated fare, so there is no meaningful
+   * price for "some route". It also pins the subscription so the daily
+   * ask-dispatch knows which riders to prompt (E3).
+   */
+  routeId: z.string().uuid(),
 });
 
 export const checkoutResponseSchema = z.object({

--- a/services/api/src/modules/payments/payments.service.ts
+++ b/services/api/src/modules/payments/payments.service.ts
@@ -20,7 +20,9 @@ import type {
   SubscriptionRepository,
 } from '../subscriptions/subscription.repository';
 import type { UserRepository } from '../users/user.repository';
-import type { NewPayment, PaymentRepository } from './payment.repository';
+import { derivePrice, type DerivedPrice } from './pricing';
+import type { PricingRepository } from './pricing.repository';
+import type { NewPayment, Payment, PaymentRepository } from './payment.repository';
 import type { PaystackClient } from './paystack.client';
 
 /**
@@ -30,24 +32,23 @@ import type { PaystackClient } from './paystack.client';
 export class PaymentsNotConfiguredError extends Error {}
 
 /**
+ * Thrown when a corridor has no fare in force, or a plan has no pricing row.
+ * Routes map it to HTTP 409: the request is well-formed, the corridor simply is
+ * not priced yet. Deliberately not a fallback to some default — charging a
+ * number nobody chose is exactly what #103 exists to stop.
+ */
+export class NotPricedError extends Error {}
+
+/**
  * Thrown when an incoming Paystack webhook fails signature verification. Routes
  * map it to HTTP 401.
  */
 export class InvalidWebhookError extends Error {}
 
 /**
- * Membership fee in PESEWAS to be on the platform. Server-authoritative
- * (security.md §7). PLACEHOLDERS — replaced by the `plans` table in epic E1b.
- */
-export const SUBSCRIPTION_FEES_PESEWAS: Record<SubscriptionPlan, number> = {
-  monthly: 2000, // GHS 20
-  annual: 20000, // GHS 200
-};
-
-/**
- * Rides granted when a subscription activates. PLACEHOLDER — the real formula
- * (working-days × 2, per tier) lands with the `plans` table in epic E1b; this
- * flat value keeps the allocation flow buildable now (ADR-0014).
+ * Fallback ride count for payments created before #103, whose rows carry no
+ * frozen `ridesGranted`. Live pricing comes from `plan_pricing`; this only
+ * exists so replaying an old webhook still allocates something sane.
  */
 export const PLACEHOLDER_RIDES_PER_PERIOD = 44;
 
@@ -63,8 +64,8 @@ export interface PaymentsServiceDeps {
   paystack?: PaystackClient;
   /** Users, for capturing the payer's verified phone on charge.success (#182). */
   users: UserRepository;
-  /** Plan → membership fee in pesewas (server-authoritative). */
-  subscriptionFees: Record<SubscriptionPlan, number>;
+  /** Corridor fares + plan levers (#103). Prices are derived, never stored. */
+  pricing: PricingRepository;
   /** Rides allocated per activated period (placeholder until E1b tiers). */
   ridesPerPeriod: number;
 }
@@ -122,16 +123,44 @@ export class PaymentsService {
   async initializeSubscription(
     userId: string,
     plan: SubscriptionPlan,
-    routeId?: string | null,
+    routeId: string,
   ): Promise<CheckoutResult> {
+    const price = await this.priceFor(plan, routeId);
     return this.startCheckout({
       userId,
       purpose: 'subscription',
       plan,
-      routeId: routeId ?? null,
-      amount: this.deps.subscriptionFees[plan],
+      routeId,
+      amount: price.pricePesewas,
       currency: 'GHS',
+      // Frozen here, not re-derived at activation: minutes pass before
+      // charge.success arrives, and a fare that moved in that window would
+      // grant rides priced against a fare the rider never paid.
+      ridesGranted: price.ridesGranted,
+      farePesewas: price.farePesewas,
+      creditPesewasPerRide: price.creditPesewasPerRide,
     });
+  }
+
+  /**
+   * Derive what this rider pays for this plan on this corridor.
+   *
+   * routeId is required, unlike before: the price depends on the corridor's
+   * regulated fare, so there is no meaningful price for "some route".
+   *
+   * @param plan - the plan tier.
+   * @param routeId - the corridor being subscribed to.
+   * @returns the derived price and everything snapshotted with it.
+   * @throws NotPricedError when the corridor has no fare or the plan no levers.
+   */
+  async priceFor(plan: SubscriptionPlan, routeId: string): Promise<DerivedPrice> {
+    const [fare, pricing] = await Promise.all([
+      this.deps.pricing.currentFare(routeId),
+      this.deps.pricing.planPricing(plan),
+    ]);
+    if (!fare) throw new NotPricedError(`No fare set for route ${routeId}`);
+    if (!pricing) throw new NotPricedError(`No pricing configured for plan ${plan}`);
+    return derivePrice(fare.farePesewas, pricing);
   }
 
   /**
@@ -188,8 +217,8 @@ export class PaymentsService {
     if (payment.purpose === 'subscription' && payment.plan) {
       // Membership fee paid — activate the subscription (pinned to the paid
       // route) and allocate the period's rides. Both idempotent → replay-safe.
-      await this.activateSubscription(payment.userId, payment.plan, payment.routeId);
-      await this.allocateEntitlement(payment.userId, reference);
+      await this.activateSubscription(payment.userId, payment.plan, payment.routeId, payment);
+      await this.allocateEntitlement(payment.userId, reference, payment.ridesGranted);
     }
 
     // The payer approved this debit on their handset, so the number is verified
@@ -208,11 +237,18 @@ export class PaymentsService {
    *
    * @param userId - the subscriber.
    * @param reference - the payment reference (the allocation's idempotency key).
+   * @param ridesGranted - the count frozen at checkout; null for pre-#103 rows.
    */
-  private async allocateEntitlement(userId: string, reference: string): Promise<void> {
+  private async allocateEntitlement(
+    userId: string,
+    reference: string,
+    ridesGranted: number | null,
+  ): Promise<void> {
     await this.deps.entitlements.record({
       userId,
-      deltaRides: this.deps.ridesPerPeriod,
+      // The count fixed at checkout. Pre-#103 payments have none; those fall
+      // back to the configured default so replaying an old webhook still works.
+      deltaRides: ridesGranted ?? this.deps.ridesPerPeriod,
       reason: 'allocation',
       refType: 'payment',
       refId: reference,
@@ -251,14 +287,27 @@ export class PaymentsService {
    * @param userId - the subscriber.
    * @param plan - the membership tier to activate.
    * @param routeId - the rider's pinned route/corridor (E3).
+   * @param payment - the paid payment, carrying the checkout-time snapshot.
    */
   private async activateSubscription(
     userId: string,
     plan: SubscriptionPlan,
     routeId: string | null,
+    payment: Payment,
   ): Promise<void> {
     try {
-      await this.deps.subscriptions.create({ userId, plan, routeId });
+      await this.deps.subscriptions.create({
+        userId,
+        plan,
+        routeId,
+        // Carried from the payment, so what this rider owes and what their
+        // credit is worth cannot move under them when the fare next changes
+        // (ADR-0015 §3). New prices apply at renewal.
+        pricePesewas: payment.amount,
+        ridesGranted: payment.ridesGranted,
+        farePesewas: payment.farePesewas,
+        creditPesewasPerRide: payment.creditPesewasPerRide,
+      });
     } catch (err) {
       // one-active-per-user index fired — already activated, treat as done.
       if (!isUniqueViolation(err)) throw err;

--- a/services/api/src/modules/payments/pricing.repository.pg.ts
+++ b/services/api/src/modules/payments/pricing.repository.pg.ts
@@ -1,0 +1,130 @@
+// Postgres pricing adapter (#103). Fares are effective-dated; setting a new one
+// closes the previous row rather than overwriting it, so the price a rider paid
+// stays explainable after the fare has moved.
+
+import type { Pool } from 'pg';
+import type { SubscriptionPlan } from '../subscriptions/subscription.repository';
+import type { PlanPricing } from './pricing';
+import type { CorridorFare, PricingRepository } from './pricing.repository';
+
+interface FareRow {
+  id: string;
+  route_id: string;
+  fare_pesewas: number;
+  effective_from: Date;
+  effective_to: Date | null;
+  note: string | null;
+}
+
+interface PlanRow {
+  plan: SubscriptionPlan;
+  rides_per_period: number;
+  price_multiplier_bp: number;
+  take_rate_bp: number;
+  credit_pesewas_per_ride: number;
+}
+
+function toFare(row: FareRow): CorridorFare {
+  return {
+    id: row.id,
+    routeId: row.route_id,
+    farePesewas: row.fare_pesewas,
+    effectiveFrom: row.effective_from,
+    effectiveTo: row.effective_to,
+    note: row.note,
+  };
+}
+
+function toPricing(row: PlanRow): PlanPricing {
+  return {
+    ridesPerPeriod: row.rides_per_period,
+    priceMultiplierBp: row.price_multiplier_bp,
+    takeRateBp: row.take_rate_bp,
+    creditPesewasPerRide: row.credit_pesewas_per_ride,
+  };
+}
+
+export class PgPricingRepository implements PricingRepository {
+  constructor(private readonly pool: Pool) {}
+
+  async currentFare(routeId: string): Promise<CorridorFare | null> {
+    const { rows } = await this.pool.query<FareRow>(
+      `SELECT * FROM corridor_fares WHERE route_id = $1 AND effective_to IS NULL`,
+      [routeId],
+    );
+    return rows[0] ? toFare(rows[0]) : null;
+  }
+
+  async fareHistory(routeId: string): Promise<CorridorFare[]> {
+    const { rows } = await this.pool.query<FareRow>(
+      `SELECT * FROM corridor_fares WHERE route_id = $1 ORDER BY effective_from DESC`,
+      [routeId],
+    );
+    return rows.map(toFare);
+  }
+
+  async setFare(routeId: string, farePesewas: number, note?: string): Promise<CorridorFare> {
+    const client = await this.pool.connect();
+    try {
+      // One transaction: a partial unique index enforces one open fare per
+      // corridor, so closing and opening must happen together or the insert
+      // collides with the row it is replacing.
+      await client.query('BEGIN');
+      await client.query(
+        `UPDATE corridor_fares SET effective_to = now()
+          WHERE route_id = $1 AND effective_to IS NULL`,
+        [routeId],
+      );
+      const { rows } = await client.query<FareRow>(
+        `INSERT INTO corridor_fares (route_id, fare_pesewas, note)
+         VALUES ($1, $2, $3) RETURNING *`,
+        [routeId, farePesewas, note ?? null],
+      );
+      await client.query('COMMIT');
+      return toFare(rows[0]!);
+    } catch (err) {
+      await client.query('ROLLBACK');
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
+  async planPricing(plan: SubscriptionPlan): Promise<PlanPricing | null> {
+    const { rows } = await this.pool.query<PlanRow>(`SELECT * FROM plan_pricing WHERE plan = $1`, [
+      plan,
+    ]);
+    return rows[0] ? toPricing(rows[0]) : null;
+  }
+
+  async allPlanPricing(): Promise<(PlanPricing & { plan: SubscriptionPlan })[]> {
+    const { rows } = await this.pool.query<PlanRow>(`SELECT * FROM plan_pricing ORDER BY plan`);
+    return rows.map((r) => ({ plan: r.plan, ...toPricing(r) }));
+  }
+
+  async updatePlanPricing(
+    plan: SubscriptionPlan,
+    patch: Partial<PlanPricing>,
+  ): Promise<PlanPricing | null> {
+    // COALESCE so an omitted field is left alone rather than nulled — the ops
+    // screen edits one lever at a time.
+    const { rows } = await this.pool.query<PlanRow>(
+      `UPDATE plan_pricing
+          SET rides_per_period        = COALESCE($2, rides_per_period),
+              price_multiplier_bp     = COALESCE($3, price_multiplier_bp),
+              take_rate_bp            = COALESCE($4, take_rate_bp),
+              credit_pesewas_per_ride = COALESCE($5, credit_pesewas_per_ride),
+              updated_at              = now()
+        WHERE plan = $1
+        RETURNING *`,
+      [
+        plan,
+        patch.ridesPerPeriod ?? null,
+        patch.priceMultiplierBp ?? null,
+        patch.takeRateBp ?? null,
+        patch.creditPesewasPerRide ?? null,
+      ],
+    );
+    return rows[0] ? toPricing(rows[0]) : null;
+  }
+}

--- a/services/api/src/modules/payments/pricing.repository.ts
+++ b/services/api/src/modules/payments/pricing.repository.ts
@@ -1,0 +1,134 @@
+// Persistence for the money levers (#103, ADR-0015): per-corridor regulated
+// fares and per-plan pricing configuration.
+//
+// Repository pattern (ADR-0009): interface + InMemory here, Postgres in *.pg.ts.
+
+import type { SubscriptionPlan } from '../subscriptions/subscription.repository';
+import type { PlanPricing } from './pricing';
+
+/** A corridor fare and the window it applies to. */
+export interface CorridorFare {
+  id: string;
+  routeId: string;
+  farePesewas: number;
+  effectiveFrom: Date;
+  /** Null while this is the fare in force. */
+  effectiveTo: Date | null;
+  note: string | null;
+}
+
+/** Persistence for fares and plan pricing. */
+export interface PricingRepository {
+  /**
+   * The fare in force for a corridor.
+   *
+   * @param routeId - the corridor.
+   * @returns the current fare, or null when none has been set.
+   */
+  currentFare(routeId: string): Promise<CorridorFare | null>;
+  /**
+   * Every fare recorded for a corridor, newest first — the audit trail that
+   * answers "why did this rider pay that in August".
+   *
+   * @param routeId - the corridor.
+   * @returns the fare history.
+   */
+  fareHistory(routeId: string): Promise<CorridorFare[]>;
+  /**
+   * Set a corridor's fare, closing the previous one.
+   *
+   * Closing rather than overwriting is the point: a fare change is a new row,
+   * so the old price stays explainable after the union announces again.
+   *
+   * @param routeId - the corridor.
+   * @param farePesewas - the new fare.
+   * @param note - why it changed (announcement, fuel adjustment, correction).
+   * @returns the newly effective fare.
+   */
+  setFare(routeId: string, farePesewas: number, note?: string): Promise<CorridorFare>;
+  /**
+   * The pricing levers for a plan.
+   *
+   * @param plan - the plan tier.
+   * @returns the configured levers, or null when unconfigured.
+   */
+  planPricing(plan: SubscriptionPlan): Promise<PlanPricing | null>;
+  /**
+   * Every plan's levers, for the ops screen.
+   *
+   * @returns all configured plans.
+   */
+  allPlanPricing(): Promise<(PlanPricing & { plan: SubscriptionPlan })[]>;
+  /**
+   * Update a plan's levers.
+   *
+   * @param plan - the plan tier.
+   * @param patch - the fields to change; omitted fields are left alone.
+   * @returns the updated levers, or null when the plan is unknown.
+   */
+  updatePlanPricing(
+    plan: SubscriptionPlan,
+    patch: Partial<PlanPricing>,
+  ): Promise<PlanPricing | null>;
+}
+
+/** In-memory {@link PricingRepository} for dev and unit tests. */
+export class InMemoryPricingRepository implements PricingRepository {
+  private readonly fares: CorridorFare[] = [];
+  private readonly plans = new Map<SubscriptionPlan, PlanPricing>([
+    [
+      'monthly',
+      { ridesPerPeriod: 44, priceMultiplierBp: 10_000, takeRateBp: 0, creditPesewasPerRide: 45 },
+    ],
+    [
+      'annual',
+      { ridesPerPeriod: 528, priceMultiplierBp: 10_000, takeRateBp: 0, creditPesewasPerRide: 45 },
+    ],
+  ]);
+
+  async currentFare(routeId: string): Promise<CorridorFare | null> {
+    return this.fares.find((f) => f.routeId === routeId && f.effectiveTo === null) ?? null;
+  }
+
+  async fareHistory(routeId: string): Promise<CorridorFare[]> {
+    return this.fares
+      .filter((f) => f.routeId === routeId)
+      .sort((a, b) => b.effectiveFrom.getTime() - a.effectiveFrom.getTime());
+  }
+
+  async setFare(routeId: string, farePesewas: number, note?: string): Promise<CorridorFare> {
+    const now = new Date();
+    const current = await this.currentFare(routeId);
+    if (current) current.effectiveTo = now;
+
+    const fare: CorridorFare = {
+      id: crypto.randomUUID(),
+      routeId,
+      farePesewas,
+      effectiveFrom: now,
+      effectiveTo: null,
+      note: note ?? null,
+    };
+    this.fares.push(fare);
+    return fare;
+  }
+
+  async planPricing(plan: SubscriptionPlan): Promise<PlanPricing | null> {
+    return this.plans.get(plan) ?? null;
+  }
+
+  async allPlanPricing(): Promise<(PlanPricing & { plan: SubscriptionPlan })[]> {
+    return [...this.plans.entries()].map(([plan, pricing]) => ({ plan, ...pricing }));
+  }
+
+  async updatePlanPricing(
+    plan: SubscriptionPlan,
+    patch: Partial<PlanPricing>,
+  ): Promise<PlanPricing | null> {
+    const existing = this.plans.get(plan);
+    if (!existing) return null;
+    const updated = { ...existing, ...patch };
+    this.plans.set(plan, updated);
+    return updated;
+  }
+}

--- a/services/api/src/modules/payments/pricing.routes.ts
+++ b/services/api/src/modules/payments/pricing.routes.ts
@@ -1,0 +1,173 @@
+// Admin pricing routes (#103, ADR-0015). The point of this module: the numbers
+// we charge real people are data an admin can correct in seconds, not constants
+// requiring a code review and a deploy.
+
+import type { FastifyInstance } from 'fastify';
+import type { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { z } from 'zod';
+import { errorResponseSchema } from '../../lib/schemas';
+import type { RateLimitConfig } from '../ratelimit/ratelimit.plugin';
+import { PLANS } from './payments.schema';
+import type { PricingRepository } from './pricing.repository';
+
+const fareResponseSchema = z.object({
+  id: z.string().uuid(),
+  routeId: z.string().uuid(),
+  farePesewas: z.number().int(),
+  effectiveFrom: z.date(),
+  effectiveTo: z.date().nullable(),
+  note: z.string().nullable(),
+});
+
+const planPricingResponseSchema = z.object({
+  plan: z.enum(PLANS),
+  ridesPerPeriod: z.number().int(),
+  priceMultiplierBp: z.number().int(),
+  takeRateBp: z.number().int(),
+  creditPesewasPerRide: z.number().int(),
+});
+
+const setFareBodySchema = z.object({
+  farePesewas: z.number().int().positive(),
+  /** Why it changed — a union announcement, a fuel adjustment, a correction. */
+  note: z.string().max(500).optional(),
+});
+
+const updatePlanBodySchema = z
+  .object({
+    ridesPerPeriod: z.number().int().positive(),
+    priceMultiplierBp: z.number().int().positive(),
+    takeRateBp: z.number().int().min(0).max(10_000),
+    creditPesewasPerRide: z.number().int().min(0),
+  })
+  .partial();
+
+/**
+ * Register the admin pricing routes.
+ *
+ * @param app - the Fastify instance to register on.
+ * @param opts - route dependencies.
+ * @param opts.pricing - the pricing repository (503 when absent).
+ * @param opts.rateLimit - rate-limit config (applied per user).
+ */
+export async function pricingRoutes(
+  app: FastifyInstance,
+  opts: { pricing?: PricingRepository; rateLimit: RateLimitConfig },
+): Promise<void> {
+  const r = app.withTypeProvider<ZodTypeProvider>();
+  const UNAVAILABLE = { error: 'unavailable', message: 'Pricing is not configured' };
+  const adminOnly = [
+    app.authenticate,
+    app.rateLimit({ ...opts.rateLimit, by: 'user' }),
+    app.requireRole('admin'),
+  ];
+
+  r.get(
+    '/admin/routes/:id/fares',
+    {
+      schema: {
+        tags: ['admin'],
+        summary: "A corridor's fare history, newest first",
+        description:
+          'The audit trail behind every price. Fares are effective-dated because ' +
+          'government and the transport unions set them, so a subscription sold in ' +
+          'August has to stay explainable in October.',
+        security: [{ bearerAuth: [] }],
+        params: z.object({ id: z.string().uuid() }),
+        response: {
+          200: z.object({ fares: z.array(fareResponseSchema) }),
+          401: errorResponseSchema,
+          403: errorResponseSchema,
+          503: errorResponseSchema,
+        },
+      },
+      preHandler: adminOnly,
+    },
+    async (request, reply) => {
+      if (!opts.pricing) return reply.code(503).send(UNAVAILABLE);
+      return { fares: await opts.pricing.fareHistory(request.params.id) };
+    },
+  );
+
+  r.put(
+    '/admin/routes/:id/fare',
+    {
+      schema: {
+        tags: ['admin'],
+        summary: "Set a corridor's fare (closes the previous one)",
+        description:
+          'Records a new fare and closes the one it replaces rather than overwriting ' +
+          'it. Every plan price on this corridor recomputes from it; existing ' +
+          'subscriptions keep the price they were sold at until renewal.',
+        security: [{ bearerAuth: [] }],
+        params: z.object({ id: z.string().uuid() }),
+        body: setFareBodySchema,
+        response: {
+          200: fareResponseSchema,
+          401: errorResponseSchema,
+          403: errorResponseSchema,
+          503: errorResponseSchema,
+        },
+      },
+      preHandler: adminOnly,
+    },
+    async (request, reply) => {
+      if (!opts.pricing) return reply.code(503).send(UNAVAILABLE);
+      return opts.pricing.setFare(request.params.id, request.body.farePesewas, request.body.note);
+    },
+  );
+
+  r.get(
+    '/admin/plan-pricing',
+    {
+      schema: {
+        tags: ['admin'],
+        summary: 'The pricing levers for every plan',
+        security: [{ bearerAuth: [] }],
+        response: {
+          200: z.object({ plans: z.array(planPricingResponseSchema) }),
+          401: errorResponseSchema,
+          403: errorResponseSchema,
+          503: errorResponseSchema,
+        },
+      },
+      preHandler: adminOnly,
+    },
+    async (_request, reply) => {
+      if (!opts.pricing) return reply.code(503).send(UNAVAILABLE);
+      return { plans: await opts.pricing.allPlanPricing() };
+    },
+  );
+
+  r.patch(
+    '/admin/plan-pricing/:plan',
+    {
+      schema: {
+        tags: ['admin'],
+        summary: 'Update a plan’s multiplier, take rate, ride count or credit value',
+        description:
+          'Rates are basis points: 10000 = 1.0. priceMultiplierBp is what the rider ' +
+          'pays relative to spot (10000 = parity); takeRateBp is our share of the ' +
+          'fare. Changes apply to new subscriptions and renewals, never to an ' +
+          'active period.',
+        security: [{ bearerAuth: [] }],
+        params: z.object({ plan: z.enum(PLANS) }),
+        body: updatePlanBodySchema,
+        response: {
+          200: planPricingResponseSchema,
+          401: errorResponseSchema,
+          403: errorResponseSchema,
+          404: errorResponseSchema,
+          503: errorResponseSchema,
+        },
+      },
+      preHandler: adminOnly,
+    },
+    async (request, reply) => {
+      if (!opts.pricing) return reply.code(503).send(UNAVAILABLE);
+      const updated = await opts.pricing.updatePlanPricing(request.params.plan, request.body);
+      if (!updated) return reply.code(404).send({ error: 'not_found', message: 'Unknown plan' });
+      return { plan: request.params.plan, ...updated };
+    },
+  );
+}

--- a/services/api/src/modules/payments/pricing.ts
+++ b/services/api/src/modules/payments/pricing.ts
@@ -1,0 +1,113 @@
+// Deriving what a rider pays and what an operator earns (#103, ADR-0015).
+//
+// Pure functions over integers. No floats anywhere: rates are basis points
+// (10000 = 1.0) and money is pesewas, matching the rest of the money system
+// (ADR-0011). A rate that cannot be represented exactly becomes a rounding
+// argument with an operator about a month of payouts.
+//
+//   rider price     = fare x rides per period x multiplier
+//   operator payout = fare x rides DELIVERED  x (1 - take rate)
+//   trotxi revenue  = rider price - operator payout
+//
+// Note the asymmetry in the middle term: the rider buys rides, the operator is
+// paid for seats actually run. A rider who buys 44 and travels 31 costs us 31
+// payouts. That gap is where the margin lives, and it is why the entitlement
+// ledger separates `boarding` from `no_show`.
+
+/** One basis point is 1/10000. 10000 bp = 1.0 = parity. */
+export const BASIS_POINTS = 10_000;
+
+/** The ops-editable levers for one plan. Mirrors the plan_pricing row. */
+export interface PlanPricing {
+  ridesPerPeriod: number;
+  /** What the rider pays relative to spot. 10000 = parity (ADR-0015 §4). */
+  priceMultiplierBp: number;
+  /** Our share of the fare, in basis points. */
+  takeRateBp: number;
+  /** What one unused ride converts to at period end. */
+  creditPesewasPerRide: number;
+}
+
+/** A priced plan, ready to charge and to snapshot onto the subscription. */
+export interface DerivedPrice {
+  /** What the rider is charged, in pesewas. */
+  pricePesewas: number;
+  /** Rides granted for the period. */
+  ridesGranted: number;
+  /** The corridor fare this was derived from, for the audit trail. */
+  farePesewas: number;
+  /** Credit value per unused ride, frozen with the rest. */
+  creditPesewasPerRide: number;
+}
+
+/**
+ * Multiply a pesewa amount by a basis-point rate, rounding half up.
+ *
+ * Rounding is explicit rather than inherited from float behaviour: at parity
+ * the result is exact, and away from parity a rider should never be charged a
+ * fraction of a pesewa that Paystack cannot represent.
+ *
+ * @param pesewas - the amount to scale.
+ * @param bp - the rate in basis points.
+ * @returns the scaled amount in whole pesewas.
+ */
+export function applyBp(pesewas: number, bp: number): number {
+  return Math.round((pesewas * bp) / BASIS_POINTS);
+}
+
+/**
+ * What a rider pays for a plan on a corridor.
+ *
+ * @param farePesewas - the corridor's fare in force.
+ * @param pricing - the plan's ops-configured levers.
+ * @returns the price plus everything to snapshot alongside it.
+ */
+export function derivePrice(farePesewas: number, pricing: PlanPricing): DerivedPrice {
+  const spend = farePesewas * pricing.ridesPerPeriod;
+  return {
+    pricePesewas: applyBp(spend, pricing.priceMultiplierBp),
+    ridesGranted: pricing.ridesPerPeriod,
+    farePesewas,
+    creditPesewasPerRide: pricing.creditPesewasPerRide,
+  };
+}
+
+/**
+ * What the operator earns for the seats they actually ran.
+ *
+ * Delivered rides, not rides sold — see the file header.
+ *
+ * @param farePesewas - the fare in force when the rides were delivered.
+ * @param ridesDelivered - seats actually carried.
+ * @param takeRateBp - our share, in basis points.
+ * @returns the operator's payout in pesewas.
+ */
+export function deriveOperatorPayout(
+  farePesewas: number,
+  ridesDelivered: number,
+  takeRateBp: number,
+): number {
+  const gross = farePesewas * ridesDelivered;
+  return gross - applyBp(gross, takeRateBp);
+}
+
+/**
+ * Our revenue on a subscription, given how much of it was actually travelled.
+ *
+ * Worth computing rather than assuming: at parity with a zero take rate this is
+ * exactly the value of the rides the rider did not use, which is a
+ * uncomfortable business to be in and better seen than discovered.
+ *
+ * @param price - the derived price the rider paid.
+ * @param ridesDelivered - seats actually carried in the period.
+ * @param takeRateBp - our share, in basis points.
+ * @returns revenue in pesewas; negative means the period lost money.
+ */
+export function deriveRevenue(
+  price: DerivedPrice,
+  ridesDelivered: number,
+  takeRateBp: number,
+): number {
+  const payout = deriveOperatorPayout(price.farePesewas, ridesDelivered, takeRateBp);
+  return price.pricePesewas - payout;
+}

--- a/services/api/src/modules/subscriptions/subscription.repository.pg.ts
+++ b/services/api/src/modules/subscriptions/subscription.repository.pg.ts
@@ -13,6 +13,10 @@ interface SubscriptionRow {
   plan: SubscriptionPlan;
   status: SubscriptionStatus;
   route_id: string | null;
+  price_pesewas: number | null;
+  rides_granted: number | null;
+  fare_pesewas: number | null;
+  credit_pesewas_per_ride: number | null;
   created_at: Date;
 }
 
@@ -23,6 +27,10 @@ function toSubscription(row: SubscriptionRow): Subscription {
     plan: row.plan,
     status: row.status,
     routeId: row.route_id,
+    pricePesewas: row.price_pesewas,
+    ridesGranted: row.rides_granted,
+    farePesewas: row.fare_pesewas,
+    creditPesewasPerRide: row.credit_pesewas_per_ride,
     createdAt: row.created_at,
   };
 }
@@ -33,10 +41,19 @@ export class PgSubscriptionRepository implements SubscriptionRepository {
   /** Creates a new subscription for a user with the given plan + route. Status defaults to 'active'. */
   async create(input: NewSubscription): Promise<Subscription> {
     const { rows } = await this.pool.query<SubscriptionRow>(
-      `INSERT INTO subscriptions (user_id, plan, route_id)
-       VALUES ($1, $2, $3)
+      `INSERT INTO subscriptions (user_id, plan, route_id,
+                                  price_pesewas, rides_granted, fare_pesewas, credit_pesewas_per_ride)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)
        RETURNING *`,
-      [input.userId, input.plan, input.routeId ?? null],
+      [
+        input.userId,
+        input.plan,
+        input.routeId ?? null,
+        input.pricePesewas ?? null,
+        input.ridesGranted ?? null,
+        input.farePesewas ?? null,
+        input.creditPesewasPerRide ?? null,
+      ],
     );
     return toSubscription(rows[0]!);
   }

--- a/services/api/src/modules/subscriptions/subscription.repository.ts
+++ b/services/api/src/modules/subscriptions/subscription.repository.ts
@@ -9,6 +9,14 @@ export interface Subscription {
   status: SubscriptionStatus;
   /** The rider's pinned route/corridor (E3); null for pre-E3 subscriptions. */
   routeId: string | null;
+  /** What this rider actually paid, frozen at activation (#103). */
+  pricePesewas: number | null;
+  /** Rides granted for the period, frozen at activation. */
+  ridesGranted: number | null;
+  /** The corridor fare the price was derived from — the audit trail. */
+  farePesewas: number | null;
+  /** Ride Credit value per unused ride, frozen at activation. */
+  creditPesewasPerRide: number | null;
   createdAt: Date;
 }
 
@@ -17,6 +25,10 @@ export interface NewSubscription {
   userId: string;
   plan: SubscriptionPlan;
   routeId?: string | null;
+  pricePesewas?: number | null;
+  ridesGranted?: number | null;
+  farePesewas?: number | null;
+  creditPesewasPerRide?: number | null;
 }
 
 /** Persistence for memberships; one active subscription per user. */
@@ -70,6 +82,10 @@ export class InMemorySubscriptionRepository implements SubscriptionRepository {
       plan: input.plan,
       status: 'active',
       routeId: input.routeId ?? null,
+      pricePesewas: input.pricePesewas ?? null,
+      ridesGranted: input.ridesGranted ?? null,
+      farePesewas: input.farePesewas ?? null,
+      creditPesewasPerRide: input.creditPesewasPerRide ?? null,
       createdAt: new Date(),
     };
     this.subscriptions.set(subscription.id, subscription);

--- a/services/api/src/server.ts
+++ b/services/api/src/server.ts
@@ -45,6 +45,11 @@ import {
   InMemoryRouteGeometryRepository,
   type RouteGeometryRepository,
 } from './modules/mobility/route-geometry.repository';
+import {
+  InMemoryPricingRepository,
+  type PricingRepository,
+} from './modules/payments/pricing.repository';
+import { PgPricingRepository } from './modules/payments/pricing.repository.pg';
 import { PgRouteGeometryRepository } from './modules/mobility/route-geometry.repository.pg';
 import { RouteLearningService } from './modules/mobility/route-learning.service';
 import {
@@ -90,11 +95,7 @@ import {
 import { PgPaymentRepository } from './modules/payments/payment.repository.pg';
 import { FakePaystackClient, type PaystackClient } from './modules/payments/paystack.client';
 import { PaystackHttpClient } from './modules/payments/paystack.client.live';
-import {
-  PaymentsService,
-  PLACEHOLDER_RIDES_PER_PERIOD,
-  SUBSCRIPTION_FEES_PESEWAS,
-} from './modules/payments/payments.service';
+import { PaymentsService, PLACEHOLDER_RIDES_PER_PERIOD } from './modules/payments/payments.service';
 import {
   InMemoryEntitlementLedgerRepository,
   type EntitlementLedgerRepository,
@@ -170,6 +171,7 @@ async function main(): Promise<void> {
   let routeStops: RouteStopRepository;
   let trips: TripRepository;
   let tripPositions: TripPositionRepository;
+  let pricing: PricingRepository;
   let routeGeometry: RouteGeometryRepository;
   let segmentSpeeds: SegmentSpeedRepository;
   let vehicles: VehicleRepository;
@@ -193,6 +195,7 @@ async function main(): Promise<void> {
     routeStops = new PgRouteStopRepository(pool);
     trips = new PgTripRepository(pool);
     tripPositions = new PgTripPositionRepository(pool);
+    pricing = new PgPricingRepository(pool);
     routeGeometry = new PgRouteGeometryRepository(pool);
     segmentSpeeds = new PgSegmentSpeedRepository(pool);
     vehicles = new PgVehicleRepository(pool);
@@ -216,6 +219,7 @@ async function main(): Promise<void> {
     routeStops = new InMemoryRouteStopRepository();
     trips = new InMemoryTripRepository();
     tripPositions = new InMemoryTripPositionRepository();
+    pricing = new InMemoryPricingRepository();
     routeGeometry = new InMemoryRouteGeometryRepository();
     segmentSpeeds = new InMemorySegmentSpeedRepository();
     vehicles = new InMemoryVehicleRepository();
@@ -296,7 +300,7 @@ async function main(): Promise<void> {
     entitlements,
     users,
     paystack,
-    subscriptionFees: SUBSCRIPTION_FEES_PESEWAS,
+    pricing,
     ridesPerPeriod: PLACEHOLDER_RIDES_PER_PERIOD,
   });
 
@@ -372,6 +376,7 @@ async function main(): Promise<void> {
     mapTilesUrl: env.MAP_TILES_URL,
     segmentSpeeds,
     routeLearning,
+    pricing,
     isReady,
     auth,
     rateLimit,

--- a/services/api/tests/payments-phone-capture.test.ts
+++ b/services/api/tests/payments-phone-capture.test.ts
@@ -5,23 +5,27 @@ import { PaymentsService } from '../src/modules/payments/payments.service';
 import { InMemorySubscriptionRepository } from '../src/modules/subscriptions/subscription.repository';
 import { InMemoryEntitlementLedgerRepository } from '../src/modules/entitlements/entitlement-ledger.repository';
 import { InMemoryUserRepository, type User } from '../src/modules/users/user.repository';
+import { InMemoryPricingRepository } from '../src/modules/payments/pricing.repository';
 
 const FAKE_SECRET = 'fake-paystack-secret';
-const FEES = { monthly: 2000, annual: 20000 } as const;
+const FARE = 600;
+const ROUTE = '11111111-1111-4111-8111-111111111111';
 
 async function make(users = new InMemoryUserRepository()) {
   const payments = new InMemoryPaymentRepository();
   const subscriptions = new InMemorySubscriptionRepository();
+  const pricing = new InMemoryPricingRepository();
+  await pricing.setFare(ROUTE, FARE);
   const service = new PaymentsService({
     payments,
     subscriptions,
     entitlements: new InMemoryEntitlementLedgerRepository(),
     users,
     paystack: new FakePaystackClient(FAKE_SECRET),
-    subscriptionFees: FEES,
+    pricing,
     ridesPerPeriod: 44,
   });
-  return { service, payments, subscriptions, users };
+  return { service, payments, subscriptions, users, pricing };
 }
 
 /** A charge.success payload carrying the payer's mobile-money number. */
@@ -43,7 +47,7 @@ describe('phone capture on charge.success (#182)', () => {
     const user = await users.create({ displayName: 'Ama' });
     const { service } = await make(users);
 
-    const { reference } = await service.initializeSubscription(user.id, 'monthly');
+    const { reference } = await service.initializeSubscription(user.id, 'monthly', ROUTE);
     const { body, signature } = chargeSuccess(reference, '0244123456');
     await service.handleWebhook(body, signature);
 
@@ -57,7 +61,7 @@ describe('phone capture on charge.success (#182)', () => {
     const user = await users.create({ displayName: 'Ama' });
     const { service } = await make(users);
 
-    const { reference } = await service.initializeSubscription(user.id, 'monthly');
+    const { reference } = await service.initializeSubscription(user.id, 'monthly', ROUTE);
     const { body, signature } = chargeSuccess(reference, undefined, '+233 244 999 888');
     await service.handleWebhook(body, signature);
 
@@ -69,7 +73,7 @@ describe('phone capture on charge.success (#182)', () => {
     const user = await users.create({ displayName: 'Ama', phone: '+233201111111' });
     const { service } = await make(users);
 
-    const { reference } = await service.initializeSubscription(user.id, 'monthly');
+    const { reference } = await service.initializeSubscription(user.id, 'monthly', ROUTE);
     const { body, signature } = chargeSuccess(reference, '0244123456');
     await service.handleWebhook(body, signature);
 
@@ -89,7 +93,7 @@ describe('phone capture on charge.success (#182)', () => {
     }) as InMemoryUserRepository;
 
     const { service, subscriptions, payments } = await make(exploding);
-    const { reference } = await service.initializeSubscription(user.id, 'monthly');
+    const { reference } = await service.initializeSubscription(user.id, 'monthly', ROUTE);
     const { body, signature } = chargeSuccess(reference, '0244123456');
 
     await expect(service.handleWebhook(body, signature)).resolves.toBeUndefined();
@@ -102,7 +106,7 @@ describe('phone capture on charge.success (#182)', () => {
     const user = await users.create({ displayName: 'Ama' });
     const { service } = await make(users);
 
-    const { reference } = await service.initializeSubscription(user.id, 'monthly');
+    const { reference } = await service.initializeSubscription(user.id, 'monthly', ROUTE);
     const { body, signature } = chargeSuccess(reference, 'not-a-number');
     await service.handleWebhook(body, signature);
 

--- a/services/api/tests/payments.routes.test.ts
+++ b/services/api/tests/payments.routes.test.ts
@@ -3,6 +3,7 @@ import { buildApp } from '../src/app';
 import { InMemoryPaymentRepository } from '../src/modules/payments/payment.repository';
 import { FakePaystackClient, paystackSignature } from '../src/modules/payments/paystack.client';
 import { InMemoryUserRepository } from '../src/modules/users/user.repository';
+import { InMemoryPricingRepository } from '../src/modules/payments/pricing.repository';
 import { PaymentsService } from '../src/modules/payments/payments.service';
 import { InMemorySubscriptionRepository } from '../src/modules/subscriptions/subscription.repository';
 import { InMemoryEntitlementLedgerRepository } from '../src/modules/entitlements/entitlement-ledger.repository';
@@ -18,16 +19,22 @@ const jwt = createJwtService(auth);
 const FAKE_SECRET = 'fake-paystack-secret';
 const bearer = (t: string) => ({ authorization: `Bearer ${t}` });
 
+const ROUTE = '11111111-1111-4111-8111-111111111111';
+const FARE = 600;
+
 function appWithPayments() {
   const subscriptions = new InMemorySubscriptionRepository();
   const entitlements = new InMemoryEntitlementLedgerRepository();
+  const pricing = new InMemoryPricingRepository();
+  // Price the corridor: since #103 there is no price without a fare in force.
+  void pricing.setFare(ROUTE, FARE);
   const paymentsService = new PaymentsService({
     payments: new InMemoryPaymentRepository(),
     subscriptions,
     entitlements,
     paystack: new FakePaystackClient(FAKE_SECRET),
     users: new InMemoryUserRepository(),
-    subscriptionFees: { monthly: 2000, annual: 20000 },
+    pricing,
     ridesPerPeriod: 44,
   });
   // Share the entitlements instance with the app so GET /me/rides sees the
@@ -56,7 +63,7 @@ describe('POST /payments/subscribe', () => {
         await app.inject({
           method: 'POST',
           url: '/payments/subscribe',
-          payload: { plan: 'monthly' },
+          payload: { plan: 'monthly', routeId: ROUTE },
         })
       ).statusCode,
     ).toBe(401);
@@ -69,7 +76,7 @@ describe('POST /payments/subscribe', () => {
       method: 'POST',
       url: '/payments/subscribe',
       headers: bearer(token),
-      payload: { plan: 'monthly' },
+      payload: { plan: 'monthly', routeId: ROUTE },
     });
     expect(res.statusCode).toBe(200);
     expect(res.json().authorizationUrl).toBeTruthy();
@@ -85,7 +92,7 @@ describe('POST /payments/subscribe', () => {
           method: 'POST',
           url: '/payments/subscribe',
           headers: bearer(token),
-          payload: { plan: 'monthly' },
+          payload: { plan: 'monthly', routeId: ROUTE },
         })
       ).statusCode,
     ).toBe(503);
@@ -114,7 +121,7 @@ describe('POST /webhooks/paystack', () => {
         method: 'POST',
         url: '/payments/subscribe',
         headers: bearer(token),
-        payload: { plan: 'monthly' },
+        payload: { plan: 'monthly', routeId: ROUTE },
       })
     ).json();
 

--- a/services/api/tests/payments.service.test.ts
+++ b/services/api/tests/payments.service.test.ts
@@ -3,6 +3,7 @@ import { InMemoryPaymentRepository } from '../src/modules/payments/payment.repos
 import { FakePaystackClient, paystackSignature } from '../src/modules/payments/paystack.client';
 import {
   InvalidWebhookError,
+  NotPricedError,
   PaymentsNotConfiguredError,
   PaymentsService,
 } from '../src/modules/payments/payments.service';
@@ -12,24 +13,35 @@ import {
 } from '../src/modules/subscriptions/subscription.repository';
 import { InMemoryEntitlementLedgerRepository } from '../src/modules/entitlements/entitlement-ledger.repository';
 import { InMemoryUserRepository } from '../src/modules/users/user.repository';
+import { InMemoryPricingRepository } from '../src/modules/payments/pricing.repository';
 
 const FAKE_SECRET = 'fake-paystack-secret';
-const subscriptionFees = { monthly: 2000, annual: 20000 }; // pesewas (GHS 20 / 200)
 const RIDES = 44;
+/** GHS 6 a trip — a plausible Accra corridor fare. */
+const FARE = 600;
+const ROUTE = '11111111-1111-4111-8111-111111111111';
 
 function make(subscriptions: SubscriptionRepository = new InMemorySubscriptionRepository()) {
   const payments = new InMemoryPaymentRepository();
   const entitlements = new InMemoryEntitlementLedgerRepository();
+  const pricing = new InMemoryPricingRepository();
   const service = new PaymentsService({
     payments,
     subscriptions,
     entitlements,
     paystack: new FakePaystackClient(FAKE_SECRET),
     users: new InMemoryUserRepository(),
-    subscriptionFees,
+    pricing,
     ridesPerPeriod: RIDES,
   });
-  return { payments, subscriptions, entitlements, service };
+  return { payments, subscriptions, entitlements, pricing, service };
+}
+
+/** A priced corridor: without a fare in force there is no price to charge. */
+async function priced(subscriptions?: SubscriptionRepository) {
+  const ctx = make(subscriptions);
+  await ctx.pricing.setFare(ROUTE, FARE);
+  return ctx;
 }
 
 function chargeSuccess(reference: string): { body: string; signature: string } {
@@ -38,28 +50,69 @@ function chargeSuccess(reference: string): { body: string; signature: string } {
 }
 
 describe('PaymentsService.initializeSubscription', () => {
-  it('creates a pending payment with the membership fee + a checkout URL', async () => {
-    const { service, payments } = make();
-    const { reference, authorizationUrl } = await service.initializeSubscription('u1', 'monthly');
+  it('derives the price from the corridor fare rather than a constant', async () => {
+    const { service, payments } = await priced();
+    const { reference, authorizationUrl } = await service.initializeSubscription(
+      'u1',
+      'monthly',
+      ROUTE,
+    );
     expect(authorizationUrl).toBeTruthy();
     expect(await payments.findByReference(reference)).toMatchObject({
       purpose: 'subscription',
       plan: 'monthly',
-      amount: 2000,
+      // fare x rides x parity = 600 x 44 = GHS 264, not the old flat GHS 20.
+      amount: FARE * RIDES,
       status: 'pending',
     });
   });
 
+  it('freezes the price inputs on the payment at checkout', async () => {
+    // Not re-derived at activation: minutes pass before charge.success, and a
+    // fare that moved in that window would grant rides priced against a fare
+    // the rider never paid.
+    const { service, payments } = await priced();
+    const { reference } = await service.initializeSubscription('u1', 'monthly', ROUTE);
+
+    expect(await payments.findByReference(reference)).toMatchObject({
+      ridesGranted: RIDES,
+      farePesewas: FARE,
+      creditPesewasPerRide: 45,
+    });
+  });
+
+  it('refuses to price a corridor with no fare rather than inventing one', async () => {
+    const { service } = make(); // no fare set
+    await expect(service.initializeSubscription('u1', 'monthly', ROUTE)).rejects.toBeInstanceOf(
+      NotPricedError,
+    );
+  });
+
+  it('charges the new fare after a fare change, without touching what is sold', async () => {
+    const { service, payments, pricing } = await priced();
+    const before = await service.initializeSubscription('u1', 'monthly', ROUTE);
+
+    await pricing.setFare(ROUTE, 700, 'fuel adjustment');
+    const after = await service.initializeSubscription('u2', 'monthly', ROUTE);
+
+    expect((await payments.findByReference(before.reference))?.amount).toBe(FARE * RIDES);
+    expect((await payments.findByReference(after.reference))?.amount).toBe(700 * RIDES);
+  });
+
   it('throws when payments are not configured', async () => {
+    // Priced, so the failure is Paystack being absent rather than the corridor
+    // having no fare — those are different errors with different status codes.
+    const unpricedButConfigured = new InMemoryPricingRepository();
+    await unpricedButConfigured.setFare(ROUTE, FARE);
     const service = new PaymentsService({
       payments: new InMemoryPaymentRepository(),
       subscriptions: new InMemorySubscriptionRepository(),
       entitlements: new InMemoryEntitlementLedgerRepository(),
       users: new InMemoryUserRepository(),
-      subscriptionFees,
+      pricing: unpricedButConfigured,
       ridesPerPeriod: RIDES,
     });
-    await expect(service.initializeSubscription('u1', 'monthly')).rejects.toBeInstanceOf(
+    await expect(service.initializeSubscription('u1', 'monthly', ROUTE)).rejects.toBeInstanceOf(
       PaymentsNotConfiguredError,
     );
   });
@@ -72,8 +125,8 @@ describe('PaymentsService.handleWebhook', () => {
   });
 
   it('subscription paid: activates the subscription, allocates rides, marks paid', async () => {
-    const { service, subscriptions, payments, entitlements } = make();
-    const { reference } = await service.initializeSubscription('u1', 'monthly');
+    const { service, subscriptions, payments, entitlements } = await priced();
+    const { reference } = await service.initializeSubscription('u1', 'monthly', ROUTE);
     const { body, signature } = chargeSuccess(reference);
 
     await service.handleWebhook(body, signature);
@@ -84,8 +137,9 @@ describe('PaymentsService.handleWebhook', () => {
   });
 
   it('pins the paid route onto the activated subscription (E3 rider↔route)', async () => {
-    const { service, subscriptions } = make();
+    const { service, subscriptions, pricing } = make();
     const routeId = crypto.randomUUID();
+    await pricing.setFare(routeId, FARE);
     const { reference } = await service.initializeSubscription('u1', 'monthly', routeId);
     const { body, signature } = chargeSuccess(reference);
 
@@ -96,8 +150,8 @@ describe('PaymentsService.handleWebhook', () => {
   });
 
   it('is idempotent — a replayed webhook does not double-activate or double-allocate', async () => {
-    const { service, subscriptions, entitlements } = make();
-    const { reference } = await service.initializeSubscription('u1', 'monthly');
+    const { service, subscriptions, entitlements } = await priced();
+    const { reference } = await service.initializeSubscription('u1', 'monthly', ROUTE);
     const { body, signature } = chargeSuccess(reference);
 
     await service.handleWebhook(body, signature);
@@ -107,8 +161,8 @@ describe('PaymentsService.handleWebhook', () => {
   });
 
   it('ignores non charge.success events and unknown references', async () => {
-    const { service, subscriptions } = make();
-    const { reference } = await service.initializeSubscription('u1', 'monthly');
+    const { service, subscriptions } = await priced();
+    const { reference } = await service.initializeSubscription('u1', 'monthly', ROUTE);
 
     const failed = JSON.stringify({ event: 'charge.failed', data: { reference } });
     await service.handleWebhook(failed, paystackSignature(failed, FAKE_SECRET));
@@ -127,8 +181,8 @@ describe('PaymentsService.handleWebhook', () => {
         throw Object.assign(new Error('dup'), { code: '23505' });
       },
     };
-    const { service } = make(subscriptions);
-    const { reference } = await service.initializeSubscription('u1', 'monthly');
+    const { service } = await priced(subscriptions);
+    const { reference } = await service.initializeSubscription('u1', 'monthly', ROUTE);
     const { body, signature } = chargeSuccess(reference);
     await expect(service.handleWebhook(body, signature)).resolves.toBeUndefined();
   });
@@ -142,8 +196,8 @@ describe('PaymentsService.handleWebhook', () => {
         throw new Error('db down');
       },
     };
-    const { service } = make(subscriptions);
-    const { reference } = await service.initializeSubscription('u1', 'monthly');
+    const { service } = await priced(subscriptions);
+    const { reference } = await service.initializeSubscription('u1', 'monthly', ROUTE);
     const { body, signature } = chargeSuccess(reference);
     await expect(service.handleWebhook(body, signature)).rejects.toThrow('db down');
   });

--- a/services/api/tests/pricing.repository.test.ts
+++ b/services/api/tests/pricing.repository.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { InMemoryPricingRepository } from '../src/modules/payments/pricing.repository';
+
+const ROUTE = '11111111-1111-4111-8111-111111111111';
+
+describe('fare history', () => {
+  it('closes the previous fare rather than overwriting it', async () => {
+    // The whole point of effective dating: a subscription sold in August has to
+    // stay explainable in October, after the unions have announced twice.
+    const repo = new InMemoryPricingRepository();
+    await repo.setFare(ROUTE, 600, 'initial');
+    await repo.setFare(ROUTE, 700, 'fuel adjustment');
+
+    const history = await repo.fareHistory(ROUTE);
+    expect(history).toHaveLength(2);
+    expect(history[0]!.farePesewas).toBe(700);
+    expect(history[0]!.effectiveTo).toBeNull();
+    expect(history[1]!.effectiveTo).not.toBeNull();
+  });
+
+  it('has exactly one fare in force at a time', async () => {
+    const repo = new InMemoryPricingRepository();
+    await repo.setFare(ROUTE, 600);
+    await repo.setFare(ROUTE, 700);
+    await repo.setFare(ROUTE, 800);
+
+    const current = await repo.currentFare(ROUTE);
+    expect(current?.farePesewas).toBe(800);
+    expect((await repo.fareHistory(ROUTE)).filter((f) => f.effectiveTo === null)).toHaveLength(1);
+  });
+
+  it('records why a fare moved', async () => {
+    const repo = new InMemoryPricingRepository();
+    await repo.setFare(ROUTE, 700, 'GPRTU announcement');
+    expect((await repo.currentFare(ROUTE))?.note).toBe('GPRTU announcement');
+  });
+
+  it('returns null for a corridor that has never been priced', async () => {
+    expect(await new InMemoryPricingRepository().currentFare(ROUTE)).toBeNull();
+  });
+});
+
+describe('plan pricing', () => {
+  it('seeds with the values previously hardcoded, at parity and zero take rate', async () => {
+    // Storage changed, behaviour did not. A take rate nobody has agreed with an
+    // operator starts at zero — charging a share nobody signed is worse than
+    // charging none.
+    const repo = new InMemoryPricingRepository();
+    const monthly = await repo.planPricing('monthly');
+    expect(monthly).toEqual({
+      ridesPerPeriod: 44,
+      priceMultiplierBp: 10_000,
+      takeRateBp: 0,
+      creditPesewasPerRide: 45,
+    });
+  });
+
+  it('updates one lever without disturbing the others', async () => {
+    const repo = new InMemoryPricingRepository();
+    const updated = await repo.updatePlanPricing('monthly', { takeRateBp: 1_500 });
+
+    expect(updated?.takeRateBp).toBe(1_500);
+    expect(updated?.ridesPerPeriod).toBe(44);
+    expect(updated?.priceMultiplierBp).toBe(10_000);
+  });
+
+  it('returns null for an unknown plan rather than inventing one', async () => {
+    const repo = new InMemoryPricingRepository();
+    expect(await repo.updatePlanPricing('weekly' as never, { takeRateBp: 1 })).toBeNull();
+  });
+});

--- a/services/api/tests/pricing.test.ts
+++ b/services/api/tests/pricing.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import {
+  applyBp,
+  BASIS_POINTS,
+  derivePrice,
+  deriveOperatorPayout,
+  deriveRevenue,
+  type PlanPricing,
+} from '../src/modules/payments/pricing';
+
+/** GHS 6 a trip, 44 rides — a plausible Accra month. */
+const FARE = 600;
+const PARITY: PlanPricing = {
+  ridesPerPeriod: 44,
+  priceMultiplierBp: BASIS_POINTS,
+  takeRateBp: 0,
+  creditPesewasPerRide: 45,
+};
+
+describe('applyBp', () => {
+  it('is exact at parity', () => {
+    expect(applyBp(26_400, BASIS_POINTS)).toBe(26_400);
+  });
+
+  it('returns whole pesewas — Paystack cannot charge a fraction', () => {
+    // 333 bp of 1000 is 33.3 pesewas; a float would leak the .3 into a total.
+    expect(Number.isInteger(applyBp(1000, 333))).toBe(true);
+    expect(applyBp(1000, 333)).toBe(33);
+  });
+});
+
+describe('derivePrice', () => {
+  it('prices a month at the corridor fare when the multiplier is parity', () => {
+    const price = derivePrice(FARE, PARITY);
+    // Exactly what the rider already spends: 600 × 44 = GHS 264.
+    expect(price.pricePesewas).toBe(26_400);
+    expect(price.ridesGranted).toBe(44);
+  });
+
+  it('carries the fare through for the audit trail', () => {
+    // Answers "why did this rider pay that" after the fare has moved twice.
+    expect(derivePrice(FARE, PARITY).farePesewas).toBe(FARE);
+  });
+
+  it('supports a discount, parity and a premium — the multiplier is not a discount', () => {
+    const discounted = derivePrice(FARE, { ...PARITY, priceMultiplierBp: 9_000 });
+    const parity = derivePrice(FARE, PARITY);
+    const premium = derivePrice(FARE, { ...PARITY, priceMultiplierBp: 11_000 });
+
+    expect(discounted.pricePesewas).toBeLessThan(parity.pricePesewas);
+    expect(premium.pricePesewas).toBeGreaterThan(parity.pricePesewas);
+  });
+
+  it('recomputes when the fare moves — prices are derived, never stored', () => {
+    const before = derivePrice(600, PARITY).pricePesewas;
+    const after = derivePrice(700, PARITY).pricePesewas;
+    expect(after).toBeGreaterThan(before);
+  });
+});
+
+describe('deriveOperatorPayout', () => {
+  it('pays the whole fare through when we take nothing', () => {
+    expect(deriveOperatorPayout(FARE, 31, 0)).toBe(FARE * 31);
+  });
+
+  it('withholds our share', () => {
+    // 20% take on 31 delivered rides.
+    expect(deriveOperatorPayout(FARE, 31, 2_000)).toBe(FARE * 31 * 0.8);
+  });
+
+  it('pays for rides DELIVERED, not rides sold', () => {
+    // The rider bought 44 and travelled 31. The operator carried 31 seats.
+    const sold = deriveOperatorPayout(FARE, 44, 2_000);
+    const delivered = deriveOperatorPayout(FARE, 31, 2_000);
+    expect(delivered).toBeLessThan(sold);
+  });
+});
+
+describe('deriveRevenue', () => {
+  it('at parity with a zero take rate, revenue is exactly the unused rides', () => {
+    // Worth seeing rather than discovering: with no take rate we earn only what
+    // riders did not travel, which is an uncomfortable business to be in.
+    const price = derivePrice(FARE, PARITY);
+    expect(deriveRevenue(price, 31, 0)).toBe(FARE * (44 - 31));
+  });
+
+  it('a take rate earns on every delivered ride, not just the unused ones', () => {
+    const price = derivePrice(FARE, PARITY);
+    expect(deriveRevenue(price, 31, 2_000)).toBeGreaterThan(deriveRevenue(price, 31, 0));
+  });
+
+  it('a fully-travelled month at parity with no take rate earns nothing', () => {
+    const price = derivePrice(FARE, PARITY);
+    expect(deriveRevenue(price, 44, 0)).toBe(0);
+  });
+
+  it('goes negative when the take rate cannot cover a premium-free month', () => {
+    // A rider who somehow travels more than they bought (standby, goodwill)
+    // costs us money. The formula must show that rather than clamp it.
+    const price = derivePrice(FARE, PARITY);
+    expect(deriveRevenue(price, 50, 0)).toBeLessThan(0);
+  });
+});


### PR DESCRIPTION
**Closes #103.** Implements ADR-0015.

## What was wrong

The numbers charged to real people were TypeScript constants:

```ts
SUBSCRIPTION_FEES_PESEWAS = { monthly: 2000, annual: 20000 }
PLACEHOLDER_RIDES_PER_PERIOD = 44
PLACEHOLDER_CREDIT_PESEWAS_PER_RIDE = 45
```

All three invented to make the flow buildable. All three wired to Paystack. Changing any needed a review and a deploy — which is what made *"decide the prices"* look like an engineering blocker when it never was.

## The model

```
rider price     = corridor fare × rides per period × price multiplier
operator payout = corridor fare × rides DELIVERED  × (1 − take rate)
trotxi revenue  = rider price − operator payout
```

**Fares are effective-dated.** A change is one row per corridor and every price recomputes — no migration when fuel moves. A **partial unique index** keeps exactly one fare in force while history accumulates, so a subscription sold in August stays explainable in October.

**Rates are basis points, never floats.** The rest of the money system is integer pesewas for the same reason (ADR-0011): a rate that can't be represented exactly becomes a rounding argument with an operator over a month of payouts.

## The subtle bit: where the snapshot is taken

Price inputs are frozen on the **payment at checkout**, then copied to the subscription on activation. **Not re-derived at activation** — minutes pass before `charge.success` arrives, and a fare that moved in that window would grant rides priced against a fare the rider never paid.

The **take rate is deliberately not snapshotted**: payout is earned per ride delivered and uses the rate in force then. Freezing it would mean a rate renegotiated in March still paying January's terms on April's rides.

## Breaking change: `routeId` is now required

The price depends on the corridor's fare, so there is no meaningful price for "some route". An unpriced corridor returns **`409 not_priced`** rather than falling back to a default — charging a number nobody chose is exactly what this issue exists to prevent.

Now is the moment for this: #36 (subscribe & pay in the app) isn't built yet.

## Seeded to change storage, not behaviour

Existing values carried over, **except `take_rate_bp` which starts at 0**. Charging an operator a share nobody has agreed is worse than charging nothing.

The multiplier defaults to **parity (10000bp)** per ADR-0015 §4 — on these corridors the constraint is supply, so we sell certainty rather than a lower price.

## Admin surface

`PUT /admin/routes/:id/fare` · `GET /admin/routes/:id/fares` (history) · `GET /admin/plan-pricing` · `PATCH /admin/plan-pricing/:plan`

Setting the multiplier or take rate is now data entry, not a deploy.

## Verification

Full gates green. **401 tests**, coverage 92.68%.

**Migration run twice against real Postgres**, second pass a clean no-op. Verified the partial unique index rejects a second open fare on a corridor, and that closing-then-inserting preserves history with exactly one row in force:

```
ERROR: duplicate key value violates unique constraint "idx_corridor_fares_current"
...
history rows: 2
in force now: 700 (fuel adjustment)
```

New tests cover the derivation, that a discount/parity/premium are all expressible, that a fare change repricesnew subscriptions without touching sold ones, that unpriced corridors are refused, and that revenue at parity with a zero take rate is exactly the value of unused rides — a fact better seen in a test than discovered in a board meeting.

## Still open, and now purely data entry

1. **Price multiplier** — defaults to 1.0
2. **Operator take rate** — the number that decides whether there's a business
3. **Entitlement formula** — rides per period
4. **Band boundaries** — deferred; pointless at pilot scale with two corridors