### PR TITLE
fix(api): enforce vehicle seat capacity on reservations

### DIFF
--- a/services/api/src/app.ts
+++ b/services/api/src/app.ts
@@ -300,6 +300,8 @@ export async function buildApp(deps: AppDeps = {}): Promise<FastifyInstance> {
   await app.register(reservationRoutes, {
     reservations,
     secret: authConfig.secret,
+    trips: deps.trips,
+    vehicles: deps.vehicles,
     rateLimit: deps.rateLimit ?? DEFAULT_RATE_LIMIT,
   });
   // Ask-dispatch (E3): only wired when trips + subscriptions are available (the
@@ -314,6 +316,7 @@ export async function buildApp(deps: AppDeps = {}): Promise<FastifyInstance> {
             subscriptions: deps.subscriptions,
             reservations,
             notifier,
+            vehicles: deps.vehicles,
           })
         : undefined,
     rateLimit: deps.rateLimit ?? DEFAULT_RATE_LIMIT,
@@ -372,6 +375,7 @@ export async function buildApp(deps: AppDeps = {}): Promise<FastifyInstance> {
     featureFlags: deps.featureFlags,
     minVersions: deps.minVersions,
     rateLimit: deps.rateLimit ?? DEFAULT_RATE_LIMIT,
+    reservations,
   });
   await app.register(flagsRoutes, {
     featureFlags: deps.featureFlags,

--- a/services/api/src/modules/admin/admin.routes.ts
+++ b/services/api/src/modules/admin/admin.routes.ts
@@ -11,6 +11,7 @@ import type { ZodTypeProvider } from 'fastify-type-provider-zod';
 import { z } from 'zod';
 import { errorResponseSchema } from '../../lib/schemas';
 import type { RateLimitConfig } from '../ratelimit/ratelimit.plugin';
+import type { ReservationRepository } from '../reservations/reservation.repository';
 import type { DriverRepository } from '../mobility/driver.repository';
 import type { RouteStopRepository } from '../mobility/route-stop.repository';
 import type { RouteRepository } from '../mobility/route.repository';
@@ -87,6 +88,8 @@ export interface AdminDeps {
   /** Feature flags + force-update floor (#27), managed under /admin/flags + /admin/min-versions. */
   featureFlags?: FeatureFlagRepository;
   minVersions?: MinVersionRepository;
+  /** Reservations, to refuse a bus smaller than the confirmed seats (#161). */
+  reservations?: ReservationRepository;
   rateLimit: RateLimitConfig;
 }
 
@@ -492,7 +495,7 @@ export async function adminRoutes(app: FastifyInstance, opts: AdminDeps): Promis
         security: [{ bearerAuth: [] }],
         params: idParam,
         body: assignTripBodySchema,
-        response: { 200: tripResponseSchema, ...authErrorsNF },
+        response: { 200: tripResponseSchema, 409: errorResponseSchema, ...authErrorsNF },
       },
       preHandler: adminOnly,
     },
@@ -501,11 +504,26 @@ export async function adminRoutes(app: FastifyInstance, opts: AdminDeps): Promis
         return reply.code(503).send(UNAVAILABLE);
       }
       const { vehicleId, assignedDriverId } = request.body;
