### PR TITLE
feat(seed): price the seeded corridor

### DIFF
--- a/services/api/scripts/seed-staging.ts
+++ b/services/api/scripts/seed-staging.ts
@@ -39,6 +39,15 @@ const auth: AuthConfig = {
 
 const ROUTE_NAME = 'Circle ⇄ Madina';
 
+// Corridor fare in pesewas. Since #103 a route without a fare in force cannot be
+// subscribed to at all — POST /payments/subscribe returns 409 not_priced — so a
+// seeded environment without one looks complete right up until checkout.
+//
+// A PLACEHOLDER, like everything else this script creates. GHS 6 is a plausible
+// Accra trotro fare; the real number comes from the union rate for the corridor
+// and is ops' to set. Override with SEED_FARE_PESEWAS.
+const FARE_PESEWAS = Number(process.env.SEED_FARE_PESEWAS ?? 600);
+
 // Real Accra coordinates along the corridor, in boarding order.
 const STOPS = [
   { name: 'Circle Interchange', latitude: 5.5717, longitude: -0.2107 },
@@ -211,9 +220,32 @@ async function main(): Promise<void> {
   }
   console.log(`trips: ${created} created, ${skipped} already present (${DAYS} days)`);
 
+  // Price the corridor. Idempotent by intent rather than by accident: setting an
+  // identical fare would close the current row and open a new one, growing the
+  // history with changes that never happened, so re-running only writes when the
+  // fare actually differs.
+  const fares = must('read fares', await api('GET', `/admin/routes/${route.id}/fares`));
+  const current = (fares.fares ?? []).find((f: { effectiveTo: string | null }) => !f.effectiveTo);
+  if (current?.farePesewas === FARE_PESEWAS) {
+    console.log(`fare: unchanged at ${FARE_PESEWAS} pesewas`);
+  } else {
+    must(
+      'set fare',
+      await api('PUT', `/admin/routes/${route.id}/fare`, {
+        farePesewas: FARE_PESEWAS,
+        note: 'seed placeholder — replace with the corridor’s union rate',
+      }),
+    );
+    console.log(`fare: set to ${FARE_PESEWAS} pesewas (GHS ${(FARE_PESEWAS / 100).toFixed(2)})`);
+  }
+
   const finalRoutes = must('verify', await api('GET', '/routes'));
   const n = Array.isArray(finalRoutes) ? finalRoutes.length : (finalRoutes.routes?.length ?? 0);
   console.log(`\ndone — ${n} route(s) live at ${BASE}/routes`);
+  console.log(
+    'NB: the fare is a placeholder. Set the real corridor rate via ' +
+      `PUT ${BASE}/admin/routes/${route.id}/fare`,
+  );
 }
 
 main().catch((err: unknown) => {


### PR DESCRIPTION
Follow-up to #190, which made a fare mandatory for checkout.

## The gap

A seeded corridor has stops, a fleet, drivers and trips — and **cannot be subscribed to**. `POST /payments/subscribe` returns `409 not_priced` because no fare is in force. The environment looks complete right up until someone hits checkout, which is exactly the kind of thing that costs the apps team an afternoon.

## The change

The seed sets a fare as its last step. It already mints its own admin token, so this needs nothing new from whoever runs it — same one command.

**Idempotent by intent, not by accident.** Setting an identical fare would close the current row and open a new one, growing the fare history with changes that never happened. It reads the current fare first and only writes when it differs:

```
fare: unchanged at 600 pesewas
```

## Still a placeholder, and it says so

GHS 6 is plausible for an Accra corridor. It is not researched, and the real number is the union rate for that route. The script prints the endpoint to correct it on the way out, and `SEED_FARE_PESEWAS` overrides it.

Consistent with everything else this script creates: enough to develop against, never mistaken for real.