### PR TITLE
feat(infra): declare the production service and database

### DIFF
--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -24,7 +24,8 @@ new code ships.
 - The pipeline is **dormant** until the `DEPLOY_ENABLED` repo variable is
   `true` — flip it after the one-time setup below.
 - The production stage is **skipped** until `RENDER_PRODUCTION_SERVICE_ID` is
-  set (uncomment the production block in `render.yaml` when going live).
+  set. The production service is now declared in `render.yaml`; see
+  "Going live" below for the order things must happen in.
 
 ## One-time setup (≈15 minutes)
 
@@ -71,3 +72,60 @@ new code ships.
 - The same `Dockerfile` runs anywhere (Fly.io, Railway, ECS, Cloud Run):
   provide `DATABASE_URL` once a datastore lands; the container listens on
   `$PORT` (default 3000).
+
+## Going live
+
+The production service and its database are declared in `render.yaml`. Order
+matters — the service cannot resolve `DATABASE_URL` before the database exists.
+
+1. **Apply the blueprint.** Render creates `trotxi-db-production` and
+   `trotxi-api`. The service will not be reachable by CI yet.
+
+2. **Set every `sync: false` value** in the Render dashboard:
+
+   | Variable                                                                 | Notes                                                                                                                                             |
+   | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+   | `JWT_SECRET`                                                             | **Generate a fresh one** (`openssl rand -base64 48`). Never reuse staging's — a leaked staging secret must not be able to mint production tokens. |
+   | `PAYSTACK_SECRET_KEY`                                                    | The **live** key (`sk_live_…`). Staging's test key would accept payments that go nowhere and look like they worked.                               |
+   | `FIREBASE_SERVICE_ACCOUNT`                                               | The whole service-account JSON. Unset -> no push, so the daily ask never reaches anyone.                                                          |
+   | `R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_BUCKET` | Unset -> avatars are held in memory and lost on restart.                                                                                          |
+   | `METRICS_TOKEN`                                                          | Unset in production -> `/metrics` is disabled (404) rather than left open.                                                                        |
+   | `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_HEADERS`              | Grafana Cloud. Unset -> no tracing.                                                                                                               |
+   | `CORS_ORIGINS`                                                           | Set once the ops console has a production origin.                                                                                                 |
+
+   Everything else (`NODE_ENV`, `GOOGLE_CLIENT_ID`, `OTEL_SERVICE_NAME`,
+   `MAP_TILES_URL`) comes from the blueprint and needs no dashboard entry.
+
+3. **Migrate the production database once**, before any traffic:
+
+   ```bash
+   DATABASE_URL=<production-connection-string> pnpm --filter @trotxi/api run migrate
+   ```
+
+4. **Seed the corridors and set their fares.** Since #103 a route with no fare
+   in force cannot be subscribed to — `/payments/subscribe` returns
+   `409 not_priced`.
+
+   ```bash
+   JWT_SECRET=<production-secret> API_BASE_URL=https://<production-url> \
+     pnpm --filter @trotxi/api seed:staging
+   ```
+
+   The seed's fare is a **placeholder**. Replace it with the corridor's real
+   rate via `PUT /admin/routes/:id/fare`.
+
+5. **Set the GitHub repository variables** `RENDER_PRODUCTION_SERVICE_ID` and
+   `PRODUCTION_URL`. Until both exist the production stage is skipped; once
+   they do, it still waits for a manual approval in the `production`
+   environment.
+
+### Blueprint changes need an apply
+
+Render syncs blueprint-declared values (those with `value:` rather than
+`sync: false`) **only when the blueprint is applied**. Merging a change to
+`render.yaml` does not push it to a running service.
+
+This has already bitten once: `MAP_TILES_URL` shipped in #186 and staging
+served `mapTiles.url: null` for days, because the blueprint was never
+re-applied. If a config change does not appear, apply the blueprint before
+looking for a bug.

--- a/render.yaml
+++ b/render.yaml
@@ -11,6 +11,14 @@ databases:
     plan: free # NB: free Postgres expires ~30 days after creation
     region: frankfurt # closest Render region to Ghana
 
+  - name: trotxi-db-production
+    databaseName: trotxi
+    user: trotxi
+    # Paid so the data does not expire. The free tier drops after ~30 days,
+    # which is survivable for staging and would be a company-ending event here.
+    plan: basic-256mb
+    region: frankfurt
+
 # Shared config for the ask-dispatch cron jobs (E3). The cron mints a short-lived
 # admin token, so its JWT_SECRET MUST equal the web service's JWT_SECRET — set it
 # once here in the dashboard and all four crons inherit it. API_BASE_URL is the