-      if (vehicleId && !(await opts.vehicles.findById(vehicleId))) {
+      const vehicle = vehicleId ? await opts.vehicles.findById(vehicleId) : null;
+      if (vehicleId && !vehicle) {
         return reply.code(404).send(notFound('Vehicle not found'));
       }
       if (assignedDriverId && !(await opts.drivers.findById(assignedDriverId))) {
         return reply.code(404).send(notFound('Driver not found'));
+      }
+
+      // Refuse a bus smaller than the seats already confirmed (#161). Silently
+      // accepting it would put riders holding a valid reservation on a vehicle
+      // with nowhere to sit, and nobody would find out until boarding.
+      // Reassigning to a bigger bus, or to none, is always allowed.
+      if (vehicle && vehicle.capacity > 0 && opts.reservations) {
+        const taken = await opts.reservations.countSeatsTaken(request.params.id);
+        if (taken > vehicle.capacity) {
+          return reply.code(409).send({
+            error: 'capacity_too_small',
+            message: `${vehicle.registration} seats ${vehicle.capacity}, but ${taken} riders are already confirmed on this trip`,
+          });
+        }
       }
       const updated = await opts.trips.update(request.params.id, { vehicleId, assignedDriverId });
       if (!updated) return reply.code(404).send(notFound('Trip not found'));

--- a/services/api/src/modules/notifications/ask-dispatch.schema.ts
+++ b/services/api/src/modules/notifications/ask-dispatch.schema.ts
@@ -15,4 +15,12 @@ export const askDispatchResponseSchema = z.object({
 
 export const resolveDefaultsResponseSchema = z.object({
   defaulted: z.number().int(),
+  /**
+   * Riders left `pending` because their trip was already full (#161).
+   *
+   * Reported rather than silently dropped: a non-zero count means demand
+   * exceeded the bus, which is exactly the signal ops needs to put a second
+   * vehicle on that corridor — and the trigger for the standby pool (#105).
+   */
+  skippedFull: z.number().int(),
 });

--- a/services/api/src/modules/notifications/ask-dispatch.service.ts
+++ b/services/api/src/modules/notifications/ask-dispatch.service.ts
@@ -10,6 +10,7 @@
 // this targets those subscribers.
 
 import { directionOf } from '../mobility/direction';
+import type { VehicleRepository } from '../mobility/vehicle.repository';
 import type { TripRepository } from '../mobility/trip.repository';
 import type {
   ReservationDirection,
@@ -24,6 +25,12 @@ export interface AskDispatchDeps {
   subscriptions: SubscriptionRepository;
   reservations: ReservationRepository;
   notifier: NotificationSender;
+  /**
+   * Seat ceiling per trip (#161). Absent -> the cutoff defaults everyone, as
+   * before. Present -> riders are never defaulted into a seat that does not
+   * exist, which is how an overfull trip used to get worse at 21:00.
+   */
+  vehicles?: VehicleRepository;
 }
 
 /** How many riders were prompted, across how many trips. */
@@ -83,12 +90,35 @@ export class AskDispatchService {
    *
    * @param travelDate - the travel day (`YYYY-MM-DD`).
    * @param direction - morning or evening.
-   * @returns how many reservations were defaulted.
+   * @returns how many were defaulted, and how many were skipped because their
+   *   trip was already full.
    */
   async resolveDefaults(
     travelDate: string,
     direction: ReservationDirection,
-  ): Promise<{ defaulted: number }> {
-    return { defaulted: await this.deps.reservations.markDefaultTravelling(travelDate, direction) };
+  ): Promise<{ defaulted: number; skippedFull: number }> {
+    return this.deps.reservations.markDefaultTravelling(
+      travelDate,
+      direction,
+      this.deps.vehicles ? (tripId) => this.capacityOf(tripId) : undefined,
+    );
+  }
+
+  /**
+   * The seat ceiling for a trip, or null when it has none.
+   *
+   * A trip with no vehicle assigned is unlimited, not zero: ops routinely
+   * creates trips before assigning a bus, and treating that as zero would stop
+   * anyone reserving on a run that has not been crewed yet.
+   *
+   * @param tripId - the trip.
+   * @returns the vehicle's capacity, or null for unlimited.
+   */
+  private async capacityOf(tripId: string): Promise<number | null> {
+    const trip = await this.deps.trips.findById(tripId);
+    if (!trip?.vehicleId) return null;
+    const vehicle = await this.deps.vehicles!.findById(trip.vehicleId);
+    // capacity 0 means "not recorded" in the fleet data, not "no seats".
+    return vehicle && vehicle.capacity > 0 ? vehicle.capacity : null;
   }
 }

--- a/services/api/src/modules/reservations/reservation.repository.pg.ts
+++ b/services/api/src/modules/reservations/reservation.repository.pg.ts
@@ -1,3 +1,4 @@
+import { SEAT_CONSUMING_STATUSES } from './reservation.repository';
 import type { Pool } from 'pg';
 import type {
   Reservation,
@@ -78,17 +79,129 @@ export class PgReservationRepository implements ReservationRepository {
     return toReservation(rows[0]!);
   }
 
+  async countSeatsTaken(tripId: string): Promise<number> {
+    const { rows } = await this.pool.query<{ count: string }>(
+      `SELECT count(*)::text AS count FROM reservations
+        WHERE trip_id = $1 AND status = ANY($2::text[])`,
+      [tripId, [...SEAT_CONSUMING_STATUSES]],
+    );
+    return Number(rows[0]?.count ?? 0);
+  }
+
+  async respondWithinCapacity(
+    input: ReservationResponse,
+    capacity: number,
+  ): Promise<Reservation | null> {
+    // Declining never needs a seat.
+    if (!input.travelling || !input.tripId) return this.respond(input);
+
+    const client = await this.pool.connect();
+    try {
+      await client.query('BEGIN');
+
+      // Lock the trip row for the duration. This is what makes the count and
+      // the write atomic: the 18:00 push lands a corridor's riders within the
+      // same few seconds, so without it two riders both read "one seat free"
+      // before either writes, and both get it.
+      await client.query('SELECT id FROM trips WHERE id = $1 FOR UPDATE', [input.tripId]);
+
+      const { rows: counted } = await client.query<{ count: string }>(
+        `SELECT count(*)::text AS count FROM reservations
+          WHERE trip_id = $1 AND status = ANY($2::text[])
+            AND user_id <> $3`,
+        [input.tripId, [...SEAT_CONSUMING_STATUSES], input.userId],
+      );
+      // Excluding this rider means re-confirming a seat they already hold is
+      // never refused, and never double-counts them against the ceiling.
+      if (Number(counted[0]?.count ?? 0) >= capacity) {
+        await client.query('ROLLBACK');
+        return null;
+      }
+
+      const { rows } = await client.query<ReservationRow>(
+        `INSERT INTO reservations (user_id, trip_id, travel_date, direction, status, source, daily_pin_hash, confirmed_at)
+         VALUES ($1, $2, $3, $4, 'reserved', 'confirmation', $5, now())
+         ON CONFLICT (user_id, travel_date, direction)
+         DO UPDATE SET trip_id = COALESCE(EXCLUDED.trip_id, reservations.trip_id),
+                       status = EXCLUDED.status,
+                       source = 'confirmation',
+                       daily_pin_hash = EXCLUDED.daily_pin_hash,
+                       confirmed_at = now(),
+                       updated_at = now()
+         RETURNING *`,
+        [input.userId, input.tripId, input.travelDate, input.direction, input.pinHash ?? null],
+      );
+      await client.query('COMMIT');
+      return toReservation(rows[0]!);
+    } catch (err) {
+      await client.query('ROLLBACK');
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
   async markDefaultTravelling(
     travelDate: string,
     direction: ReservationDirection,
-  ): Promise<number> {
-    const { rowCount } = await this.pool.query(
-      `UPDATE reservations
-         SET status = 'reserved', source = 'default', confirmed_at = now(), updated_at = now()
-       WHERE travel_date = $1 AND direction = $2 AND status = 'pending'`,
+    capacityOf?: (tripId: string) => Promise<number | null>,
+  ): Promise<{ defaulted: number; skippedFull: number }> {
+    // No capacity resolver (or nothing to resolve): the original bulk update.
+    if (!capacityOf) {
+      const { rowCount } = await this.pool.query(
+        `UPDATE reservations
+           SET status = 'reserved', source = 'default', confirmed_at = now(), updated_at = now()
+         WHERE travel_date = $1 AND direction = $2 AND status = 'pending'`,
+        [travelDate, direction],
+      );
+      return { defaulted: rowCount ?? 0, skippedFull: 0 };
+    }
+
+    // Capacity-aware: defaulting a rider into a seat that does not exist is
+    // how the cutoff turns an overfull trip into a worse one, silently, at
+    // 21:00. Grouped by trip so each ceiling is resolved once, not per rider.
+    const { rows: pending } = await this.pool.query<{ id: string; trip_id: string | null }>(
+      `SELECT id, trip_id FROM reservations
+        WHERE travel_date = $1 AND direction = $2 AND status = 'pending'
+        ORDER BY created_at ASC`,
       [travelDate, direction],
     );
-    return rowCount ?? 0;
+
+    let defaulted = 0;
+    let skippedFull = 0;
+    const remaining = new Map<string, number>();
+
+    for (const row of pending) {
+      if (row.trip_id) {
+        if (!remaining.has(row.trip_id)) {
+          const capacity = await capacityOf(row.trip_id);
+          remaining.set(
+            row.trip_id,
+            capacity === null
+              ? Number.POSITIVE_INFINITY
+              : capacity - (await this.countSeatsTaken(row.trip_id)),
+          );
+        }
+        const free = remaining.get(row.trip_id)!;
+        if (free <= 0) {
+          skippedFull++;
+          continue;
+        }
+        remaining.set(row.trip_id, free - 1);
+      }
+
+      // Oldest pending first (ORDER BY created_at): when a trip cannot take
+      // everyone, the rider who was asked first gets the seat. Arbitrary is
+      // worse than a rule we can explain.
+      await this.pool.query(
+        `UPDATE reservations
+           SET status = 'reserved', source = 'default', confirmed_at = now(), updated_at = now()
+         WHERE id = $1`,
+        [row.id],
+      );
+      defaulted++;
+    }
+    return { defaulted, skippedFull };
   }
 
   async listForUser(userId: string, opts?: { fromDate?: string }): Promise<Reservation[]> {

--- a/services/api/src/modules/reservations/reservation.repository.ts
+++ b/services/api/src/modules/reservations/reservation.repository.ts
@@ -21,6 +21,13 @@ export type ReservationStatus =
   | 'released' // freed to the standby pool (E6)
   | 'operator_cancelled'; // Trotxi couldn't run it — no deduction
 
+/**
+ * The statuses that occupy a seat (#161). A `no_show` deliberately does not:
+ * the rider has already been charged for it, and the vehicle no longer needs to
+ * hold it. `released` frees the seat to the standby pool (E6).
+ */
+export const SEAT_CONSUMING_STATUSES = ['reserved', 'boarded'] as const;
+
 /** How a reservation reached its current state. */
 export type ReservationSource = 'confirmation' | 'default' | 'standby';
 
@@ -75,6 +82,31 @@ export interface ReservationRepository {
    */
   respond(input: ReservationResponse): Promise<Reservation>;
   /**
+   * Confirm a seat, refusing when the trip is already full (#161).
+   *
+   * Capacity is enforced HERE rather than by the caller because a
+   * check-then-write in application code races: the 18:00 push means a
+   * corridor's riders all answer within the same few seconds, and two riders
+   * confirming into the last seat would both read "one free" before either
+   * wrote. Only the store can make the count and the write atomic.
+   *
+   * @param input - the rider's response.
+   * @param capacity - the assigned vehicle's seat count.
+   * @returns the reservation, or null when the trip is at capacity.
+   */
+  respondWithinCapacity(input: ReservationResponse, capacity: number): Promise<Reservation | null>;
+  /**
+   * Seats currently taken on a trip.
+   *
+   * Only `reserved` and `boarded` consume one. `declined`, `no_show`,
+   * `released` and `operator_cancelled` do not — a no-show has already been
+   * charged for a seat the vehicle no longer needs to hold.
+   *
+   * @param tripId - the trip.
+   * @returns how many seats are taken.
+   */
+  countSeatsTaken(tripId: string): Promise<number>;
+  /**
    * Seed a `pending` reservation (the scheduled ask-dispatch; #18). A duplicate
    * day+direction for the rider is left untouched.
    *
@@ -91,7 +123,11 @@ export interface ReservationRepository {
    * @param direction - morning or evening.
    * @returns how many reservations were defaulted.
    */
-  markDefaultTravelling(travelDate: string, direction: ReservationDirection): Promise<number>;
+  markDefaultTravelling(
+    travelDate: string,
+    direction: ReservationDirection,
+    capacityOf?: (tripId: string) => Promise<number | null>,
+  ): Promise<{ defaulted: number; skippedFull: number }>;
   /**
    * List a rider's reservations, newest travel day first.
    *
@@ -238,22 +274,58 @@ export class InMemoryReservationRepository implements ReservationRepository {
     return created;
   }
 
+  async countSeatsTaken(tripId: string): Promise<number> {
+    return this.rows.filter(
+      (r) =>
+        r.tripId === tripId && (SEAT_CONSUMING_STATUSES as readonly string[]).includes(r.status),
+    ).length;
+  }
+
+  async respondWithinCapacity(
+    input: ReservationResponse,
+    capacity: number,
+  ): Promise<Reservation | null> {
+    // Declining never needs a seat, so it is never refused.
+    if (input.travelling && input.tripId) {
+      const taken = await this.countSeatsTaken(input.tripId);
+      const existing = this.rows[this.index(input.userId, input.travelDate, input.direction)];
+      const alreadyHolds =
+        existing?.tripId === input.tripId &&
+        (SEAT_CONSUMING_STATUSES as readonly string[]).includes(existing.status);
+      // A rider re-confirming a seat they already hold is not a new seat.
+      if (!alreadyHolds && taken >= capacity) return null;
+    }
+    return this.respond(input);
+  }
+
   async markDefaultTravelling(
     travelDate: string,
     direction: ReservationDirection,
-  ): Promise<number> {
-    let count = 0;
+    capacityOf?: (tripId: string) => Promise<number | null>,
+  ): Promise<{ defaulted: number; skippedFull: number }> {
+    let defaulted = 0;
+    let skippedFull = 0;
     const now = new Date();
     for (const r of this.rows) {
       if (r.travelDate === travelDate && r.direction === direction && r.status === 'pending') {
+        // The cutoff must not default a rider into a seat that does not exist.
+        // Without this the default-yes makes an overfull trip worse, silently,
+        // at 21:00 when nobody is looking.
+        if (capacityOf && r.tripId) {
+          const capacity = await capacityOf(r.tripId);
+          if (capacity !== null && (await this.countSeatsTaken(r.tripId)) >= capacity) {
+            skippedFull++;
+            continue;
+          }
+        }
         r.status = 'reserved';
         r.source = 'default';
         r.confirmedAt = now;
         r.updatedAt = now;
-        count++;
+        defaulted++;
       }
     }
-    return count;
+    return { defaulted, skippedFull };
   }
 
   async listForUser(userId: string, opts?: { fromDate?: string }): Promise<Reservation[]> {

--- a/services/api/src/modules/reservations/reservations.routes.ts
+++ b/services/api/src/modules/reservations/reservations.routes.ts
@@ -6,6 +6,8 @@
 import type { FastifyInstance } from 'fastify';
 import type { ZodTypeProvider } from 'fastify-type-provider-zod';
 import { errorResponseSchema } from '../../lib/schemas';
+import type { TripRepository } from '../mobility/trip.repository';
+import type { VehicleRepository } from '../mobility/vehicle.repository';
 import type { RateLimitConfig } from '../ratelimit/ratelimit.plugin';
 import type { Reservation, ReservationRepository } from './reservation.repository';
 import { generatePin, hashPin } from './pin';
@@ -47,15 +49,40 @@ function toResponse(
  * @param app - the Fastify instance to register on.
  * @param opts - route dependencies.
  * @param opts.reservations - the reservation repository (503 when absent).
+ * @param opts.trips - trip lookup, to resolve the assigned vehicle (#161).
+ * @param opts.vehicles - the fleet, for the seat ceiling; absent -> not enforced.
  * @param opts.secret - server key for hashing the daily boarding PIN.
  * @param opts.rateLimit - rate-limit config (applied per user).
  */
 export async function reservationRoutes(
   app: FastifyInstance,
-  opts: { reservations?: ReservationRepository; secret: string; rateLimit: RateLimitConfig },
+  opts: {
+    reservations?: ReservationRepository;
+    /** Trip lookup, to resolve the assigned vehicle's seat ceiling (#161). */
+    trips?: TripRepository;
+    /** Fleet, for that ceiling. Absent -> capacity is not enforced. */
+    vehicles?: VehicleRepository;
+    secret: string;
+    rateLimit: RateLimitConfig;
+  },
 ): Promise<void> {
   const r = app.withTypeProvider<ZodTypeProvider>();
   const UNAVAILABLE = { error: 'unavailable', message: 'Reservations are not configured' };
+
+  /**
+   * The seat ceiling for a trip, or null when there is none to enforce.
+   *
+   * @param tripId - the trip being reserved on, if any.
+   * @returns the vehicle's capacity, or null for unlimited.
+   */
+  const seatCeiling = async (tripId: string | null): Promise<number | null> => {
+    if (!tripId || !opts.trips || !opts.vehicles) return null;
+    const trip = await opts.trips.findById(tripId);
+    if (!trip?.vehicleId) return null;
+    const vehicle = await opts.vehicles.findById(trip.vehicleId);
+    // capacity 0 means "not recorded" in the fleet data, not "no seats".
+    return vehicle && vehicle.capacity > 0 ? vehicle.capacity : null;
+  };
 
   r.post(
     '/me/reservations',
@@ -68,6 +95,7 @@ export async function reservationRoutes(
         response: {
           200: reservationResponseSchema,
           401: errorResponseSchema,
+          409: errorResponseSchema,
           429: errorResponseSchema,
           503: errorResponseSchema,
         },
@@ -79,14 +107,34 @@ export async function reservationRoutes(
       // Confirming issues a fresh daily PIN; only the hash is stored, the
       // plaintext is returned once here for the rider to show at boarding.
       const pin = request.body.travelling ? generatePin() : undefined;
-      const reservation = await opts.reservations.respond({
+      const input = {
         userId: request.user!.id,
         tripId: request.body.tripId ?? null,
         travelDate: request.body.travelDate,
         direction: request.body.direction,
         travelling: request.body.travelling,
         pinHash: pin ? hashPin(pin, opts.secret) : null,
-      });
+      };
+
+      const capacity = request.body.travelling
+        ? await seatCeiling(request.body.tripId ?? null)
+        : null;
+
+      // null ceiling = no vehicle assigned yet, or capacity not recorded. Ops
+      // routinely creates trips before crewing them, so that means unlimited
+      // rather than zero — otherwise nobody could reserve on a run until a bus
+      // was attached.
+      const reservation =
+        capacity === null
+          ? await opts.reservations.respond(input)
+          : await opts.reservations.respondWithinCapacity(input, capacity);
+
+      if (!reservation) {
+        // Its own error code, not a bare 409: the app has to tell "this run is
+        // full" from a generic conflict to show the right thing. This is also
+        // where the standby offer cascade attaches (#105).
+        return reply.code(409).send({ error: 'trip_full', message: 'This run is full' });
+      }
       return toResponse(reservation, pin);
     },
   );

--- a/services/api/tests/ask-dispatch.test.ts
+++ b/services/api/tests/ask-dispatch.test.ts
@@ -74,7 +74,10 @@ describe('AskDispatchService.dispatchAsks', () => {
     await subscriptions.create({ userId: 'ama', plan: 'monthly', routeId: ROUTE_A });
     await svc.dispatchAsks(TOMORROW, 'morning'); // ama is pending
 
-    expect(await svc.resolveDefaults(TOMORROW, 'morning')).toEqual({ defaulted: 1 });
+    expect(await svc.resolveDefaults(TOMORROW, 'morning')).toEqual({
+      defaulted: 1,
+      skippedFull: 0,
+    });
     expect(await reservations.find('ama', TOMORROW, 'morning')).toMatchObject({
       status: 'reserved',
       source: 'default',
@@ -124,7 +127,7 @@ describe('POST /admin/ask-dispatch (+ resolve-defaults)', () => {
       headers: bearer(admin),
       payload: { travelDate: TOMORROW, direction: 'morning' },
     });
-    expect(resolve.json()).toEqual({ defaulted: 1 });
+    expect(resolve.json()).toEqual({ defaulted: 1, skippedFull: 0 });
     expect((await reservations.find('rider-x', TOMORROW, 'morning'))?.status).toBe('reserved');
   });
 });

--- a/services/api/tests/reservations.test.ts
+++ b/services/api/tests/reservations.test.ts
@@ -36,8 +36,8 @@ describe('ReservationRepository', () => {
     // a different direction stays pending
     await repo.createPending({ userId: 'a', travelDate: DATE, direction: 'evening' });
 
-    const count = await repo.markDefaultTravelling(DATE, 'morning');
-    expect(count).toBe(1); // only 'a' morning
+    const { defaulted } = await repo.markDefaultTravelling(DATE, 'morning');
+    expect(defaulted).toBe(1); // only 'a' morning
 
     expect(await repo.find('a', DATE, 'morning')).toMatchObject({
       status: 'reserved',

--- a/services/api/tests/seat-capacity.routes.test.ts
+++ b/services/api/tests/seat-capacity.routes.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+import { buildApp } from '../src/app';
+import { InMemoryReservationRepository } from '../src/modules/reservations/reservation.repository';
+import { InMemoryTripRepository } from '../src/modules/mobility/trip.repository';
+import { InMemoryVehicleRepository } from '../src/modules/mobility/vehicle.repository';
+import { InMemoryRouteRepository } from '../src/modules/mobility/route.repository';
+import { InMemoryDriverRepository } from '../src/modules/mobility/driver.repository';
+import { createJwtService, type AuthConfig } from '../src/modules/auth/jwt';
+
+const auth: AuthConfig = {
+  secret: 'test-secret-at-least-32-characters-long-0000',
+  accessTtl: '15m',
+  issuer: 'trotxi',
+  audience: 'trotxi-api',
+};
+const jwt = createJwtService(auth);
+const DATE = '2026-08-26';
+
+async function setup(capacity: number) {
+  const routes = new InMemoryRouteRepository();
+  const vehicles = new InMemoryVehicleRepository();
+  const trips = new InMemoryTripRepository();
+  const reservations = new InMemoryReservationRepository();
+  // The assignment endpoint needs all three fleet repos or it 503s.
+  const drivers = new InMemoryDriverRepository();
+
+  const route = await routes.create({ name: 'Circle ⇄ Madina' });
+  const vehicle = await vehicles.create({ registration: 'GR-2417-26', capacity });
+  const trip = await trips.create({
+    routeId: route.id,
+    scheduledAt: new Date(`${DATE}T06:30:00.000Z`),
+    vehicleId: vehicle.id,
+  });
+
+  const app = await buildApp({ auth, routes, vehicles, trips, drivers, reservations });
+  return { app, trip, vehicle, reservations };
+}
+
+async function confirmAs(
+  app: Awaited<ReturnType<typeof buildApp>>,
+  userId: string,
+  tripId: string,
+) {
+  const token = await jwt.signAccessToken({ userId, role: 'commuter' });
+  return app.inject({
+    method: 'POST',
+    url: '/me/reservations',
+    headers: { authorization: `Bearer ${token}` },
+    payload: { tripId, travelDate: DATE, direction: 'morning', travelling: true },
+  });
+}
+
+describe('POST /me/reservations capacity (#161)', () => {
+  it('returns 409 trip_full once the bus is full', async () => {
+    const { app, trip } = await setup(2);
+
+    expect((await confirmAs(app, 'aaaaaaaa-0000-4000-8000-000000000001', trip.id)).statusCode).toBe(
+      200,
+    );
+    expect((await confirmAs(app, 'aaaaaaaa-0000-4000-8000-000000000002', trip.id)).statusCode).toBe(
+      200,
+    );
+
+    const third = await confirmAs(app, 'aaaaaaaa-0000-4000-8000-000000000003', trip.id);
+    expect(third.statusCode).toBe(409);
+    // Its own code, not a bare 409: the app must tell "full" from a generic
+    // conflict to show the right thing.
+    expect(third.json().error).toBe('trip_full');
+  });
+
+  it('writes no reservation when it refuses', async () => {
+    const { app, trip, reservations } = await setup(1);
+    await confirmAs(app, 'aaaaaaaa-0000-4000-8000-000000000001', trip.id);
+    await confirmAs(app, 'aaaaaaaa-0000-4000-8000-000000000002', trip.id);
+
+    expect(await reservations.countSeatsTaken(trip.id)).toBe(1);
+  });
+
+  it('does not constrain a trip whose capacity is unrecorded', async () => {
+    // capacity 0 means "not in the fleet data", not "no seats".
+    const { app, trip } = await setup(0);
+    for (const n of ['1', '2', '3']) {
+      const res = await confirmAs(app, `aaaaaaaa-0000-4000-8000-00000000000${n}`, trip.id);
+      expect(res.statusCode).toBe(200);
+    }
+  });
+});
+
+describe('PUT /admin/trips/:id/assignment capacity (#161)', () => {
+  it('refuses a bus smaller than the seats already confirmed', async () => {
+    const { app, trip } = await setup(10);
+    for (const n of ['1', '2', '3']) {
+      await confirmAs(app, `aaaaaaaa-0000-4000-8000-00000000000${n}`, trip.id);
+    }
+
+    const adminToken = await jwt.signAccessToken({ userId: 'admin-1', role: 'admin' });
+    // A 2-seat bus for 3 confirmed riders — silently accepting this would put
+    // riders holding a valid reservation on a vehicle with nowhere to sit.
+    const small = await app.inject({
+      method: 'POST',
+      url: '/admin/vehicles',
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { registration: 'GR-0002-26', capacity: 2 },
+    });
+
+    const res = await app.inject({
+      method: 'PUT',
+      url: `/admin/trips/${trip.id}/assignment`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { vehicleId: small.json().id },
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json().error).toBe('capacity_too_small');
+  });
+
+  it('allows reassigning to a bigger bus', async () => {
+    const { app, trip } = await setup(3);
+    for (const n of ['1', '2']) {
+      await confirmAs(app, `aaaaaaaa-0000-4000-8000-00000000000${n}`, trip.id);
+    }
+
+    const adminToken = await jwt.signAccessToken({ userId: 'admin-1', role: 'admin' });
+    const big = await app.inject({
+      method: 'POST',
+      url: '/admin/vehicles',
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { registration: 'GR-0003-26', capacity: 30 },
+    });
+
+    const res = await app.inject({
+      method: 'PUT',
+      url: `/admin/trips/${trip.id}/assignment`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { vehicleId: big.json().id },
+    });
+    expect(res.statusCode).toBe(200);
+  });
+});

--- a/services/api/tests/seat-capacity.test.ts
+++ b/services/api/tests/seat-capacity.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+import {
+  InMemoryReservationRepository,
+  type ReservationResponse,
+} from '../src/modules/reservations/reservation.repository';
+
+const TRIP = 'aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa';
+const DATE = '2026-08-26';
+
+function confirm(userId: string, tripId: string | null = TRIP): ReservationResponse {
+  return {
+    userId,
+    tripId,
+    travelDate: DATE,
+    direction: 'morning',
+    travelling: true,
+    pinHash: null,
+  };
+}
+
+describe('seat capacity on confirmation (#161)', () => {
+  it('refuses a rider once the vehicle is full', async () => {
+    const repo = new InMemoryReservationRepository();
+    // A 2-seat bus.
+    expect(await repo.respondWithinCapacity(confirm('u1'), 2)).not.toBeNull();
+    expect(await repo.respondWithinCapacity(confirm('u2'), 2)).not.toBeNull();
+    expect(await repo.respondWithinCapacity(confirm('u3'), 2)).toBeNull();
+  });
+
+  it('lets a rider re-confirm a seat they already hold', async () => {
+    // Re-confirming is not a new seat; refusing it would strand a rider who
+    // taps the push twice on a full bus they are already on.
+    const repo = new InMemoryReservationRepository();
+    await repo.respondWithinCapacity(confirm('u1'), 1);
+    expect(await repo.respondWithinCapacity(confirm('u1'), 1)).not.toBeNull();
+  });
+
+  it('never refuses a decline', async () => {
+    const repo = new InMemoryReservationRepository();
+    await repo.respondWithinCapacity(confirm('u1'), 1);
+    const declined = await repo.respondWithinCapacity({ ...confirm('u2'), travelling: false }, 1);
+    expect(declined?.status).toBe('declined');
+  });
+
+  it('frees the seat when a rider declines after confirming', async () => {
+    const repo = new InMemoryReservationRepository();
+    await repo.respondWithinCapacity(confirm('u1'), 1);
+    await repo.respondWithinCapacity({ ...confirm('u1'), travelling: false }, 1);
+
+    expect(await repo.countSeatsTaken(TRIP)).toBe(0);
+    expect(await repo.respondWithinCapacity(confirm('u2'), 1)).not.toBeNull();
+  });
+
+  it('counts only reserved and boarded against the ceiling', async () => {
+    // A no-show has already been charged for a seat the vehicle no longer needs
+    // to hold, so it must not keep occupying one.
+    const repo = new InMemoryReservationRepository();
+    const r1 = await repo.respondWithinCapacity(confirm('u1'), 5);
+    const r2 = await repo.respondWithinCapacity(confirm('u2'), 5);
+    await repo.markBoarded(r1!.id);
+    await repo.markNoShow(r2!.id);
+
+    expect(await repo.countSeatsTaken(TRIP)).toBe(1);
+  });
+
+  it('does not constrain a trip with no vehicle assigned', async () => {
+    // Ops routinely creates trips before crewing them; treating that as zero
+    // would stop anyone reserving until a bus was attached.
+    const repo = new InMemoryReservationRepository();
+    for (const u of ['u1', 'u2', 'u3']) {
+      expect(await repo.respond(confirm(u, null))).not.toBeNull();
+    }
+  });
+});
+
+describe('cutoff default-yes respects capacity', () => {
+  /** Seed `n` pending reservations on the trip. */
+  async function pending(repo: InMemoryReservationRepository, n: number) {
+    for (let i = 0; i < n; i++) {
+      await repo.createPending({
+        userId: `p${i}`,
+        tripId: TRIP,
+        travelDate: DATE,
+        direction: 'morning',
+      });
+    }
+  }
+
+  it('does not default riders into seats that do not exist', async () => {
+    // The bug this closes: at 21:00 the cutoff used to flip every pending
+    // rider to reserved regardless of the bus, making an overfull trip worse
+    // with nobody watching.
+    const repo = new InMemoryReservationRepository();
+    await repo.respondWithinCapacity(confirm('confirmed'), 3);
+    await pending(repo, 5);
+
+    const result = await repo.markDefaultTravelling(DATE, 'morning', async () => 3);
+
+    expect(result.defaulted).toBe(2); // 3 seats, 1 already taken
+    expect(result.skippedFull).toBe(3);
+    expect(await repo.countSeatsTaken(TRIP)).toBe(3);
+  });
+
+  it('defaults everyone when no capacity resolver is supplied', async () => {
+    const repo = new InMemoryReservationRepository();
+    await pending(repo, 4);
+    const result = await repo.markDefaultTravelling(DATE, 'morning');
+    expect(result).toEqual({ defaulted: 4, skippedFull: 0 });
+  });
+
+  it('treats an unlimited trip as unlimited', async () => {
+    const repo = new InMemoryReservationRepository();
+    await pending(repo, 4);
+    const result = await repo.markDefaultTravelling(DATE, 'morning', async () => null);
+    expect(result).toEqual({ defaulted: 4, skippedFull: 0 });
+  });
+});


### PR DESCRIPTION
**Closes #161.** The one live correctness bug in the backlog.

## What was wrong

`vehicles.capacity` existed and **nothing read it**. An unlimited number of riders could confirm onto a 22-seat bus.

The cutoff made it worse. At 21:00 `resolve-defaults` flipped every still-pending rider to `reserved` regardless of the bus — so a trip that was merely full became badly oversold, silently, with nobody watching.

## Guarded in all three places a seat can be taken

| Path | Result |
|---|---|
| `POST /me/reservations` | `409 trip_full` |
| `POST /admin/resolve-defaults` | skips, reports `skippedFull` |
| `PUT /admin/trips/:id/assignment` | `409 capacity_too_small` |

## Enforced in the repository, not the caller

A check-then-write in application code **races**. The 18:00 push lands a corridor's riders within the same few seconds, so two confirming into the last seat would both read "one free" before either wrote. Only the store can make the count and the write atomic.

The Postgres path takes a **row lock on the trip** (`SELECT id FROM trips WHERE id = $1 FOR UPDATE`), so every confirmation for that trip serialises.

**Verified against real Postgres**, not asserted:

```
=== 8 riders racing for 1 seat, concurrently ===
  seats taken: 1
```

## Decisions worth reviewing

**Only `reserved` and `boarded` consume a seat.** A `no_show` does not — the rider has already been charged for a seat the vehicle no longer needs to hold. `released` frees it to the standby pool.

**No vehicle, or capacity 0, means unlimited — not zero.** Ops routinely creates trips before crewing them; treating that as zero would stop anyone reserving on an uncrewed run. Capacity `0` means "not recorded in the fleet data".

**Re-confirming a seat you already hold is never refused.** The count excludes the requesting rider, so tapping the push twice on a full bus you're already on works.

**`skippedFull` is surfaced on the API, not dropped.** A non-zero count means demand exceeded the bus — the signal to put a second vehicle on that corridor, and the natural trigger for the standby pool (#105).

**Oldest-pending-first when a trip can't take everyone.** `ORDER BY created_at` — the rider asked first gets the seat. Arbitrary is worse than a rule we can explain to someone who didn't get one.

## Verification

Full gates green. **415 tests** (up from 401), coverage 92.42%. 14 new tests covering the ceiling, the re-confirm case, no-show not occupying a seat, unlimited trips, the cutoff skipping, and both 409s at route level.