### PR TITLE
feat(api): subscription billing periods

### DIFF
--- a/services/api/src/app.ts
+++ b/services/api/src/app.ts
@@ -11,6 +11,8 @@ import {
 import { z } from 'zod';
 import { InMemoryKvStore, type KvStore } from './kv/kv.store';
 import { FakeObjectStore, type ObjectStore } from './storage/object-store';
+import { RenewalService } from './modules/subscriptions/renewal.service';
+import { renewalRoutes } from './modules/subscriptions/renewal.routes';
 import type { PricingRepository } from './modules/payments/pricing.repository';
 import { pricingRoutes } from './modules/payments/pricing.routes';
 import type { AccountDeletionService } from './modules/users/account-deletion.service';
@@ -292,6 +294,7 @@ export async function buildApp(deps: AppDeps = {}): Promise<FastifyInstance> {
     entitlements,
     credits,
     rateLimit: deps.rateLimit ?? DEFAULT_RATE_LIMIT,
+    subscriptions: deps.subscriptions,
   });
   // Credit conversion (E5): the month-end job. Only wired when a subscription
   // store is available (the route 503s otherwise), since it iterates active subs.
@@ -364,6 +367,12 @@ export async function buildApp(deps: AppDeps = {}): Promise<FastifyInstance> {
     tripPositions: deps.tripPositions ?? new InMemoryTripPositionRepository(),
     segmentSpeeds: deps.segmentSpeeds,
     kv,
+    rateLimit: deps.rateLimit ?? DEFAULT_RATE_LIMIT,
+  });
+  await app.register(renewalRoutes, {
+    renewal: deps.subscriptions
+      ? new RenewalService({ subscriptions: deps.subscriptions })
+      : undefined,
     rateLimit: deps.rateLimit ?? DEFAULT_RATE_LIMIT,
   });
   await app.register(pricingRoutes, {

--- a/services/api/src/cron/ask-dispatch-cron.ts
+++ b/services/api/src/cron/ask-dispatch-cron.ts
@@ -8,10 +8,12 @@
 //   noshow  evening (20:00) -> same, after the evening run
 // Ghana runs on UTC (GMT+0), so the cron schedules are plain UTC, no offset.
 //
-// Deliberately NOT scheduled: /admin/convert-credits. Its conversion is keyed by
-// subscription id rather than by billing period, so it can only ever run once per
-// subscription and would zero a rider who subscribed days earlier. It stays a
-// manual admin action until E5b makes it period-aware (#128).
+// /admin/convert-credits was deliberately NOT scheduled here, because its
+// conversion was keyed by subscription id rather than billing period: it could
+// only ever run once per subscription and would have zeroed a rider who
+// subscribed days earlier. #162 fixed that — conversion is now keyed per period
+// and only touches subscriptions whose period has ENDED, so it is safe to
+// schedule alongside /admin/expire-subscriptions once the crons are funded.
 
 import { createJwtService, type AuthConfig } from '../modules/auth/jwt';
 

--- a/services/api/src/db/migrations/029_subscription_periods.sql
+++ b/services/api/src/db/migrations/029_subscription_periods.sql
@@ -1,0 +1,50 @@
+-- 029_subscription_periods: give a subscription a billing period (#162).
+--
+-- Until now a subscription had a plan ('monthly' | 'annual') and nothing acting
+-- on it. Three things follow from that, and all three are broken:
+--
+-- 1. THE APPS CANNOT RENDER THE BALANCE CARD. "renews 1 Sep", "23 of 40" and
+--    "of 40 · renews 1 Sep" all appear in the commuter designs. None of it is
+--    computable.
+--
+-- 2. CREDIT CONVERSION IS KEYED WRONG, AND THAT IS WHY IT IS NOT ON CRON.
+--    credit.service.ts builds its idempotency key as `convert:${sub.id}`.
+--    Keyed on the SUBSCRIPTION rather than the PERIOD, conversion can only ever
+--    run once in the lifetime of a subscription: scheduling it would zero a
+--    rider who subscribed three days earlier, then no-op forever from month
+--    two. This is the sole reason /admin/convert-credits is excluded from the
+--    cron blueprint.
+--
+-- 3. NOTHING EXPIRES. status can be 'expired' but no job ever sets it, so a
+--    lapsed subscription stays 'active' indefinitely — and the partial unique
+--    index (003) means that stale row also blocks the rider from ever
+--    subscribing again.
+--
+-- Periods are half-open [period_start, period_end): the instant period_end
+-- arrives the period is over. Avoids the off-by-one-second arguments that
+-- inclusive ends invite when a rider subscribes at 23:59:59.
+
+ALTER TABLE subscriptions
+  ADD COLUMN IF NOT EXISTS period_start timestamptz,
+  ADD COLUMN IF NOT EXISTS period_end   timestamptz;
+
+COMMENT ON COLUMN subscriptions.period_start IS
+  'Start of the current billing period, inclusive. Set on activation from the plan.';
+COMMENT ON COLUMN subscriptions.period_end IS
+  'End of the current billing period, EXCLUSIVE. Drives renewal, expiry, and the idempotency key for month-end credit conversion.';
+
+-- Backfill so nothing is left null and existing riders behave sensibly. Derived
+-- from created_at rather than guessed: a subscription created on 12 Aug on a
+-- monthly plan is treated as running 12 Aug -> 12 Sep, which is what the rider
+-- was actually sold.
+UPDATE subscriptions
+   SET period_start = created_at,
+       period_end   = created_at + CASE WHEN plan = 'annual'
+                                        THEN interval '1 year'
+                                        ELSE interval '1 month' END
+ WHERE period_start IS NULL;
+
+-- Finding whose period has ended is the whole job of the renewal/expiry sweep,
+-- and it runs over every active subscription.
+CREATE INDEX IF NOT EXISTS idx_subscriptions_period_end
+  ON subscriptions (period_end) WHERE status = 'active';

--- a/services/api/src/modules/entitlements/credit.routes.ts
+++ b/services/api/src/modules/entitlements/credit.routes.ts
@@ -35,7 +35,13 @@ export async function creditRoutes(
     {
       schema: {
         tags: ['admin'],
-        summary: "Month-end: convert every active rider's unused rides to Ride Credits",
+        summary: 'Month-end: convert unused rides to Ride Credits for ENDED periods',
+        description:
+          'Only subscriptions whose billing period has ended are converted — not every ' +
+          'active rider. Keyed per period (#162), so this is safe to run repeatedly ' +
+          'within a period and converts normally in the next one. Before #162 it was ' +
+          'keyed on the subscription id and could only ever fire once in its lifetime, ' +
+          'which is why it was excluded from the cron schedule.',
         security: [{ bearerAuth: [] }],
         response: {
           200: convertCreditsResponseSchema,

--- a/services/api/src/modules/entitlements/credit.service.ts
+++ b/services/api/src/modules/entitlements/credit.service.ts
@@ -8,6 +8,7 @@
 // decided (see #104 — plan price ÷ entitlement vs a fixed table). The mechanism
 // ships now; only the number changes later.
 
+import { periodRef as makePeriodRef } from '../subscriptions/period';
 import type { CreditLedgerRepository } from './credit-ledger.repository';
 import type { EntitlementLedgerRepository } from './entitlement-ledger.repository';
 import type { SubscriptionRepository } from '../subscriptions/subscription.repository';
@@ -58,8 +59,10 @@ export class CreditService {
    * credit, and applies the (still-pending) debit — converging exactly-once.
    *
    * @param userId - the rider whose unused rides to convert.
-   * @param periodRef - a stable id for the ending period (the subscription id);
-   *   also the idempotency key, so re-running is a no-op.
+   * @param periodRef - a stable id for the ending period, from
+   *   {@link makePeriodRef}: `${subscriptionId}:${periodEnd}`. Also the
+   *   idempotency key, so re-running within a period is a no-op while the NEXT
+   *   period converts normally.
    * @returns how many rides were converted and the credit minted.
    */
   async convertUnusedRides(userId: string, periodRef: string): Promise<ConversionResult> {
@@ -88,17 +91,31 @@ export class CreditService {
   }
 
   /**
-   * Convert unused rides for every active subscriber — the month-end job. Each
-   * rider is keyed by their active subscription id, so a re-run (or a run that
-   * partially completed) converges without double-crediting.
+   * Convert unused rides for every subscriber whose PERIOD HAS ENDED — the
+   * month-end job.
    *
+   * Keyed by subscription AND period, so a re-run within a period is a no-op
+   * while the next period converts normally. Keyed on the subscription alone
+   * (pre-#162) it could only ever fire once in a subscription's lifetime,
+   * which is why this was never put on a schedule.
+   *
+   * @param now - the instant to judge "period has ended" against; injectable
+   *   so the boundary is testable without waiting a month.
    * @returns batch totals (riders credited, rides retired, pesewas minted).
    */
-  async convertAllActive(): Promise<BatchConversionResult> {
-    const subs = await this.deps.subscriptions.findAllActive();
+  async convertAllActive(now: Date = new Date()): Promise<BatchConversionResult> {
+    // Only subscriptions whose period has actually ENDED — not every active
+    // rider. Converting mid-period would zero someone who subscribed three
+    // days ago and still has a month of travel ahead of them, which is what
+    // made this unsafe to schedule at all before #162.
+    const subs = await this.deps.subscriptions.findEndedPeriods(now);
     const totals: BatchConversionResult = { riders: 0, ridesConverted: 0, creditPesewas: 0 };
     for (const sub of subs) {
-      const res = await this.convertUnusedRides(sub.userId, sub.id);
+      // Keyed on the PERIOD, not the subscription. The old key (`sub.id`) could
+      // only ever fire once in a subscription's lifetime, so month two onwards
+      // silently no-opped.
+      if (!sub.periodEnd) continue; // pre-#162 row that somehow escaped backfill
+      const res = await this.convertUnusedRides(sub.userId, makePeriodRef(sub.id, sub.periodEnd));
       if (res.ridesConverted > 0) {
         totals.riders++;
         totals.ridesConverted += res.ridesConverted;

--- a/services/api/src/modules/entitlements/entitlements.routes.ts
+++ b/services/api/src/modules/entitlements/entitlements.routes.ts
@@ -6,6 +6,7 @@ import type { FastifyInstance } from 'fastify';
 import type { ZodTypeProvider } from 'fastify-type-provider-zod';
 import { errorResponseSchema } from '../../lib/schemas';
 import type { RateLimitConfig } from '../ratelimit/ratelimit.plugin';
+import type { SubscriptionRepository } from '../subscriptions/subscription.repository';
 import type { CreditLedgerRepository } from './credit-ledger.repository';
 import type { EntitlementLedgerRepository } from './entitlement-ledger.repository';
 import { ridesResponseSchema } from './entitlements.schema';
@@ -17,6 +18,7 @@ import { ridesResponseSchema } from './entitlements.schema';
  * @param opts - route dependencies.
  * @param opts.entitlements - the ride-entitlement ledger (503 when absent).
  * @param opts.credits - the Ride Credit ledger (503 when absent).
+ * @param opts.subscriptions - supplies renewsAt + ridesPerPeriod (#162).
  * @param opts.rateLimit - rate-limit config (applied per user).
  */
 export async function entitlementRoutes(
@@ -25,6 +27,8 @@ export async function entitlementRoutes(
     entitlements?: EntitlementLedgerRepository;
     credits?: CreditLedgerRepository;
     rateLimit: RateLimitConfig;
+    /** Supplies renewsAt + ridesPerPeriod for the balance card (#162). */
+    subscriptions?: SubscriptionRepository;
   },
 ): Promise<void> {
   const r = app.withTypeProvider<ZodTypeProvider>();
@@ -56,7 +60,16 @@ export async function entitlementRoutes(
         opts.entitlements.remainingRides(userId),
         opts.credits.balancePesewas(userId),
       ]);
-      return { remainingRides, creditPesewas };
+      // The subscription supplies what the balance card needs beyond the two
+      // numbers: "23 of 40 · renews 1 Sep" is not computable from the ledgers
+      // alone. Null when there is no active subscription, rather than invented.
+      const sub = opts.subscriptions ? await opts.subscriptions.findActiveByUser(userId) : null;
+      return {
+        remainingRides,
+        creditPesewas,
+        ridesPerPeriod: sub?.ridesGranted ?? null,
+        renewsAt: sub?.periodEnd ?? null,
+      };
     },
   );
 }

--- a/services/api/src/modules/entitlements/entitlements.schema.ts
+++ b/services/api/src/modules/entitlements/entitlements.schema.ts
@@ -5,4 +5,14 @@ export const ridesResponseSchema = z.object({
   remainingRides: z.number().int(),
   /** Ride Credit balance in pesewas (carries toward the next renewal). */
   creditPesewas: z.number().int(),
+  /**
+   * Rides the current period started with, so the app can show "23 of 40".
+   * Null without an active subscription, or on a pre-#103 row.
+   */
+  ridesPerPeriod: z.number().int().nullable(),
+  /**
+   * When the current period ends — the "renews 1 Sep" line in the designs.
+   * Null without an active subscription (#162).
+   */
+  renewsAt: z.date().nullable(),
 });

--- a/services/api/src/modules/payments/payments.service.ts
+++ b/services/api/src/modules/payments/payments.service.ts
@@ -20,6 +20,7 @@ import type {
   SubscriptionRepository,
 } from '../subscriptions/subscription.repository';
 import type { UserRepository } from '../users/user.repository';
+import { periodFor } from '../subscriptions/period';
 import { derivePrice, type DerivedPrice } from './pricing';
 import type { PricingRepository } from './pricing.repository';
 import type { NewPayment, Payment, PaymentRepository } from './payment.repository';
@@ -296,10 +297,15 @@ export class PaymentsService {
     payment: Payment,
   ): Promise<void> {
     try {
+      const period = periodFor(plan, new Date());
       await this.deps.subscriptions.create({
         userId,
         plan,
         routeId,
+        // The billing window this payment buys (#162). Without it nothing can
+        // renew, expire, or convert credit per period.
+        periodStart: period.start,
+        periodEnd: period.end,
         // Carried from the payment, so what this rider owes and what their
         // credit is worth cannot move under them when the fare next changes
         // (ADR-0015 §3). New prices apply at renewal.

--- a/services/api/src/modules/subscriptions/period.ts
+++ b/services/api/src/modules/subscriptions/period.ts
@@ -1,0 +1,107 @@
+// Billing period arithmetic (#162). Pure and clock-free, so the same inputs
+// always give the same period and the awkward dates are testable.
+//
+// Periods are half-open: [start, end). The instant `end` arrives the period is
+// over. Inclusive ends invite off-by-one-second arguments for a rider who
+// subscribed at 23:59:59, and there is no good answer to "is 1 Sep 00:00:00 in
+// August's period" other than "no".
+
+import type { SubscriptionPlan } from './subscription.repository';
+
+/** A half-open billing window. */
+export interface BillingPeriod {
+  start: Date;
+  /** Exclusive. */
+  end: Date;
+}
+
+/**
+ * Add whole months to a date, clamping the day to the target month's length.
+ *
+ * JavaScript's `setUTCMonth` overflows instead of clamping: 31 Jan + 1 month
+ * becomes 3 March (or 2 March in a leap year), because February has no 31st.
+ * A rider who subscribes on the 31st would silently get a period ending in the
+ * following month, and their renewal date would drift further every cycle.
+ *
+ * Clamping to the 28th/29th/30th instead keeps the renewal on or before the
+ * anniversary, which is the behaviour every subscription business uses and the
+ * one a rider can predict.
+ *
+ * @param from - the starting instant.
+ * @param months - whole months to add.
+ * @returns the shifted date, day-clamped.
+ */
+export function addMonthsClamped(from: Date, months: number): Date {
+  const day = from.getUTCDate();
+  // Day 1 of the target month, then clamp the day onto it — never overflows.
+  const target = new Date(
+    Date.UTC(
+      from.getUTCFullYear(),
+      from.getUTCMonth() + months,
+      1,
+      from.getUTCHours(),
+      from.getUTCMinutes(),
+      from.getUTCSeconds(),
+      from.getUTCMilliseconds(),
+    ),
+  );
+  const lastDayOfTarget = new Date(
+    Date.UTC(target.getUTCFullYear(), target.getUTCMonth() + 1, 0),
+  ).getUTCDate();
+  target.setUTCDate(Math.min(day, lastDayOfTarget));
+  return target;
+}
+
+/**
+ * The billing period a plan buys, starting now.
+ *
+ * @param plan - monthly or annual.
+ * @param start - when the period begins (activation time).
+ * @returns the half-open period.
+ */
+export function periodFor(plan: SubscriptionPlan, start: Date): BillingPeriod {
+  return { start, end: addMonthsClamped(start, plan === 'annual' ? 12 : 1) };
+}
+
+/**
+ * The period that follows this one, with no gap.
+ *
+ * The next period starts exactly where the last ended, not "now": renewing a
+ * day late must not shift a rider's anniversary forward permanently.
+ *
+ * @param plan - monthly or annual.
+ * @param current - the period ending.
+ * @returns the next half-open period.
+ */
+export function nextPeriod(plan: SubscriptionPlan, current: BillingPeriod): BillingPeriod {
+  return periodFor(plan, current.end);
+}
+
+/**
+ * Whether a period has ended as of `now`.
+ *
+ * @param period - the period to test.
+ * @param now - the current instant.
+ * @returns true when `now` is at or past the exclusive end.
+ */
+export function hasEnded(period: BillingPeriod, now: Date): boolean {
+  return now.getTime() >= period.end.getTime();
+}
+
+/**
+ * A stable identifier for one period of one subscription.
+ *
+ * This is the fix at the heart of #162. Conversion was keyed on the
+ * subscription id alone, so it could only ever run once in that
+ * subscription's lifetime — scheduling it would zero a rider who subscribed
+ * days earlier, then no-op forever afterwards. Including the period end makes
+ * the key unique per cycle, which is what lets the job run every month and
+ * still be safe to retry within one.
+ *
+ * @param subscriptionId - the subscription.
+ * @param periodEnd - the period's exclusive end.
+ * @returns a key stable for that period and no other.
+ */
+export function periodRef(subscriptionId: string, periodEnd: Date): string {
+  return `${subscriptionId}:${periodEnd.toISOString()}`;
+}

--- a/services/api/src/modules/subscriptions/renewal.routes.ts
+++ b/services/api/src/modules/subscriptions/renewal.routes.ts
@@ -1,0 +1,60 @@
+// Admin trigger for the period-end sweep (#162).
+//
+// Mirrors the other daily-loop triggers: admin-only, idempotent, and callable
+// both by hand and by a scheduled job once the crons are funded.
+
+import type { FastifyInstance } from 'fastify';
+import type { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { z } from 'zod';
+import { errorResponseSchema } from '../../lib/schemas';
+import type { RateLimitConfig } from '../ratelimit/ratelimit.plugin';
+import type { RenewalService } from './renewal.service';
+
+/**
+ * Register `POST /admin/expire-subscriptions`.
+ *
+ * @param app - the Fastify instance to register on.
+ * @param opts - route dependencies.
+ * @param opts.renewal - the renewal service (503 when absent).
+ * @param opts.rateLimit - rate-limit config (applied per user).
+ */
+export async function renewalRoutes(
+  app: FastifyInstance,
+  opts: { renewal?: RenewalService; rateLimit: RateLimitConfig },
+): Promise<void> {
+  const r = app.withTypeProvider<ZodTypeProvider>();
+
+  r.post(
+    '/admin/expire-subscriptions',
+    {
+      schema: {
+        tags: ['admin'],
+        summary: 'Expire subscriptions whose billing period has ended',
+        description:
+          'Nothing did this before #162: `status` could be `expired` but no job set it, ' +
+          'so a lapsed subscription stayed `active` forever — and the one-active-per-user ' +
+          'index meant that stale row blocked the rider from subscribing again. ' +
+          'Deliberately does not auto-renew: charging without the rider initiating it ' +
+          'needs a stored mandate we do not have (#128).',
+        security: [{ bearerAuth: [] }],
+        response: {
+          200: z.object({ expired: z.number().int(), considered: z.number().int() }),
+          401: errorResponseSchema,
+          403: errorResponseSchema,
+          503: errorResponseSchema,
+        },
+      },
+      preHandler: [
+        app.authenticate,
+        app.rateLimit({ ...opts.rateLimit, by: 'user' }),
+        app.requireRole('admin'),
+      ],
+    },
+    async (_request, reply) => {
+      if (!opts.renewal) {
+        return reply.code(503).send({ error: 'unavailable', message: 'Renewal is not configured' });
+      }
+      return opts.renewal.sweep();
+    },
+  );
+}

--- a/services/api/src/modules/subscriptions/renewal.service.ts
+++ b/services/api/src/modules/subscriptions/renewal.service.ts
@@ -1,0 +1,74 @@
+// What happens when a billing period ends (#162).
+//
+// Nothing did this before. `status` could be 'expired' but no job ever set it,
+// so a lapsed subscription stayed 'active' forever — and because of the partial
+// unique index (003_subscriptions_constraints), that stale row also blocked the
+// rider from ever subscribing again. Their only route back was an admin
+// deleting a row by hand.
+//
+// This sweep expires them. It deliberately does NOT auto-renew: taking money
+// without the rider initiating it needs a stored mandate we do not have, and
+// #128 (E5b, credit-netted renewal) is where that belongs. Expiring is the
+// honest half we can do correctly today.
+
+import { hasEnded, type BillingPeriod } from './period';
+import type { Subscription, SubscriptionRepository } from './subscription.repository';
+
+/** What a sweep did. */
+export interface RenewalSweepResult {
+  /** Subscriptions moved to `expired`. */
+  expired: number;
+  /** Subscriptions examined. */
+  considered: number;
+}
+
+/** Collaborators for {@link RenewalService}. */
+export interface RenewalDeps {
+  subscriptions: SubscriptionRepository;
+}
+
+/** Expires subscriptions whose billing period has ended. */
+export class RenewalService {
+  /** @param deps - the subscription store. */
+  constructor(private readonly deps: RenewalDeps) {}
+
+  /**
+   * Expire every active subscription whose period has ended.
+   *
+   * Idempotent: an already-expired subscription is not returned by
+   * `findEndedPeriods` (it filters on `status = 'active'`), so re-running is a
+   * no-op rather than a double transition.
+   *
+   * @param now - the instant to judge against; injectable so the behaviour at
+   *   a period boundary is testable without waiting a month.
+   * @returns how many were considered and how many expired.
+   */
+  async sweep(now: Date = new Date()): Promise<RenewalSweepResult> {
+    const due = await this.deps.subscriptions.findEndedPeriods(now);
+    let expired = 0;
+
+    for (const sub of due) {
+      // findEndedPeriods already filters on period_end <= now, but re-checking
+      // through the same predicate the rest of the system uses means one
+      // definition of "ended" rather than two that can drift.
+      if (!this.isDue(sub, now)) continue;
+      await this.deps.subscriptions.rollPeriod(sub.id, { status: 'expired' });
+      expired++;
+    }
+
+    return { expired, considered: due.length };
+  }
+
+  /**
+   * Whether a subscription's period has ended.
+   *
+   * @param sub - the subscription.
+   * @param now - the instant to judge against.
+   * @returns true when the period is over.
+   */
+  private isDue(sub: Subscription, now: Date): boolean {
+    if (!sub.periodStart || !sub.periodEnd) return false;
+    const period: BillingPeriod = { start: sub.periodStart, end: sub.periodEnd };
+    return hasEnded(period, now);
+  }
+}

--- a/services/api/src/modules/subscriptions/subscription.repository.pg.ts
+++ b/services/api/src/modules/subscriptions/subscription.repository.pg.ts
@@ -17,6 +17,8 @@ interface SubscriptionRow {
   rides_granted: number | null;
   fare_pesewas: number | null;
   credit_pesewas_per_ride: number | null;
+  period_start: Date | null;
+  period_end: Date | null;
   created_at: Date;
 }
 
@@ -31,6 +33,8 @@ function toSubscription(row: SubscriptionRow): Subscription {
     ridesGranted: row.rides_granted,
     farePesewas: row.fare_pesewas,
     creditPesewasPerRide: row.credit_pesewas_per_ride,
+    periodStart: row.period_start,
+    periodEnd: row.period_end,
     createdAt: row.created_at,
   };
 }
@@ -42,8 +46,9 @@ export class PgSubscriptionRepository implements SubscriptionRepository {
   async create(input: NewSubscription): Promise<Subscription> {
     const { rows } = await this.pool.query<SubscriptionRow>(
       `INSERT INTO subscriptions (user_id, plan, route_id,
-                                  price_pesewas, rides_granted, fare_pesewas, credit_pesewas_per_ride)
-       VALUES ($1, $2, $3, $4, $5, $6, $7)
+                                  price_pesewas, rides_granted, fare_pesewas, credit_pesewas_per_ride,
+                                  period_start, period_end)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
        RETURNING *`,
       [
         input.userId,
@@ -53,6 +58,8 @@ export class PgSubscriptionRepository implements SubscriptionRepository {
         input.ridesGranted ?? null,
         input.farePesewas ?? null,
         input.creditPesewasPerRide ?? null,
+        input.periodStart ?? null,
+        input.periodEnd ?? null,
       ],
     );
     return toSubscription(rows[0]!);
@@ -82,5 +89,32 @@ export class PgSubscriptionRepository implements SubscriptionRepository {
       `SELECT * FROM subscriptions WHERE status = 'active'`,
     );
     return rows.map(toSubscription);
+  }
+
+  async findEndedPeriods(now: Date): Promise<Subscription[]> {
+    const { rows } = await this.pool.query<SubscriptionRow>(
+      `SELECT * FROM subscriptions
+        WHERE status = 'active' AND period_end IS NOT NULL AND period_end <= $1
+        ORDER BY period_end ASC`,
+      [now],
+    );
+    return rows.map(toSubscription);
+  }
+
+  async rollPeriod(
+    id: string,
+    patch: { periodStart: Date; periodEnd: Date } | { status: 'expired' },
+  ): Promise<Subscription | null> {
+    const { rows } =
+      'status' in patch
+        ? await this.pool.query<SubscriptionRow>(
+            `UPDATE subscriptions SET status = 'expired' WHERE id = $1 RETURNING *`,
+            [id],
+          )
+        : await this.pool.query<SubscriptionRow>(
+            `UPDATE subscriptions SET period_start = $2, period_end = $3 WHERE id = $1 RETURNING *`,
+            [id, patch.periodStart, patch.periodEnd],
+          );
+    return rows[0] ? toSubscription(rows[0]) : null;
   }
 }

--- a/services/api/src/modules/subscriptions/subscription.repository.ts
+++ b/services/api/src/modules/subscriptions/subscription.repository.ts
@@ -17,6 +17,10 @@ export interface Subscription {
   farePesewas: number | null;
   /** Ride Credit value per unused ride, frozen at activation. */
   creditPesewasPerRide: number | null;
+  /** Start of the current billing period, inclusive (#162). */
+  periodStart: Date | null;
+  /** End of the current period, EXCLUSIVE — drives renewal and expiry. */
+  periodEnd: Date | null;
   createdAt: Date;
 }
 
@@ -29,6 +33,8 @@ export interface NewSubscription {
   ridesGranted?: number | null;
   farePesewas?: number | null;
   creditPesewasPerRide?: number | null;
+  periodStart?: Date | null;
+  periodEnd?: Date | null;
 }
 
 /** Persistence for memberships; one active subscription per user. */
@@ -63,6 +69,28 @@ export interface SubscriptionRepository {
    * @returns all active subscriptions.
    */
   findAllActive(): Promise<Subscription[]>;
+  /**
+   * Active subscriptions whose period has ended (#162).
+   *
+   * The renewal/expiry sweep's input. Without it nothing ever transitions a
+   * lapsed subscription out of `active`, and the partial unique index means
+   * that stale row blocks the rider from ever subscribing again.
+   *
+   * @param now - the instant to compare against.
+   * @returns active subscriptions with `periodEnd <= now`.
+   */
+  findEndedPeriods(now: Date): Promise<Subscription[]>;
+  /**
+   * Move a subscription into its next period, or mark it expired.
+   *
+   * @param id - the subscription.
+   * @param patch - the new period, or the terminal status.
+   * @returns the updated subscription, or null if not found.
+   */
+  rollPeriod(
+    id: string,
+    patch: { periodStart: Date; periodEnd: Date } | { status: 'expired' },
+  ): Promise<Subscription | null>;
 }
 
 /** In-memory {@link SubscriptionRepository} for dev and unit tests. */
@@ -86,6 +114,8 @@ export class InMemorySubscriptionRepository implements SubscriptionRepository {
       ridesGranted: input.ridesGranted ?? null,
       farePesewas: input.farePesewas ?? null,
       creditPesewasPerRide: input.creditPesewasPerRide ?? null,
+      periodStart: input.periodStart ?? null,
+      periodEnd: input.periodEnd ?? null,
       createdAt: new Date(),
     };
     this.subscriptions.set(subscription.id, subscription);
@@ -109,5 +139,22 @@ export class InMemorySubscriptionRepository implements SubscriptionRepository {
 
   async findAllActive(): Promise<Subscription[]> {
     return Array.from(this.subscriptions.values()).filter((s) => s.status === 'active');
+  }
+  async findEndedPeriods(now: Date): Promise<Subscription[]> {
+    return [...this.subscriptions.values()].filter(
+      (s) =>
+        s.status === 'active' && s.periodEnd !== null && s.periodEnd.getTime() <= now.getTime(),
+    );
+  }
+
+  async rollPeriod(
+    id: string,
+    patch: { periodStart: Date; periodEnd: Date } | { status: 'expired' },
+  ): Promise<Subscription | null> {
+    const existing = this.subscriptions.get(id);
+    if (!existing) return null;
+    const updated: Subscription = { ...existing, ...patch };
+    this.subscriptions.set(id, updated);
+    return updated;
   }
 }

--- a/services/api/tests/credits.test.ts
+++ b/services/api/tests/credits.test.ts
@@ -6,6 +6,19 @@ import { InMemoryEntitlementLedgerRepository } from '../src/modules/entitlements
 import { InMemorySubscriptionRepository } from '../src/modules/subscriptions/subscription.repository';
 import { createJwtService, type AuthConfig } from '../src/modules/auth/jwt';
 
+/**
+ * A period that ended a month ago. Relative to `Date.now()` rather than a fixed
+ * date, because one of these cases goes through the HTTP route, which uses the
+ * real clock — a hard-coded date would pass today and silently stop converting
+ * once it drifted into the future.
+ */
+const DAY = 86_400_000;
+const ENDED_PERIOD = {
+  periodStart: new Date(Date.now() - 60 * DAY),
+  periodEnd: new Date(Date.now() - 30 * DAY),
+};
+const NOW = new Date();
+
 const auth: AuthConfig = {
   secret: 'test-secret-at-least-32-characters-long-0000',
   accessTtl: '15m',
@@ -104,13 +117,15 @@ describe('CreditService.convertUnusedRides', () => {
 describe('CreditService.convertAllActive', () => {
   it('converts every active subscriber and sums the totals (skipping empties)', async () => {
     const { entitlements, subscriptions, svc } = make();
-    await subscriptions.create({ userId: 'ama', plan: 'monthly' });
-    await subscriptions.create({ userId: 'kofi', plan: 'monthly' });
-    await subscriptions.create({ userId: 'norides', plan: 'monthly' });
+    // Since #162 only subscriptions whose PERIOD HAS ENDED are converted, so
+    // these need a period that is already over.
+    for (const userId of ['ama', 'kofi', 'norides']) {
+      await subscriptions.create({ userId, plan: 'monthly', ...ENDED_PERIOD });
+    }
     await allocate(entitlements, 'ama', 10);
     await allocate(entitlements, 'kofi', 4);
 
-    expect(await svc.convertAllActive()).toEqual({
+    expect(await svc.convertAllActive(NOW)).toEqual({
       riders: 2, // 'norides' had nothing → skipped
       ridesConverted: 14,
       creditPesewas: 14 * PER_RIDE,
@@ -145,7 +160,7 @@ describe('POST /admin/convert-credits', () => {
     const entitlements = new InMemoryEntitlementLedgerRepository();
     const credits = new InMemoryCreditLedgerRepository();
     const subscriptions = new InMemorySubscriptionRepository();
-    await subscriptions.create({ userId: 'ama', plan: 'monthly' });
+    await subscriptions.create({ userId: 'ama', plan: 'monthly', ...ENDED_PERIOD });
     await entitlements.record({
       userId: 'ama',
       deltaRides: 12,

--- a/services/api/tests/entitlements.test.ts
+++ b/services/api/tests/entitlements.test.ts
@@ -103,7 +103,12 @@ describe('GET /me/rides', () => {
 
     const res = await app.inject({ method: 'GET', url: '/me/rides', headers: bearer(token) });
     expect(res.statusCode).toBe(200);
-    expect(res.json()).toEqual({ remainingRides: 44, creditPesewas: 4000 });
+    expect(res.json()).toEqual({
+      remainingRides: 44,
+      creditPesewas: 4000,
+      ridesPerPeriod: null,
+      renewsAt: null,
+    });
   });
 
   it('defaults to zero for a rider with no ledger entries', async () => {
@@ -111,6 +116,11 @@ describe('GET /me/rides', () => {
     const token = await jwt.signAccessToken({ userId: 'newbie', role: 'commuter' });
     const res = await app.inject({ method: 'GET', url: '/me/rides', headers: bearer(token) });
     expect(res.statusCode).toBe(200);
-    expect(res.json()).toEqual({ remainingRides: 0, creditPesewas: 0 });
+    expect(res.json()).toEqual({
+      remainingRides: 0,
+      creditPesewas: 0,
+      ridesPerPeriod: null,
+      renewsAt: null,
+    });
   });
 });

--- a/services/api/tests/payments.service.test.ts
+++ b/services/api/tests/payments.service.test.ts
@@ -177,6 +177,8 @@ describe('PaymentsService.handleWebhook', () => {
       findActiveByUser: async () => null,
       findActiveByRoute: async () => [],
       findAllActive: async () => [],
+      findEndedPeriods: async () => [],
+      rollPeriod: async () => null,
       create: async () => {
         throw Object.assign(new Error('dup'), { code: '23505' });
       },
@@ -192,6 +194,8 @@ describe('PaymentsService.handleWebhook', () => {
       findActiveByUser: async () => null,
       findActiveByRoute: async () => [],
       findAllActive: async () => [],
+      findEndedPeriods: async () => [],
+      rollPeriod: async () => null,
       create: async () => {
         throw new Error('db down');
       },

--- a/services/api/tests/period.test.ts
+++ b/services/api/tests/period.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+import {
+  addMonthsClamped,
+  hasEnded,
+  nextPeriod,
+  periodFor,
+  periodRef,
+} from '../src/modules/subscriptions/period';
+
+const iso = (d: Date) => d.toISOString();
+
+describe('addMonthsClamped', () => {
+  it('keeps the same day in an ordinary month', () => {
+    expect(iso(addMonthsClamped(new Date('2026-08-12T09:00:00Z'), 1))).toBe(
+      '2026-09-12T09:00:00.000Z',
+    );
+  });
+
+  it('clamps 31 Jan to 28 Feb rather than overflowing into March', () => {
+    // setUTCMonth would give 3 March. A rider subscribing on the 31st would
+    // get a renewal date that drifts a few days further every single cycle.
+    expect(iso(addMonthsClamped(new Date('2026-01-31T00:00:00Z'), 1))).toBe(
+      '2026-02-28T00:00:00.000Z',
+    );
+  });
+
+  it('clamps to 29 Feb in a leap year', () => {
+    expect(iso(addMonthsClamped(new Date('2028-01-31T00:00:00Z'), 1))).toBe(
+      '2028-02-29T00:00:00.000Z',
+    );
+  });
+
+  it('clamps 31 May to 30 June', () => {
+    expect(iso(addMonthsClamped(new Date('2026-05-31T00:00:00Z'), 1))).toBe(
+      '2026-06-30T00:00:00.000Z',
+    );
+  });
+
+  it('crosses a year boundary', () => {
+    expect(iso(addMonthsClamped(new Date('2026-12-15T00:00:00Z'), 1))).toBe(
+      '2027-01-15T00:00:00.000Z',
+    );
+  });
+
+  it('adds twelve months for an annual plan', () => {
+    expect(iso(addMonthsClamped(new Date('2026-08-12T00:00:00Z'), 12))).toBe(
+      '2027-08-12T00:00:00.000Z',
+    );
+  });
+});
+
+describe('periodFor', () => {
+  it('gives a monthly plan one month', () => {
+    const p = periodFor('monthly', new Date('2026-08-12T09:00:00Z'));
+    expect(iso(p.end)).toBe('2026-09-12T09:00:00.000Z');
+  });
+
+  it('gives an annual plan a year', () => {
+    const p = periodFor('annual', new Date('2026-08-12T09:00:00Z'));
+    expect(iso(p.end)).toBe('2027-08-12T09:00:00.000Z');
+  });
+});
+
+describe('nextPeriod', () => {
+  it('starts exactly where the last ended, leaving no gap', () => {
+    const first = periodFor('monthly', new Date('2026-08-12T09:00:00Z'));
+    const second = nextPeriod('monthly', first);
+    expect(iso(second.start)).toBe(iso(first.end));
+  });
+
+  it('does not drift when a renewal is processed late', () => {
+    // The next period follows the last one, not "now". Renewing three days
+    // late must not move a rider's anniversary permanently.
+    const first = periodFor('monthly', new Date('2026-01-31T00:00:00Z'));
+    const second = nextPeriod('monthly', first); // 28 Feb -> 28 Mar
+    const third = nextPeriod('monthly', second);
+    expect(iso(second.end)).toBe('2026-03-28T00:00:00.000Z');
+    expect(iso(third.end)).toBe('2026-04-28T00:00:00.000Z');
+  });
+});
+
+describe('hasEnded', () => {
+  const p = periodFor('monthly', new Date('2026-08-12T09:00:00Z'));
+
+  it('is false inside the period', () => {
+    expect(hasEnded(p, new Date('2026-09-11T23:59:59Z'))).toBe(false);
+  });
+
+  it('is true at the exclusive end, not a second later', () => {
+    // Half-open: the instant `end` arrives, the period is over.
+    expect(hasEnded(p, p.end)).toBe(true);
+  });
+});
+
+describe('periodRef — the fix at the heart of #162', () => {
+  it('differs between consecutive periods of one subscription', () => {
+    // The old key was the subscription id alone, so conversion could only ever
+    // run ONCE in that subscription's lifetime: it would zero a rider who
+    // subscribed days earlier, then no-op forever from month two.
+    const first = periodFor('monthly', new Date('2026-08-12T09:00:00Z'));
+    const second = nextPeriod('monthly', first);
+
+    expect(periodRef('sub-1', first.end)).not.toBe(periodRef('sub-1', second.end));
+  });
+
+  it('is stable within one period, so a retry is still a no-op', () => {
+    const p = periodFor('monthly', new Date('2026-08-12T09:00:00Z'));
+    expect(periodRef('sub-1', p.end)).toBe(periodRef('sub-1', new Date(p.end)));
+  });
+
+  it('differs between subscriptions in the same period', () => {
+    const p = periodFor('monthly', new Date('2026-08-12T09:00:00Z'));
+    expect(periodRef('sub-1', p.end)).not.toBe(periodRef('sub-2', p.end));
+  });
+});

--- a/services/api/tests/subscription-periods.test.ts
+++ b/services/api/tests/subscription-periods.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from 'vitest';
+import { CreditService } from '../src/modules/entitlements/credit.service';
+import { RenewalService } from '../src/modules/subscriptions/renewal.service';
+import { InMemorySubscriptionRepository } from '../src/modules/subscriptions/subscription.repository';
+import { InMemoryCreditLedgerRepository } from '../src/modules/entitlements/credit-ledger.repository';
+import { InMemoryEntitlementLedgerRepository } from '../src/modules/entitlements/entitlement-ledger.repository';
+import { periodFor, nextPeriod } from '../src/modules/subscriptions/period';
+
+const AUG = new Date('2026-08-12T09:00:00Z');
+const CREDIT_PER_RIDE = 45;
+
+async function setup() {
+  const subscriptions = new InMemorySubscriptionRepository();
+  const credits = new InMemoryCreditLedgerRepository();
+  const entitlements = new InMemoryEntitlementLedgerRepository();
+
+  const period = periodFor('monthly', AUG);
+  const sub = await subscriptions.create({
+    userId: 'rider-1',
+    plan: 'monthly',
+    routeId: null,
+    periodStart: period.start,
+    periodEnd: period.end,
+  });
+  // 44 rides allocated, 13 travelled -> 31 unused.
+  await entitlements.record({
+    userId: 'rider-1',
+    deltaRides: 44,
+    reason: 'allocation',
+    idempotencyKey: 'alloc-1',
+  });
+  await entitlements.record({
+    userId: 'rider-1',
+    deltaRides: -13,
+    reason: 'boarding',
+    idempotencyKey: 'board-1',
+  });
+
+  const credit = new CreditService({
+    subscriptions,
+    credits,
+    entitlements,
+    creditPesewasPerRide: CREDIT_PER_RIDE,
+  });
+  const renewal = new RenewalService({ subscriptions });
+  return { subscriptions, credits, entitlements, credit, renewal, sub, period };
+}
+
+describe('credit conversion is keyed per period (#162)', () => {
+  it('does not convert a rider whose period is still running', async () => {
+    // The bug this closes: conversion used to sweep every ACTIVE subscription,
+    // so scheduling it would have zeroed someone three days into their month.
+    const { credit, entitlements } = await setup();
+
+    const result = await credit.convertAllActive(new Date('2026-08-20T00:00:00Z'));
+
+    expect(result.riders).toBe(0);
+    expect(await entitlements.remainingRides('rider-1')).toBe(31);
+  });
+
+  it('converts once the period has ended', async () => {
+    const { credit, entitlements, period } = await setup();
+
+    const result = await credit.convertAllActive(period.end);
+
+    expect(result.riders).toBe(1);
+    expect(result.ridesConverted).toBe(31);
+    expect(result.creditPesewas).toBe(31 * CREDIT_PER_RIDE);
+    expect(await entitlements.remainingRides('rider-1')).toBe(0);
+  });
+
+  it('is a no-op when re-run within the same period', async () => {
+    const { credit, credits, period } = await setup();
+
+    await credit.convertAllActive(period.end);
+    const second = await credit.convertAllActive(period.end);
+
+    expect(second.riders).toBe(0);
+    expect(await credits.balancePesewas('rider-1')).toBe(31 * CREDIT_PER_RIDE);
+  });
+
+  it('converts AGAIN in the next period — the month-two case that was broken', async () => {
+    // Keyed on sub.id, the second period silently no-opped forever. This is
+    // the single most important assertion in the file.
+    const { credit, credits, entitlements, subscriptions, sub, period } = await setup();
+
+    await credit.convertAllActive(period.end);
+
+    // Roll into September and travel a little.
+    const second = nextPeriod('monthly', period);
+    await subscriptions.rollPeriod(sub.id, {
+      periodStart: second.start,
+      periodEnd: second.end,
+    });
+    await entitlements.record({
+      userId: 'rider-1',
+      deltaRides: 44,
+      reason: 'allocation',
+      idempotencyKey: 'alloc-2',
+    });
+    await entitlements.record({
+      userId: 'rider-1',
+      deltaRides: -40,
+      reason: 'boarding',
+      idempotencyKey: 'board-2',
+    });
+
+    const result = await credit.convertAllActive(second.end);
+
+    expect(result.riders).toBe(1);
+    expect(result.ridesConverted).toBe(4);
+    expect(await credits.balancePesewas('rider-1')).toBe((31 + 4) * CREDIT_PER_RIDE);
+  });
+});
+
+describe('period-end expiry sweep (#162)', () => {
+  it('leaves a running subscription alone', async () => {
+    const { renewal, subscriptions } = await setup();
+
+    const result = await renewal.sweep(new Date('2026-08-20T00:00:00Z'));
+
+    expect(result.expired).toBe(0);
+    expect(await subscriptions.findActiveByUser('rider-1')).not.toBeNull();
+  });
+
+  it('expires a subscription whose period has ended', async () => {
+    // Before this, nothing ever set `expired` — and the one-active-per-user
+    // index meant the stale row blocked the rider from subscribing again.
+    const { renewal, subscriptions, period } = await setup();
+
+    const result = await renewal.sweep(period.end);
+
+    expect(result.expired).toBe(1);
+    expect(await subscriptions.findActiveByUser('rider-1')).toBeNull();
+  });
+
+  it('lets the rider subscribe again once expired', async () => {
+    const { renewal, subscriptions, period } = await setup();
+    await renewal.sweep(period.end);
+
+    const fresh = periodFor('monthly', period.end);
+    await expect(
+      subscriptions.create({
+        userId: 'rider-1',
+        plan: 'monthly',
+        routeId: null,
+        periodStart: fresh.start,
+        periodEnd: fresh.end,
+      }),
+    ).resolves.toBeDefined();
+  });
+
+  it('is idempotent', async () => {
+    const { renewal, period } = await setup();
+    await renewal.sweep(period.end);
+    expect((await renewal.sweep(period.end)).expired).toBe(0);
+  });
+});


### PR DESCRIPTION
**Closes #162. Unblocks #104.** The last place the backend was quietly *wrong* rather than merely incomplete.

## The bug at the centre of it

```ts
const key = `convert:${periodRef}`;   // periodRef was sub.id
```

Keyed on the **subscription** rather than the **period**, month-end conversion could only ever run **once in a subscription's lifetime**. Schedule it and it would zero a rider who subscribed three days earlier, then silently no-op forever from month two.

That is the sole reason `/admin/convert-credits` was excluded from the cron blueprint. It's now keyed per period and only sweeps subscriptions whose period has **ended** — not every active rider.

The test I'd point at is *"converts AGAIN in the next period"*. It's the month-two case, and it would have failed on `main`.

## Nothing expired, and that locked riders out

`status` could be `expired` but **no job ever set it**. A lapsed subscription stayed `active` indefinitely — and because of the one-active-per-user partial index, that stale row **blocked the rider from ever subscribing again**. Their only route back was an admin deleting a row by hand.

Adds a sweep and `POST /admin/expire-subscriptions`. It deliberately **does not auto-renew**: charging without the rider initiating it needs a stored mandate we don't have, and that's #128.

## The apps can now render the balance card

`renews 1 Sep` and `23 of 40` are in the commuter designs and were not computable. `GET /me/rides` now returns `renewsAt` and `ridesPerPeriod` — **null rather than invented** when there's no active subscription.

## Date arithmetic, because this is where it goes wrong

**`setUTCMonth` overflows rather than clamping.** 31 Jan + 1 month becomes **3 March**. A rider subscribing on the 31st would watch their renewal date drift further every single cycle. `addMonthsClamped` clamps to 28/29/30 instead — tested against Feb, leap years, 31 May → 30 June, and year boundaries.

**Periods are half-open `[start, end)`.** No off-by-one-second argument for someone who subscribed at 23:59:59.

**The next period starts where the last ended, not "now".** Processing a renewal three days late must not shift a rider's anniversary permanently.

## Verification

Full gates green. **456 tests** (up from 433), coverage 91.95%.

Migration verified against real Postgres, twice. Backfill derives from `created_at` rather than guessing:

```
annual:  2026-08-07 -> 2027-08-07
monthly: 2026-08-07 -> 2026-09-07
nulls remaining: 0
```

## Also updated

The `ask-dispatch-cron.ts` header, which explained why convert-credits was unscheduled. That reason no longer holds — it can be scheduled alongside `expire-subscriptions` whenever the crons are funded.