@@ -51,6 +59,13 @@ services:
       # whole JSON as the value in the dashboard, never commit. Unset -> the
       # recording fake sender runs (no real push).
       - key: FIREBASE_SERVICE_ACCOUNT
+        sync: false
+      # Paystack secret key. Was set in the dashboard but never declared here,
+      # so a fresh blueprint apply would have created a service with payments
+      # SILENTLY DISABLED — /payments/subscribe returns 503, health checks pass,
+      # and nobody finds out until a rider tries to pay. Staging uses the TEST
+      # key (sk_test_…); production must use the live one.
+      - key: PAYSTACK_SECRET_KEY
         sync: false
       # Google "Web" OAuth client ID — the audience verified on sign-in. This is
       # PUBLIC (a Web client ID ships in clients; only a client *secret* would be
@@ -232,37 +247,90 @@ services:
     envVars:
       - fromGroup: trotxi-cron-staging
 
-  # ---- Production (uncomment when going live) ----
-  # Needs a paid Postgres plan so data doesn't expire. After applying, set the
-  # RENDER_PRODUCTION_SERVICE_ID + PRODUCTION_URL GitHub variables to activate
-  # the production stage of deploy.yml (it is skipped until then).
+  # ---- Production ----
+  # Rebuilt from staging's ACTUAL configuration (#103/#178/#182 all added env
+  # vars the old commented block never learned about). A production service
+  # missing FIREBASE_SERVICE_ACCOUNT, R2_* or MAP_TILES_URL boots cleanly,
+  # passes /healthz, and is quietly broken in four ways — so every var staging
+  # has is declared here, even where the value differs.
   #
-  # - type: web
-  #   name: trotxi-api
-  #   runtime: docker
-  #   repo: https://github.com/TROTXI/mobility-core
-  #   branch: main
-  #   dockerfilePath: services/api/Dockerfile
-  #   dockerContext: .
-  #   plan: starter
-  #   region: frankfurt
-  #   healthCheckPath: /healthz
-  #   autoDeploy: false
-  #   envVars:
-  #     - key: NODE_ENV
-  #       value: production
-  #     - key: DATABASE_URL
-  #       fromDatabase:
-  #         name: trotxi-db-production
-  #         property: connectionString
-  #     - key: JWT_SECRET
-  #       sync: false   # required; set in dashboard (ADR-0007)
-  #     - key: GOOGLE_CLIENT_ID
-  #       sync: false   # set in dashboard
+  # APPLY ORDER
+  #   1. Create the database first (Render provisions it before the web service
+  #      so DATABASE_URL resolves).
+  #   2. Apply the blueprint; the service is created but NOT yet reachable by
+  #      the deploy workflow.
+  #   3. Set every `sync: false` value in the dashboard (list below).
+  #   4. Run the migrations against the production database once.
+  #   5. Set the GitHub repository variables RENDER_PRODUCTION_SERVICE_ID and
+  #      PRODUCTION_URL. The production stage of deploy.yml is skipped until
+  #      both exist (`if: vars.RENDER_PRODUCTION_SERVICE_ID != ''`), and it
+  #      additionally requires a manual approval in the `production`
+  #      environment before it runs.
   #
