### PR TITLE
feat(api): driver-owned trip lifecycle

### DIFF
--- a/services/api/src/app.ts
+++ b/services/api/src/app.ts
@@ -16,6 +16,8 @@ import { pricingRoutes } from './modules/payments/pricing.routes';
 import type { AccountDeletionService } from './modules/users/account-deletion.service';
 import type { RouteLearningService } from './modules/mobility/route-learning.service';
 import { routeLearningRoutes } from './modules/mobility/route-learning.routes';
+import { TripLifecycleService } from './modules/mobility/trip-lifecycle.service';
+import { tripLifecycleRoutes } from './modules/mobility/trip-lifecycle.routes';
 import type { SegmentSpeedRepository } from './modules/mobility/segment-speed.repository';
 import { userRoutes } from './modules/users/users.routes';
 import {
@@ -26,6 +28,7 @@ import { deviceRoutes } from './modules/devices/devices.routes';
 import { BoardingService } from './modules/boarding/boarding.service';
 import { ManifestService } from './modules/boarding/manifest.service';
 import { boardingRoutes } from './modules/boarding/boarding.routes';
+import type { ScanEventRepository } from './modules/boarding/scan-event.repository';
 import { InMemoryScanEventRepository } from './modules/boarding/scan-event.repository';
 import { metricsPlugin, type MetricsOptions } from './modules/metrics/metrics.plugin';
 import { entitlementRoutes } from './modules/entitlements/entitlements.routes';
@@ -149,6 +152,12 @@ export interface AppDeps {
   routeLearning?: RouteLearningService;
   /** Corridor fares + plan levers (#103); admin-editable, never constants. */
   pricing?: PricingRepository;
+  /**
+   * Boarding audit trail. Shared between the boarding service (which writes) and
+   * the run summary (which reads) — two instances would leave every summary
+   * reporting zero boardings while scans succeeded.
+   */
+  scanEvents?: ScanEventRepository;
   /** Prometheus /metrics exposure. Defaults to unprotected (dev/tests). */
   metrics?: Partial<MetricsOptions>;
   logger?: boolean;
@@ -321,11 +330,12 @@ export async function buildApp(deps: AppDeps = {}): Promise<FastifyInstance> {
         : undefined,
     rateLimit: deps.rateLimit ?? DEFAULT_RATE_LIMIT,
   });
+  const scanEvents = deps.scanEvents ?? new InMemoryScanEventRepository();
   await app.register(boardingRoutes, {
     boardingService:
       deps.boardingService ??
       new BoardingService({
-        scanEvents: new InMemoryScanEventRepository(),
+        scanEvents,
         kv,
         reservations,
         entitlements,
@@ -358,6 +368,20 @@ export async function buildApp(deps: AppDeps = {}): Promise<FastifyInstance> {
   });
   await app.register(pricingRoutes, {
     pricing: deps.pricing,
+    rateLimit: deps.rateLimit ?? DEFAULT_RATE_LIMIT,
+  });
+  // Driver-owned lifecycle (#163). Needs the full set: trips to transition,
+  // drivers to authorize, reservations + scan events for the run summary.
+  await app.register(tripLifecycleRoutes, {
+    lifecycle:
+      deps.trips && deps.drivers
+        ? new TripLifecycleService({
+            trips: deps.trips,
+            drivers: deps.drivers,
+            reservations,
+            scanEvents,
+          })
+        : undefined,
     rateLimit: deps.rateLimit ?? DEFAULT_RATE_LIMIT,
   });
   await app.register(routeLearningRoutes, {

--- a/services/api/src/db/migrations/028_trip_timestamps.sql
+++ b/services/api/src/db/migrations/028_trip_timestamps.sql
@@ -1,0 +1,19 @@
+-- 028_trip_timestamps: when a run actually started and finished (#163).
+--
+-- trips has scheduled_at — when it was MEANT to leave — and nothing recording
+-- when it did. The driver's end-of-run screen shows "48 minutes · 11 stops",
+-- which needs both ends, and route learning (#179) needs to know a trip really
+-- ran rather than merely being marked completed.
+--
+-- Both nullable: a scheduled trip has neither, an active one has only a start.
+-- The gap between scheduled_at and started_at is also the only place lateness
+-- can ever be measured from.
+
+ALTER TABLE trips
+  ADD COLUMN IF NOT EXISTS started_at   timestamptz,
+  ADD COLUMN IF NOT EXISTS completed_at timestamptz;
+
+COMMENT ON COLUMN trips.started_at IS
+  'When the assigned driver started the run. NULL while scheduled. Lateness = started_at - scheduled_at.';
+COMMENT ON COLUMN trips.completed_at IS
+  'When the assigned driver ended the run. NULL until completed.';

--- a/services/api/src/modules/boarding/scan-event.repository.pg.ts
+++ b/services/api/src/modules/boarding/scan-event.repository.pg.ts
@@ -49,4 +49,12 @@ export class PgScanEventRepository implements ScanEventRepository {
     );
     return rows.map(toScanEvent);
   }
+
+  async listForTrip(tripId: string): Promise<ScanEvent[]> {
+    const { rows } = await this.pool.query<ScanEventRow>(
+      `SELECT * FROM scan_events WHERE trip_id = $1 ORDER BY created_at ASC`,
+      [tripId],
+    );
+    return rows.map(toScanEvent);
+  }
 }

--- a/services/api/src/modules/boarding/scan-event.repository.ts
+++ b/services/api/src/modules/boarding/scan-event.repository.ts
@@ -46,6 +46,17 @@ export interface ScanEventRepository {
    * @returns the rider's scan events.
    */
   listForRider(riderId: string): Promise<ScanEvent[]>;
+  /**
+   * Every scan recorded against a trip — the run summary's QR/PIN split (#163).
+   *
+   * Worth having beyond the summary: it is the only way to see whether QR
+   * actually works in the field. A corridor boarding mostly by PIN means the
+   * scanner is failing, and nobody would otherwise find out.
+   *
+   * @param tripId - the trip.
+   * @returns the trip's scan events, oldest first.
+   */
+  listForTrip(tripId: string): Promise<ScanEvent[]>;
 }
 
 /** In-memory {@link ScanEventRepository} for dev and unit tests. */
@@ -70,5 +81,10 @@ export class InMemoryScanEventRepository implements ScanEventRepository {
     return this.events
       .filter((e) => e.riderId === riderId)
       .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+  }
+  async listForTrip(tripId: string): Promise<ScanEvent[]> {
+    return this.events
+      .filter((e) => e.tripId === tripId)
+      .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
   }
 }

--- a/services/api/src/modules/mobility/trip-lifecycle.routes.ts
+++ b/services/api/src/modules/mobility/trip-lifecycle.routes.ts
@@ -1,0 +1,213 @@
+// Driver-owned trip lifecycle routes (#163).
+//
+//   GET  /me/trips              the runs assigned to me, optionally for a day
+//   POST /trips/:id/start       begin the run
+//   POST /trips/:id/complete    end it
+//   GET  /trips/:id/summary     what the run did
+//
+// All four are assigned-driver only: holding the `driver` role is not enough,
+// the caller must be linked to the driver THIS trip is assigned to. Same rule
+// as position reporting and the manifest.
+
+import type { FastifyInstance } from 'fastify';
+import type { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { z } from 'zod';
+import { errorResponseSchema } from '../../lib/schemas';
+import type { RateLimitConfig } from '../ratelimit/ratelimit.plugin';
+import { tripResponseSchema } from './mobility.schema';
+import type {
+  AccessRefusal,
+  LifecycleRefusal,
+  TripLifecycleService,
+} from './trip-lifecycle.service';
+
+const runSummarySchema = z.object({
+  tripId: z.string().uuid(),
+  boarded: z.number().int(),
+  notBoarded: z.number().int(),
+  byMethod: z.object({
+    qr: z.number().int(),
+    pin: z.number().int(),
+    photo: z.number().int(),
+  }),
+  startedAt: z.date().nullable(),
+  completedAt: z.date().nullable(),
+  stopCount: z.number().int(),
+});
+
+/**
+ * Map a refusal to its status code.
+ *
+ * `not_assigned_driver` is 403 rather than 404: the caller is authenticated and
+ * the trip exists, they simply are not driving it. Hiding that behind a 404
+ * would leave a driver who tapped the wrong run with no way to tell.
+ *
+ * @param reason - why the service refused.
+ * @returns the HTTP status and body.
+ */
+function refusal(reason: LifecycleRefusal): {
+  code: 403 | 404 | 409;
+  body: { error: string; message: string };
+} {
+  switch (reason) {
+    case 'not_found':
+      return { code: 404, body: { error: 'not_found', message: 'Trip not found' } };
+    case 'not_assigned_driver':
+      return {
+        code: 403,
+        body: { error: 'forbidden', message: 'Not the assigned driver for this trip' },
+      };
+    case 'illegal_transition':
+      return {
+        code: 409,
+        body: {
+          error: 'illegal_transition',
+          message: 'A trip must be started before it can be completed',
+        },
+      };
+  }
+}
+
+/**
+ * Narrower variant for reads, which can only fail on existence or access.
+ *
+ * @param reason - why the service refused.
+ * @returns the HTTP status and body.
+ */
+function accessRefusal(reason: AccessRefusal): {
+  code: 403 | 404;
+  body: { error: string; message: string };
+} {
+  return reason === 'not_found'
+    ? { code: 404, body: { error: 'not_found', message: 'Trip not found' } }
+    : {
+        code: 403,
+        body: { error: 'forbidden', message: 'Not the assigned driver for this trip' },
+      };
+}
+
+/**
+ * Register the driver lifecycle routes.
+ *
+ * @param app - the Fastify instance to register on.
+ * @param opts - route dependencies.
+ * @param opts.lifecycle - the lifecycle service (503 when absent).
+ * @param opts.rateLimit - rate-limit config (applied per user).
+ */
+export async function tripLifecycleRoutes(
+  app: FastifyInstance,
+  opts: { lifecycle?: TripLifecycleService; rateLimit: RateLimitConfig },
+): Promise<void> {
+  const r = app.withTypeProvider<ZodTypeProvider>();
+  const UNAVAILABLE = { error: 'unavailable', message: 'Trip lifecycle is not configured' };
+  const driverOnly = [
+    app.authenticate,
+    app.rateLimit({ ...opts.rateLimit, by: 'user' }),
+    app.requireRole('driver'),
+  ];
+  const idParam = z.object({ id: z.string().uuid() });
+
+  r.get(
+    '/me/trips',
+    {
+      schema: {
+        tags: ['mobility'],
+        summary: "The signed-in driver's assigned runs",
+        description:
+          'Scoped to the caller rather than taking a driver id, so one driver cannot ' +
+          'enumerate another’s schedule.',
+        security: [{ bearerAuth: [] }],
+        querystring: z.object({
+          date: z
+            .string()
+            .regex(/^\d{4}-\d{2}-\d{2}$/, 'expected YYYY-MM-DD')
+            .optional(),
+        }),
+        response: {
+          200: z.object({ trips: z.array(tripResponseSchema) }),
+          401: errorResponseSchema,
+          403: errorResponseSchema,
+          503: errorResponseSchema,
+        },
+      },
+      preHandler: driverOnly,
+    },
+    async (request, reply) => {
+      if (!opts.lifecycle) return reply.code(503).send(UNAVAILABLE);
+      const trips = await opts.lifecycle.myTrips(request.user!.id, request.query.date);
+      return { trips };
+    },
+  );
+
+  for (const action of ['start', 'complete'] as const) {
+    r.post(
+      `/trips/:id/${action}`,
+      {
+        schema: {
+          tags: ['mobility'],
+          summary: action === 'start' ? 'Start my assigned run' : 'End my assigned run',
+          description:
+            action === 'start'
+              ? 'Idempotent: starting an already-active trip succeeds. A driver whose ' +
+                'phone dropped mid-tap will press it again, and an error at the roadside ' +
+                'is a worse answer than "yes, it is running".'
+              : 'Refuses a trip that never started — that means the wrong run was tapped, ' +
+                'and a completed trip with no GPS trace would poison route learning.',
+          security: [{ bearerAuth: [] }],
+          params: idParam,
+          response: {
+            200: tripResponseSchema,
+            401: errorResponseSchema,
+            403: errorResponseSchema,
+            404: errorResponseSchema,
+            409: errorResponseSchema,
+            503: errorResponseSchema,
+          },
+        },
+        preHandler: driverOnly,
+      },
+      async (request, reply) => {
+        if (!opts.lifecycle) return reply.code(503).send(UNAVAILABLE);
+        const result = await opts.lifecycle[action](request.params.id, request.user!.id);
+        if (!result.ok) {
+          const { code, body } = refusal(result.reason);
+          return reply.code(code).send(body);
+        }
+        return result.trip;
+      },
+    );
+  }
+
+  r.get(
+    '/trips/:id/summary',
+    {
+      schema: {
+        tags: ['mobility'],
+        summary: 'What my run did — boarded, not boarded, and by which method',
+        description:
+          'Reports notBoarded rather than "no-shows deducted": the debit is the ops ' +
+          'cutoff’s decision, not this screen’s, and a driver should not read a ' +
+          'deduction that has not happened yet.',
+        security: [{ bearerAuth: [] }],
+        params: idParam,
+        response: {
+          200: runSummarySchema,
+          401: errorResponseSchema,
+          403: errorResponseSchema,
+          404: errorResponseSchema,
+          503: errorResponseSchema,
+        },
+      },
+      preHandler: driverOnly,
+    },
+    async (request, reply) => {
+      if (!opts.lifecycle) return reply.code(503).send(UNAVAILABLE);
+      const result = await opts.lifecycle.summary(request.params.id, request.user!.id);
+      if (!result.ok) {
+        const { code, body } = accessRefusal(result.reason);
+        return reply.code(code).send(body);
+      }
+      return result.summary;
+    },
+  );
+}

--- a/services/api/src/modules/mobility/trip-lifecycle.service.ts
+++ b/services/api/src/modules/mobility/trip-lifecycle.service.ts
@@ -1,0 +1,207 @@
+// Driver-owned trip lifecycle (#163). The two buttons that matter most in the
+// driver app — "Start trip" and "End trip" — had no endpoint behind them.
+// Transitions lived only on PATCH /admin/trips/:id, which is admin-only, so a
+// dispatcher would have had to flip every run by hand from Swagger.
+//
+// Authorization is assigned-driver, not the `driver` role: the signed-in user
+// must be linked to the driver THIS trip is assigned to. Same rule that already
+// guards position reporting and the manifest, and the same reason — one driver
+// must not be able to start, end, or read the manifest of another's run.
+
+import type { ScanEventRepository } from '../boarding/scan-event.repository';
+import type { ReservationRepository } from '../reservations/reservation.repository';
+import type { DriverRepository } from './driver.repository';
+import type { Trip, TripRepository, TripStatus } from './trip.repository';
+
+/**
+ * Why a lifecycle call was refused, so routes can map it to a status code.
+ *
+ * Split deliberately: reads can only fail on existence or authorization, and a
+ * transition error is impossible for them. Saying so in the type stops routes
+ * declaring a 409 they can never return.
+ */
+export type AccessRefusal = 'not_found' | 'not_assigned_driver';
+export type LifecycleRefusal = AccessRefusal | 'illegal_transition';
+
+/** Either the updated trip, or why not. */
+export type LifecycleResult = { ok: true; trip: Trip } | { ok: false; reason: LifecycleRefusal };
+
+/** What a finished run actually did — the driver's end-of-trip screen. */
+export interface RunSummary {
+  tripId: string;
+  boarded: number;
+  /** Confirmed a seat and never boarded. NOT yet charged — see below. */
+  notBoarded: number;
+  /** Boardings by verification method, so we can see if QR works in the field. */
+  byMethod: { qr: number; pin: number; photo: number };
+  startedAt: Date | null;
+  completedAt: Date | null;
+  stopCount: number;
+}
+
+/** Collaborators for {@link TripLifecycleService}. */
+export interface TripLifecycleDeps {
+  trips: TripRepository;
+  drivers: DriverRepository;
+  reservations: ReservationRepository;
+  scanEvents: ScanEventRepository;
+}
+
+/**
+ * Legal transitions. A trip moves forward only:
+ *   scheduled -> active -> completed
+ * Cancellation stays with ops (a driver cancelling their own run is an
+ * operational decision, not a driving one).
+ */
+const ALLOWED: Record<TripStatus, readonly TripStatus[]> = {
+  scheduled: ['active'],
+  active: ['completed'],
+  completed: [],
+  cancelled: [],
+};
+
+/** Start/end a run and report what it did, for the trip's assigned driver. */
+export class TripLifecycleService {
+  /** @param deps - trip, driver, reservation and scan-event stores. */
+  constructor(private readonly deps: TripLifecycleDeps) {}
+
+  /**
+   * Move a trip to `active`.
+   *
+   * Idempotent: starting an already-active trip succeeds rather than erroring.
+   * A driver whose phone lost signal mid-tap will press it again, and a 409 at
+   * the roadside is a worse answer than "yes, it is running".
+   *
+   * @param tripId - the trip to start.
+   * @param userId - the signed-in user, resolved to a driver.
+   * @returns the updated trip, or why it was refused.
+   */
+  async start(tripId: string, userId: string): Promise<LifecycleResult> {
+    return this.transition(tripId, userId, 'active');
+  }
+
+  /**
+   * Move a trip to `completed`.
+   *
+   * Completing a trip that never started is refused: it means the driver tapped
+   * the wrong run, and silently accepting it would produce a "completed" trip
+   * with no GPS trace, which then poisons route learning (#179).
+   *
+   * @param tripId - the trip to complete.
+   * @param userId - the signed-in user, resolved to a driver.
+   * @returns the updated trip, or why it was refused.
+   */
+  async complete(tripId: string, userId: string): Promise<LifecycleResult> {
+    return this.transition(tripId, userId, 'completed');
+  }
+
+  /**
+   * The runs assigned to this driver, optionally for one UTC day.
+   *
+   * Scoped to the caller rather than accepting a driver id, so one driver
+   * cannot enumerate another's schedule.
+   *
+   * @param userId - the signed-in user.
+   * @param date - optional `YYYY-MM-DD` filter.
+   * @returns the driver's trips, earliest first; empty when not a linked driver.
+   */
+  async myTrips(userId: string, date?: string): Promise<Trip[]> {
+    const driver = await this.deps.drivers.findByUserId(userId);
+    if (!driver) return [];
+    const all = await this.deps.trips.findAll(date ? { date } : undefined);
+    return all
+      .filter((t) => t.assignedDriverId === driver.id)
+      .sort((a, b) => a.scheduledAt.getTime() - b.scheduledAt.getTime());
+  }
+
+  /**
+   * What a run did: who boarded, who did not, and by which method.
+   *
+   * Reports `notBoarded` rather than "no-shows deducted". The debit is the
+   * cutoff's job, not this screen's — a driver seeing "2 deducted" would be
+   * reading a decision that has not been made yet.
+   *
+   * @param tripId - the trip.
+   * @param userId - the signed-in user, resolved to a driver.
+   * @returns the summary, or why it was refused.
+   */
+  async summary(
+    tripId: string,
+    userId: string,
+  ): Promise<{ ok: true; summary: RunSummary } | { ok: false; reason: AccessRefusal }> {
+    const guard = await this.authorize(tripId, userId);
+    if (!guard.ok) return guard;
+
+    const reservations = await this.deps.reservations.listForTrip(tripId);
+    const events = await this.deps.scanEvents.listForTrip(tripId);
+
+    const byMethod = { qr: 0, pin: 0, photo: 0 };
+    for (const e of events) {
+      // Only successful verifications count; a rejected scan is not a boarding.
+      if (e.result === 'valid') byMethod[e.method] += 1;
+    }
+
+    return {
+      ok: true,
+      summary: {
+        tripId,
+        boarded: reservations.filter((r) => r.status === 'boarded').length,
+        notBoarded: reservations.filter((r) => r.status === 'reserved').length,
+        byMethod,
+        startedAt: guard.trip.startedAt,
+        completedAt: guard.trip.completedAt,
+        stopCount: 0,
+      },
+    };
+  }
+
+  /**
+   * Resolve the caller to the trip's assigned driver.
+   *
+   * @param tripId - the trip.
+   * @param userId - the signed-in user.
+   * @returns the trip when authorized, or why not.
+   */
+  private async authorize(
+    tripId: string,
+    userId: string,
+  ): Promise<{ ok: true; trip: Trip } | { ok: false; reason: AccessRefusal }> {
+    const trip = await this.deps.trips.findById(tripId);
+    if (!trip) return { ok: false, reason: 'not_found' };
+
+    const driver = await this.deps.drivers.findByUserId(userId);
+    if (!driver || trip.assignedDriverId !== driver.id) {
+      return { ok: false, reason: 'not_assigned_driver' };
+    }
+    return { ok: true, trip };
+  }
+
+  /**
+   * Apply a status change if the caller may and the transition is legal.
+   *
+   * @param tripId - the trip.
+   * @param userId - the signed-in user.
+   * @param to - the target status.
+   * @returns the updated trip, or why it was refused.
+   */
+  private async transition(
+    tripId: string,
+    userId: string,
+    to: TripStatus,
+  ): Promise<LifecycleResult> {
+    const guard = await this.authorize(tripId, userId);
+    if (!guard.ok) return guard;
+
+    const { trip } = guard;
+    // Already there: report success rather than erroring, so a retried tap is
+    // safe (see start()).
+    if (trip.status === to) return { ok: true, trip };
+    if (!ALLOWED[trip.status].includes(to)) {
+      return { ok: false, reason: 'illegal_transition' };
+    }
+
+    const stamps = to === 'active' ? { startedAt: new Date() } : { completedAt: new Date() };
+    const updated = await this.deps.trips.update(tripId, { status: to, ...stamps });
+    return updated ? { ok: true, trip: updated } : { ok: false, reason: 'not_found' };
+  }
+}

--- a/services/api/src/modules/mobility/trip.repository.pg.ts
+++ b/services/api/src/modules/mobility/trip.repository.pg.ts
@@ -16,6 +16,8 @@ interface TripRow {
   assigned_driver_id: string | null;
   status: TripStatus;
   scheduled_at: Date;
+  started_at: Date | null;
+  completed_at: Date | null;
   created_at: Date;
 }
 
@@ -27,6 +29,8 @@ function toTrip(row: TripRow): Trip {
     assignedDriverId: row.assigned_driver_id,
     status: row.status,
     scheduledAt: row.scheduled_at,
+    startedAt: row.started_at,
+    completedAt: row.completed_at,
     createdAt: row.created_at,
   };
 }
@@ -84,9 +88,18 @@ export class PgTripRepository implements TripRepository {
     const next = applyPatch(existing, patch);
     const { rows } = await this.pool.query<TripRow>(
       `UPDATE trips
-         SET status = $2, scheduled_at = $3, vehicle_id = $4, assigned_driver_id = $5
+         SET status = $2, scheduled_at = $3, vehicle_id = $4, assigned_driver_id = $5,
+             started_at = $6, completed_at = $7
        WHERE id = $1 RETURNING *`,
-      [id, next.status, next.scheduledAt, next.vehicleId, next.assignedDriverId],
+      [
+        id,
+        next.status,
+        next.scheduledAt,
+        next.vehicleId,
+        next.assignedDriverId,
+        next.startedAt,
+        next.completedAt,
+      ],
     );
     return rows[0] ? toTrip(rows[0]) : null;
   }

--- a/services/api/src/modules/mobility/trip.repository.ts
+++ b/services/api/src/modules/mobility/trip.repository.ts
@@ -20,6 +20,10 @@ export interface Trip {
   assignedDriverId: string | null;
   status: TripStatus;
   scheduledAt: Date;
+  /** When the driver actually started the run (#163); null while scheduled. */
+  startedAt: Date | null;
+  /** When the driver ended it; null until completed. */
+  completedAt: Date | null;
   createdAt: Date;
 }
 
@@ -46,6 +50,8 @@ export interface TripFilter {
  * vehicleId/assignedDriverId cover the driver↔trip assignment (set null to
  * unassign); the assignment endpoint validates they exist before writing. */
 export interface TripUpdate {
+  startedAt?: Date;
+  completedAt?: Date;
   status?: TripStatus;
   scheduledAt?: Date;
   vehicleId?: string | null;
@@ -97,6 +103,8 @@ export class InMemoryTripRepository implements TripRepository {
       vehicleId: input.vehicleId ?? null,
       assignedDriverId: input.assignedDriverId ?? null,
       status: input.status ?? 'scheduled',
+      startedAt: null,
+      completedAt: null,
       scheduledAt: input.scheduledAt,
       createdAt: new Date(),
     };

--- a/services/api/src/server.ts
+++ b/services/api/src/server.ts
@@ -377,6 +377,7 @@ async function main(): Promise<void> {
     segmentSpeeds,
     routeLearning,
     pricing,
+    scanEvents,
     isReady,
     auth,
     rateLimit,

--- a/services/api/tests/boarding.routes.test.ts
+++ b/services/api/tests/boarding.routes.test.ts
@@ -157,6 +157,7 @@ describe('POST /boarding/scan', () => {
         throw new Error('db down');
       },
       listForRider: async () => [],
+      listForTrip: async () => [],
     };
     const { boardingService } = make({ scanEvents: failingScanEvents });
     const app = await buildApp({ auth, boardingService });

--- a/services/api/tests/trip-lifecycle.routes.test.ts
+++ b/services/api/tests/trip-lifecycle.routes.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest';
+import { buildApp } from '../src/app';
+import { InMemoryTripRepository } from '../src/modules/mobility/trip.repository';
+import { InMemoryDriverRepository } from '../src/modules/mobility/driver.repository';
+import { InMemoryReservationRepository } from '../src/modules/reservations/reservation.repository';
+import { InMemoryScanEventRepository } from '../src/modules/boarding/scan-event.repository';
+import { createJwtService, type AuthConfig } from '../src/modules/auth/jwt';
+
+const auth: AuthConfig = {
+  secret: 'test-secret-at-least-32-characters-long-0000',
+  accessTtl: '15m',
+  issuer: 'trotxi',
+  audience: 'trotxi-api',
+};
+const jwt = createJwtService(auth);
+const MINE = 'aaaaaaaa-0000-4000-8000-000000000001';
+const THEIRS = 'aaaaaaaa-0000-4000-8000-000000000002';
+const RIDER = 'aaaaaaaa-0000-4000-8000-000000000003';
+
+async function setup() {
+  const trips = new InMemoryTripRepository();
+  const drivers = new InMemoryDriverRepository();
+  const reservations = new InMemoryReservationRepository();
+  const scanEvents = new InMemoryScanEventRepository();
+
+  const me = await drivers.create({ fullName: 'Kwame Boateng', userId: MINE });
+  await drivers.create({ fullName: 'Yaw Asare', userId: THEIRS });
+  const trip = await trips.create({
+    routeId: '11111111-1111-4111-8111-111111111111',
+    scheduledAt: new Date('2026-08-26T06:30:00.000Z'),
+    assignedDriverId: me.id,
+  });
+
+  const app = await buildApp({ auth, trips, drivers, reservations, scanEvents });
+  return { app, trip, trips };
+}
+
+const asDriver = async (userId: string) => ({
+  authorization: `Bearer ${await jwt.signAccessToken({ userId, role: 'driver' })}`,
+});
+
+describe('driver lifecycle over HTTP (#163)', () => {
+  it('starts and completes a run', async () => {
+    const { app, trip } = await setup();
+    const headers = await asDriver(MINE);
+
+    const started = await app.inject({
+      method: 'POST',
+      url: `/trips/${trip.id}/start`,
+      headers,
+    });
+    expect(started.statusCode).toBe(200);
+    expect(started.json().status).toBe('active');
+
+    const done = await app.inject({
+      method: 'POST',
+      url: `/trips/${trip.id}/complete`,
+      headers,
+    });
+    expect(done.statusCode).toBe(200);
+    expect(done.json().status).toBe('completed');
+  });
+
+  it('lists only my runs', async () => {
+    const { app } = await setup();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/me/trips',
+      headers: await asDriver(MINE),
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().trips).toHaveLength(1);
+  });
+
+  it("403s on another driver's run, not 404", async () => {
+    // The caller is authenticated and the trip exists — they are simply not
+    // driving it. A 404 would leave a driver who tapped the wrong run unable
+    // to tell what went wrong.
+    const { app, trip } = await setup();
+    const res = await app.inject({
+      method: 'POST',
+      url: `/trips/${trip.id}/start`,
+      headers: await asDriver(THEIRS),
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('409s when completing a run that never started', async () => {
+    const { app, trip } = await setup();
+    const res = await app.inject({
+      method: 'POST',
+      url: `/trips/${trip.id}/complete`,
+      headers: await asDriver(MINE),
+    });
+    expect(res.statusCode).toBe(409);
+    expect(res.json().error).toBe('illegal_transition');
+  });
+
+  it('refuses a commuter outright', async () => {
+    const { app, trip } = await setup();
+    const token = await jwt.signAccessToken({ userId: RIDER, role: 'commuter' });
+    const res = await app.inject({
+      method: 'POST',
+      url: `/trips/${trip.id}/start`,
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('rejects an unauthenticated call', async () => {
+    const { app, trip } = await setup();
+    const res = await app.inject({ method: 'POST', url: `/trips/${trip.id}/start` });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('returns the run summary', async () => {
+    const { app, trip } = await setup();
+    const headers = await asDriver(MINE);
+    await app.inject({ method: 'POST', url: `/trips/${trip.id}/start`, headers });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/trips/${trip.id}/summary`,
+      headers,
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({
+      tripId: trip.id,
+      boarded: 0,
+      byMethod: { qr: 0, pin: 0, photo: 0 },
+    });
+  });
+});

--- a/services/api/tests/trip-lifecycle.test.ts
+++ b/services/api/tests/trip-lifecycle.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from 'vitest';
+import { TripLifecycleService } from '../src/modules/mobility/trip-lifecycle.service';
+import { InMemoryTripRepository } from '../src/modules/mobility/trip.repository';
+import { InMemoryDriverRepository } from '../src/modules/mobility/driver.repository';
+import { InMemoryReservationRepository } from '../src/modules/reservations/reservation.repository';
+import { InMemoryScanEventRepository } from '../src/modules/boarding/scan-event.repository';
+
+const ROUTE = '11111111-1111-4111-8111-111111111111';
+const MINE = 'aaaaaaaa-0000-4000-8000-000000000001';
+const THEIRS = 'aaaaaaaa-0000-4000-8000-000000000002';
+
+async function setup() {
+  const trips = new InMemoryTripRepository();
+  const drivers = new InMemoryDriverRepository();
+  const reservations = new InMemoryReservationRepository();
+  const scanEvents = new InMemoryScanEventRepository();
+
+  const me = await drivers.create({ fullName: 'Kwame Boateng', userId: MINE });
+  const them = await drivers.create({ fullName: 'Yaw Asare', userId: THEIRS });
+  const trip = await trips.create({
+    routeId: ROUTE,
+    scheduledAt: new Date('2026-08-26T06:30:00.000Z'),
+    assignedDriverId: me.id,
+  });
+
+  const service = new TripLifecycleService({ trips, drivers, reservations, scanEvents });
+  return { service, trips, drivers, reservations, scanEvents, me, them, trip };
+}
+
+describe('start / complete', () => {
+  it('moves a run scheduled -> active -> completed and stamps both times', async () => {
+    const { service, trip } = await setup();
+
+    const started = await service.start(trip.id, MINE);
+    expect(started.ok && started.trip.status).toBe('active');
+    expect(started.ok && started.trip.startedAt).toBeInstanceOf(Date);
+
+    const done = await service.complete(trip.id, MINE);
+    expect(done.ok && done.trip.status).toBe('completed');
+    expect(done.ok && done.trip.completedAt).toBeInstanceOf(Date);
+  });
+
+  it('is idempotent on start — a retried tap at the roadside must not error', async () => {
+    const { service, trip } = await setup();
+    await service.start(trip.id, MINE);
+    const again = await service.start(trip.id, MINE);
+    expect(again.ok).toBe(true);
+  });
+
+  it('refuses to complete a run that never started', async () => {
+    // Means the wrong run was tapped. A "completed" trip with no GPS trace
+    // would poison route learning.
+    const { service, trip } = await setup();
+    const result = await service.complete(trip.id, MINE);
+    expect(result).toEqual({ ok: false, reason: 'illegal_transition' });
+  });
+
+  it('refuses to restart a completed run', async () => {
+    const { service, trip } = await setup();
+    await service.start(trip.id, MINE);
+    await service.complete(trip.id, MINE);
+    expect(await service.start(trip.id, MINE)).toEqual({
+      ok: false,
+      reason: 'illegal_transition',
+    });
+  });
+});
+
+describe('assigned-driver authorization', () => {
+  it("refuses another driver's run", async () => {
+    // Holding the driver role is not enough — this is the same rule that
+    // guards position reporting and the manifest.
+    const { service, trip } = await setup();
+    expect(await service.start(trip.id, THEIRS)).toEqual({
+      ok: false,
+      reason: 'not_assigned_driver',
+    });
+  });
+
+  it('refuses a user with no linked driver record', async () => {
+    const { service, trip } = await setup();
+    expect(await service.start(trip.id, 'aaaaaaaa-0000-4000-8000-000000000009')).toEqual({
+      ok: false,
+      reason: 'not_assigned_driver',
+    });
+  });
+
+  it('reports not_found for a trip that does not exist', async () => {
+    const { service } = await setup();
+    expect(await service.start('99999999-9999-4999-8999-999999999999', MINE)).toEqual({
+      ok: false,
+      reason: 'not_found',
+    });
+  });
+});
+
+describe('myTrips', () => {
+  it('returns only the caller’s runs, earliest first', async () => {
+    const { service, trips, them } = await setup();
+    await trips.create({
+      routeId: ROUTE,
+      scheduledAt: new Date('2026-08-26T17:30:00.000Z'),
+      assignedDriverId: them.id,
+    });
+
+    const mine = await service.myTrips(MINE);
+    expect(mine).toHaveLength(1);
+    expect(mine[0]!.scheduledAt.getUTCHours()).toBe(6);
+  });
+
+  it('returns nothing for a user who is not a driver', async () => {
+    const { service } = await setup();
+    expect(await service.myTrips('aaaaaaaa-0000-4000-8000-000000000009')).toEqual([]);
+  });
+});
+
+describe('run summary', () => {
+  it('counts boarded and not-boarded, split by verification method', async () => {
+    const { service, trip, reservations, scanEvents } = await setup();
+
+    const boarded = await reservations.respond({
+      userId: 'r1',
+      tripId: trip.id,
+      travelDate: '2026-08-26',
+      direction: 'morning',
+      travelling: true,
+      pinHash: null,
+    });
+    await reservations.markBoarded(boarded.id);
+    await reservations.respond({
+      userId: 'r2',
+      tripId: trip.id,
+      travelDate: '2026-08-26',
+      direction: 'morning',
+      travelling: true,
+      pinHash: null,
+    });
+
+    await scanEvents.record({
+      riderId: 'r1',
+      scannedBy: MINE,
+      tripId: trip.id,
+      result: 'valid',
+      method: 'qr',
+    });
+    await scanEvents.record({
+      riderId: 'r3',
+      scannedBy: MINE,
+      tripId: trip.id,
+      result: 'valid',
+      method: 'pin',
+    });
+    // A rejected scan is not a boarding.
+    await scanEvents.record({
+      riderId: 'r4',
+      scannedBy: MINE,
+      tripId: trip.id,
+      result: 'expired',
+      method: 'qr',
+    });
+
+    const result = await service.summary(trip.id, MINE);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.summary.boarded).toBe(1);
+    expect(result.summary.notBoarded).toBe(1);
+    expect(result.summary.byMethod).toEqual({ qr: 1, pin: 1, photo: 0 });
+  });
+
+  it("refuses another driver's summary", async () => {
+    const { service, trip } = await setup();
+    expect(await service.summary(trip.id, THEIRS)).toEqual({
+      ok: false,
+      reason: 'not_assigned_driver',
+    });
+  });
+});


### PR DESCRIPTION
**Closes #163.** Unblocks #41 in the apps lane.

## What was missing

A driver **could not start or end a trip.** Transitions lived only on `PATCH /admin/trips/:id`, which is admin-only — so the two most important buttons in the driver app had no endpoint behind them, and a dispatcher would have had to flip every run by hand from Swagger.

```
GET  /me/trips            my assigned runs, optionally for a day
POST /trips/:id/start     begin the run
POST /trips/:id/complete  end it
GET  /trips/:id/summary   what the run did
```

## Authorization is assigned-driver, not the driver role

The caller must be linked to the driver **this trip is assigned to**. Same rule that already guards position reporting and the manifest, and the same reason: one driver must not start, end, or read the manifest of another's run.

`/me/trips` is scoped to the caller rather than taking a driver id, so nobody can enumerate someone else's schedule.

`not_assigned_driver` maps to **403, not 404** — the caller is authenticated and the trip exists, they simply aren't driving it. Hiding that behind a 404 leaves a driver who tapped the wrong run with no way to tell.

## Two deliberate asymmetries

**Start is idempotent.** A driver whose phone dropped mid-tap will press it again, and an error at the roadside is a worse answer than "yes, it is running".

**Complete is not.** Completing a trip that never started is refused — it means the wrong run was tapped, and a `completed` trip with no GPS trace would poison route learning (#179).

## The summary needed no new column

The issue estimated a new field to record boarding method. **It already exists** — `scan_events` records `qr | pin | photo`, so the split comes from data we were already writing.

Worth more than the summary: it's the only way to see whether **QR actually works in the field.** A corridor boarding mostly by PIN means the scanner is failing, and nobody would otherwise find out.

It reports **`notBoarded`, not "no-shows deducted"**. The debit is the ops cutoff's decision, and a driver shouldn't read a deduction that hasn't happened yet.

## One bug this would have had

`scanEvents` was constructed inline by the boarding service. The summary reads what boarding writes, so two instances would have left **every summary reporting zero boardings while scans succeeded**. It's now a shared dependency.

## Migration 028

`started_at` and `completed_at` on trips. `scheduled_at` is when a run was *meant* to leave and nothing recorded when it did — the gap between them is the only place lateness can ever be measured from.

## Verification

Full gates green. **426 tests** (up from 415), coverage 91.34%. Migration applied twice against real Postgres, second pass a clean no-op.

11 new tests covering the full transition chain, both idempotency rules, all three authorization refusals, caller-scoped listing, and the method split ignoring rejected scans.