-  # …and add under `databases:`
-  # - name: trotxi-db-production
-  #   databaseName: trotxi
-  #   user: trotxi
-  #   plan: basic-256mb
-  #   region: frankfurt
+  # SECRETS TO SET IN THE DASHBOARD (never committed):
+  #   JWT_SECRET               generate fresh — do NOT reuse staging's. A
+  #                            leaked staging secret must not mint production
+  #                            tokens.
+  #   PAYSTACK_SECRET_KEY      the LIVE key (sk_live_…), not staging's test key.
+  #   FIREBASE_SERVICE_ACCOUNT the whole service-account JSON.
+  #   R2_*                     four values; may reuse the staging bucket or a
+  #                            separate production one.
+  #   METRICS_TOKEN            required in production or /metrics is disabled.
+  #   OTEL_EXPORTER_OTLP_*     Grafana Cloud endpoint + auth header.
+  - type: web
+    name: trotxi-api
+    runtime: docker
+    repo: https://github.com/TROTXI/mobility-core
+    branch: main
+    dockerfilePath: services/api/Dockerfile
+    dockerContext: .
+    plan: starter
+    region: frankfurt
+    healthCheckPath: /healthz
+    autoDeploy: false # GitHub Actions deploys after CI + manual approval
+    envVars:
+      - key: NODE_ENV
+        value: production
+      - key: DATABASE_URL
+        fromDatabase:
+          name: trotxi-db-production
+          property: connectionString
+      # Required because NODE_ENV=production (ADR-0007). Generate a NEW one:
+      #   openssl rand -base64 48
+      - key: JWT_SECRET
+        sync: false
+      # Live Paystack key. Copying the staging test key here would take real
+      # payments nowhere and look like it worked.
+      - key: PAYSTACK_SECRET_KEY
+        sync: false
+      - key: FIREBASE_SERVICE_ACCOUNT
+        sync: false
+      # Public Web client id — same Google project as staging unless a separate
+      # production project is created. Public by design, so it lives here.
+      - key: GOOGLE_CLIENT_ID
+        value: 431341307838-pc4m046v2lj18ssfnfl1g52fl5g1cg4q.apps.googleusercontent.com
+      # Unset in production -> /metrics is disabled (404) rather than left open.
+      - key: METRICS_TOKEN
+        sync: false
+      - key: OTEL_EXPORTER_OTLP_ENDPOINT
+        sync: false
+      - key: OTEL_EXPORTER_OTLP_HEADERS
+        sync: false
+      - key: OTEL_SERVICE_NAME
+        value: trotxi-api-production
+      # Set once the ops console has a production origin. Unset -> any origin is
+      # reflected, which is safe here only because auth is a bearer token.
+      - key: CORS_ORIGINS
+        sync: false
+      - key: R2_ACCOUNT_ID
+        sync: false
+      - key: R2_ACCESS_KEY_ID
+        sync: false
+      - key: R2_SECRET_ACCESS_KEY
+        sync: false
+      - key: R2_BUCKET
+        sync: false
+      # Same public basemap as staging — the tiles are world-readable and there
+      # is no reason to duplicate a 97 MB archive per environment.
+      - key: MAP_TILES_URL
+        value: https://pub-9962de9eb91548789ca7e319561d8386.r2.dev/ghana.pmtiles


### PR DESCRIPTION
Makes production real. **Also fixes a live gap in staging.**

## The staging bug this found

**`PAYSTACK_SECRET_KEY` was set in your dashboard but never declared in `render.yaml`.**

A fresh blueprint apply would have created a service with **payments silently disabled** — `/payments/subscribe` returning `503`, the API booting fine, health checks green. Nobody finds out until a rider tries to pay.

That's the most dangerous shape of config gap: invisible until money is involved. Now declared for both environments.

## The production block was five features out of date

It listed **four** env vars. Staging has **sixteen**. Uncommenting it as-was would have produced a production API with:

- no `FIREBASE_SERVICE_ACCOUNT` → **no push**, so the daily ask never reaches anyone
- no `R2_*` → avatars in memory, lost on restart
- no `MAP_TILES_URL` → no basemap
- no `CORS_ORIGINS`, `METRICS_TOKEN`, or tracing

It would have passed `/healthz` while being broken four ways.

Rebuilt from staging's actual config and verified by diffing the two services:

```
staging declares 16, production declares 16
  in staging but NOT production: none
  in production but not staging: none
  secrets with a committed value: none
```

## Two values deliberately differ rather than being copied

**`JWT_SECRET` must be freshly generated.** A leaked staging secret must not be able to mint production tokens.

**`PAYSTACK_SECRET_KEY` must be the live key.** Copying staging's `sk_test_` would accept real payments that go nowhere and look like they worked.

Both are called out in the blueprint comments and the runbook, because both are exactly the sort of thing someone copies at 11pm.

## Database

`trotxi-db-production` at **`basic-256mb`** — matching what you bought. Paid because the free tier expires after ~30 days: survivable for staging, company-ending here.

## DEPLOY.md — a "Going live" runbook

Order matters and isn't obvious:

1. Apply the blueprint (database provisions before the service, so `DATABASE_URL` resolves)
2. Set every `sync: false` value, with a table of what breaks if each is missing
3. **Migrate before any traffic**
4. **Seed and price the corridors** — since #103 an unpriced route returns `409 not_priced`, so a production corridor without a fare cannot be subscribed to
5. Set the two GitHub variables that switch the deploy stage on

It also records why **blueprint changes need an apply**: `MAP_TILES_URL` shipped in #186 and staging has been serving `mapTiles.url: null` ever since, because Render only syncs blueprint-declared values on apply. Worth knowing before someone hunts for a bug that isn't there.

## Note

After merging, **apply the blueprint to staging too** — that's what finally delivers `MAP_TILES_URL`, `CORS_ORIGINS` and `METRICS_TOKEN` to the running service.