### PR TITLE
feat(api): net Ride Credit off the subscription checkout (#128)

### DIFF
--- a/services/api/src/db/migrations/030_credit_netting.sql
+++ b/services/api/src/db/migrations/030_credit_netting.sql
@@ -1,0 +1,16 @@
+-- E5b (#128): spend the Ride Credits that #162 started minting.
+--
+-- Until now the credit ledger was write-only: month-end conversion granted
+-- credit, `GET /me/rides` displayed it, and no code path could ever spend it.
+-- The balance was an accruing liability with no discharge.
+--
+-- What the rider pays on a checkout is now `price - applied_credit`. The applied
+-- amount is frozen on the PAYMENT, alongside the other #103 snapshots, for the
+-- same reason: minutes pass between checkout and charge.success, and the
+-- amount sent to Paystack is fixed the moment we call them.
+ALTER TABLE payments
+  ADD COLUMN IF NOT EXISTS applied_credit_pesewas integer NOT NULL DEFAULT 0
+    CHECK (applied_credit_pesewas >= 0);
+
+COMMENT ON COLUMN payments.applied_credit_pesewas IS
+  'Ride Credit netted off this checkout, frozen at initiation. The rider was charged amount; the ledger is debited this much on charge.success (reason renewal_applied, keyed by reference).';

--- a/services/api/src/modules/payments/payment.repository.pg.ts
+++ b/services/api/src/modules/payments/payment.repository.pg.ts
@@ -16,6 +16,7 @@ interface PaymentRow {
   plan: SubscriptionPlan | null;
   route_id: string | null;
   amount: number;
+  applied_credit_pesewas: number;
   rides_granted: number | null;
   fare_pesewas: number | null;
   credit_pesewas_per_ride: number | null;
@@ -34,6 +35,7 @@ function toPayment(row: PaymentRow): Payment {
     plan: row.plan,
     routeId: row.route_id,
     amount: row.amount,
+    appliedCreditPesewas: row.applied_credit_pesewas,
     ridesGranted: row.rides_granted,
     farePesewas: row.fare_pesewas,
     creditPesewasPerRide: row.credit_pesewas_per_ride,
@@ -50,8 +52,9 @@ export class PgPaymentRepository implements PaymentRepository {
   async create(input: NewPayment): Promise<Payment> {
     const { rows } = await this.pool.query<PaymentRow>(
       `INSERT INTO payments (user_id, reference, purpose, plan, route_id, amount, currency,
-                             rides_granted, fare_pesewas, credit_pesewas_per_ride)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+                             rides_granted, fare_pesewas, credit_pesewas_per_ride,
+                             applied_credit_pesewas)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
        RETURNING *`,
       [
         input.userId,
@@ -64,6 +67,7 @@ export class PgPaymentRepository implements PaymentRepository {
         input.ridesGranted ?? null,
         input.farePesewas ?? null,
         input.creditPesewasPerRide ?? null,
+        input.appliedCreditPesewas ?? 0,
       ],
     );
     return toPayment(rows[0]!);

--- a/services/api/src/modules/payments/payment.repository.ts
+++ b/services/api/src/modules/payments/payment.repository.ts
@@ -30,8 +30,10 @@ export interface Payment {
   farePesewas: number | null;
   /** Ride Credit value per unused ride, frozen at checkout. */
   creditPesewasPerRide: number | null;
-  /** Amount in pesewas (1 GHS = 100 pesewas). */
+  /** Amount CHARGED in pesewas, already net of `appliedCreditPesewas`. */
   amount: number;
+  /** Ride Credit netted off this checkout, frozen at initiation (#128). */
+  appliedCreditPesewas: number;
   /** ISO 4217 currency code (currently always `GHS`). */
   currency: string;
   /** Current lifecycle state. */
@@ -47,8 +49,10 @@ export interface NewPayment {
   purpose: PaymentPurpose;
   plan: SubscriptionPlan | null;
   routeId?: string | null;
-  /** Amount in pesewas (1 GHS = 100 pesewas). */
+  /** Amount CHARGED in pesewas, already net of `appliedCreditPesewas`. */
   amount: number;
+  /** Ride Credit netted off this checkout (#128). Defaults to 0. */
+  appliedCreditPesewas?: number;
   currency: string;
   /** Rides this payment buys, frozen at checkout (#103). Null pre-#103. */
   ridesGranted?: number | null;
@@ -96,6 +100,7 @@ export class InMemoryPaymentRepository implements PaymentRepository {
       plan: input.plan,
       routeId: input.routeId ?? null,
       amount: input.amount,
+      appliedCreditPesewas: input.appliedCreditPesewas ?? 0,
       currency: input.currency,
       ridesGranted: input.ridesGranted ?? null,
       farePesewas: input.farePesewas ?? null,

--- a/services/api/src/modules/payments/payments.schema.ts
+++ b/services/api/src/modules/payments/payments.schema.ts
@@ -19,6 +19,12 @@ export const subscribeBodySchema = z.object({
 export const checkoutResponseSchema = z.object({
   authorizationUrl: z.string(),
   reference: z.string(),
+  /** Full period price before credit — what the rider would owe with none. */
+  pricePesewas: z.number().int(),
+  /** Ride Credit netted off (#128); 0 when the rider has none. */
+  appliedCreditPesewas: z.number().int(),
+  /** What Paystack will actually charge: `pricePesewas - appliedCreditPesewas`. */
+  chargePesewas: z.number().int(),
 });
 
 export const webhookResponseSchema = z.object({

--- a/services/api/src/modules/payments/payments.service.ts
+++ b/services/api/src/modules/payments/payments.service.ts
@@ -2,12 +2,18 @@
 // process the charge.success webhook that activates it. Money is in PESEWAS
 // (integers, never floats), matching Paystack.
 //
+// Checkouts are netted against the rider's Ride Credit balance (#128): the
+// applied amount is frozen on the payment at initiation, and the ledger is
+// debited on charge.success — never at checkout, or an abandoned checkout would
+// burn credit the rider never spent.
+//
 // Deliberately not one DB transaction (system-design §4.2 "idempotent
 // webhooks"): each step is individually idempotent — the one-active-per-user
 // index guards activation, markPaid only does pending→paid — so a retried or
 // partial webhook converges.
 
 import { normaliseGhanaPhone } from '../../lib/phone';
+import type { CreditLedgerRepository } from '../entitlements/credit-ledger.repository';
 import type { EntitlementLedgerRepository } from '../entitlements/entitlement-ledger.repository';
 import type {
   SubscriptionPlan,
@@ -15,7 +21,7 @@ import type {
 } from '../subscriptions/subscription.repository';
 import type { UserRepository } from '../users/user.repository';
 import { periodFor } from '../subscriptions/period';
-import { derivePrice, type DerivedPrice } from './pricing';
+import { derivePrice, netCharge, type DerivedPrice } from './pricing';
 import type { PricingRepository } from './pricing.repository';
 import type { NewPayment, Payment, PaymentRepository } from './payment.repository';
 import type { PaystackClient } from './paystack.client';
@@ -55,6 +61,8 @@ export interface PaymentsServiceDeps {
   subscriptions: SubscriptionRepository;
   /** Ride entitlement ledger — allocated on a successful subscription payment. */
   entitlements: EntitlementLedgerRepository;
+  /** Ride Credit ledger — netted off a checkout and debited on success (#128). */
+  credits?: CreditLedgerRepository;
   /** Undefined when payments aren't configured (e.g. prod without a Paystack key). */
   paystack?: PaystackClient;
   /** Users, for capturing the payer's verified phone on charge.success (#182). */
@@ -92,6 +100,12 @@ export interface CheckoutResult {
   authorizationUrl: string;
   /** Our unique payment reference, echoed back by the webhook for reconciliation. */
   reference: string;
+  /** Full period price before credit, so the client can show the saving. */
+  pricePesewas: number;
+  /** Ride Credit netted off this checkout (#128). */
+  appliedCreditPesewas: number;
+  /** What Paystack is charging: `pricePesewas - appliedCreditPesewas`. */
+  chargePesewas: number;
 }
 
 /**
@@ -121,12 +135,15 @@ export class PaymentsService {
     routeId: string,
   ): Promise<CheckoutResult> {
     const price = await this.priceFor(plan, routeId);
-    return this.startCheckout({
+    const balance = this.deps.credits ? await this.deps.credits.balancePesewas(userId) : 0;
+    const { appliedCreditPesewas, chargePesewas } = netCharge(price.pricePesewas, balance);
+    const checkout = await this.startCheckout({
       userId,
       purpose: 'subscription',
       plan,
       routeId,
-      amount: price.pricePesewas,
+      amount: chargePesewas,
+      appliedCreditPesewas,
       currency: 'GHS',
       // Frozen here, not at activation: a fare moving between checkout and
       // charge.success would grant rides priced against a fare never paid.
@@ -134,6 +151,7 @@ export class PaymentsService {
       farePesewas: price.farePesewas,
       creditPesewasPerRide: price.creditPesewasPerRide,
     });
+    return { ...checkout, pricePesewas: price.pricePesewas, appliedCreditPesewas, chargePesewas };
   }
 
   /**
@@ -165,7 +183,9 @@ export class PaymentsService {
    * @returns the checkout URL and the generated reference.
    * @throws PaymentsNotConfiguredError when no Paystack client is wired.
    */
-  private async startCheckout(input: Omit<NewPayment, 'reference'>): Promise<CheckoutResult> {
+  private async startCheckout(
+    input: Omit<NewPayment, 'reference'>,
+  ): Promise<Pick<CheckoutResult, 'authorizationUrl' | 'reference'>> {
     if (!this.deps.paystack) {
       throw new PaymentsNotConfiguredError('Payments are not configured');
     }
@@ -209,6 +229,10 @@ export class PaymentsService {
     if (!payment) return; // unknown reference — not ours
 
     if (payment.purpose === 'subscription' && payment.plan) {
+      // Debit BEFORE activating: a crash between the two leaves the rider
+      // without the subscription their retry will grant, rather than with a
+      // subscription they never paid the credit half of.
+      await this.applyCredit(payment.userId, reference, payment.appliedCreditPesewas);
       // Membership fee paid — activate the subscription (pinned to the paid
       // route) and allocate the period's rides. Both idempotent → replay-safe.
       await this.activateSubscription(payment.userId, payment.plan, payment.routeId, payment);
@@ -267,6 +291,38 @@ export class PaymentsService {
       // Already held by another account, or the row vanished. Neither is worth
       // failing a paid subscription over.
     }
+  }
+
+  /**
+   * Debit the Ride Credit this checkout was netted against.
+   *
+   * Clamped to the balance actually on the ledger. Two checkouts opened before
+   * either settles are both netted against the same balance, so the second
+   * would otherwise drive it negative — spending credit that no longer exists.
+   * The clamp caps that at the balance; the rider keeps the discount already
+   * charged, which is the cheaper side of the error to be on.
+   *
+   * @param userId - the rider.
+   * @param reference - the payment reference; also the idempotency key.
+   * @param appliedCreditPesewas - what was netted off at checkout.
+   */
+  private async applyCredit(
+    userId: string,
+    reference: string,
+    appliedCreditPesewas: number,
+  ): Promise<void> {
+    if (!this.deps.credits || appliedCreditPesewas <= 0) return;
+    const balance = await this.deps.credits.balancePesewas(userId);
+    const debit = Math.min(appliedCreditPesewas, balance);
+    if (debit <= 0) return;
+    await this.deps.credits.record({
+      userId,
+      deltaPesewas: -debit,
+      reason: 'renewal_applied',
+      refType: 'payment',
+      refId: reference,
+      idempotencyKey: `renewal:${reference}`,
+    });
   }
 
   /**

--- a/services/api/src/modules/payments/pricing.ts
+++ b/services/api/src/modules/payments/pricing.ts
@@ -64,6 +64,36 @@ export function derivePrice(farePesewas: number, pricing: PlanPricing): DerivedP
 }
 
 /**
+ * Smallest amount we will send to Paystack. Below this a charge is not worth
+ * attempting, so credit is capped to leave at least this much payable and the
+ * remainder stays in the ledger for the next renewal.
+ */
+export const MIN_CHARGE_PESEWAS = 100;
+
+/** How a checkout splits between Ride Credit and money. */
+export interface NettedCharge {
+  /** Credit to debit on success. */
+  appliedCreditPesewas: number;
+  /** What Paystack is asked for. */
+  chargePesewas: number;
+}
+
+/**
+ * Split a price between the rider's credit balance and money.
+ *
+ * Credit never takes the charge below {@link MIN_CHARGE_PESEWAS}: the unused
+ * remainder is not lost, it simply stays on the ledger for the next renewal.
+ *
+ * @param pricePesewas - the derived price for the period.
+ * @param creditBalancePesewas - the rider's current Ride Credit balance.
+ * @returns how much credit is applied and how much is charged.
+ */
+export function netCharge(pricePesewas: number, creditBalancePesewas: number): NettedCharge {
+  const spendable = Math.max(0, Math.min(creditBalancePesewas, pricePesewas - MIN_CHARGE_PESEWAS));
+  return { appliedCreditPesewas: spendable, chargePesewas: pricePesewas - spendable };
+}
+
+/**
  * What the operator earns for the seats actually run.
  *
  * @param farePesewas - the fare in force when the rides were delivered.

--- a/services/api/src/server.ts
+++ b/services/api/src/server.ts
@@ -298,6 +298,7 @@ async function main(): Promise<void> {
     payments,
     subscriptions,
     entitlements,
+    credits,
     users,
     paystack,
     pricing,

--- a/services/api/tests/payments.service.test.ts
+++ b/services/api/tests/payments.service.test.ts
@@ -12,8 +12,10 @@ import {
   type SubscriptionRepository,
 } from '../src/modules/subscriptions/subscription.repository';
 import { InMemoryEntitlementLedgerRepository } from '../src/modules/entitlements/entitlement-ledger.repository';
+import { InMemoryCreditLedgerRepository } from '../src/modules/entitlements/credit-ledger.repository';
 import { InMemoryUserRepository } from '../src/modules/users/user.repository';
 import { InMemoryPricingRepository } from '../src/modules/payments/pricing.repository';
+import { MIN_CHARGE_PESEWAS } from '../src/modules/payments/pricing';
 
 const FAKE_SECRET = 'fake-paystack-secret';
 const RIDES = 44;
@@ -25,16 +27,18 @@ function make(subscriptions: SubscriptionRepository = new InMemorySubscriptionRe
   const payments = new InMemoryPaymentRepository();
   const entitlements = new InMemoryEntitlementLedgerRepository();
   const pricing = new InMemoryPricingRepository();
+  const credits = new InMemoryCreditLedgerRepository();
   const service = new PaymentsService({
     payments,
     subscriptions,
     entitlements,
+    credits,
     paystack: new FakePaystackClient(FAKE_SECRET),
     users: new InMemoryUserRepository(),
     pricing,
     ridesPerPeriod: RIDES,
   });
-  return { payments, subscriptions, entitlements, pricing, service };
+  return { payments, subscriptions, entitlements, credits, pricing, service };
 }
 
 /** A priced corridor: without a fare in force there is no price to charge. */
@@ -204,5 +208,109 @@ describe('PaymentsService.handleWebhook', () => {
     const { reference } = await service.initializeSubscription('u1', 'monthly', ROUTE);
     const { body, signature } = chargeSuccess(reference);
     await expect(service.handleWebhook(body, signature)).rejects.toThrow('db down');
+  });
+});
+
+describe('credit-netted checkout (#128)', () => {
+  /** Grant credit the way month-end conversion does, so the balance is real. */
+  async function grant(
+    credits: InMemoryCreditLedgerRepository,
+    userId: string,
+    pesewas: number,
+  ): Promise<void> {
+    await credits.record({
+      userId,
+      deltaPesewas: pesewas,
+      reason: 'month_end_conversion',
+      idempotencyKey: `grant:${userId}:${pesewas}`,
+    });
+  }
+
+  it('charges the price less the credit balance, and says so', async () => {
+    const { service, credits, payments } = await priced();
+    await grant(credits, 'u1', 5_000);
+
+    const checkout = await service.initializeSubscription('u1', 'monthly', ROUTE);
+
+    expect(checkout.pricePesewas).toBe(FARE * RIDES);
+    expect(checkout.appliedCreditPesewas).toBe(5_000);
+    expect(checkout.chargePesewas).toBe(FARE * RIDES - 5_000);
+    expect(await payments.findByReference(checkout.reference)).toMatchObject({
+      amount: FARE * RIDES - 5_000,
+      appliedCreditPesewas: 5_000,
+    });
+  });
+
+  it('does not touch the ledger at checkout — an abandoned one must not burn credit', async () => {
+    const { service, credits } = await priced();
+    await grant(credits, 'u1', 5_000);
+    await service.initializeSubscription('u1', 'monthly', ROUTE);
+    expect(await credits.balancePesewas('u1')).toBe(5_000);
+  });
+
+  it('debits the ledger on charge.success', async () => {
+    const { service, credits } = await priced();
+    await grant(credits, 'u1', 5_000);
+    const { reference } = await service.initializeSubscription('u1', 'monthly', ROUTE);
+
+    const { body, signature } = chargeSuccess(reference);
+    await service.handleWebhook(body, signature);
+
+    expect(await credits.balancePesewas('u1')).toBe(0);
+  });
+
+  it('a replayed webhook does not debit twice', async () => {
+    const { service, credits } = await priced();
+    await grant(credits, 'u1', 5_000);
+    const { reference } = await service.initializeSubscription('u1', 'monthly', ROUTE);
+
+    const { body, signature } = chargeSuccess(reference);
+    await service.handleWebhook(body, signature);
+    await service.handleWebhook(body, signature);
+
+    expect(await credits.balancePesewas('u1')).toBe(0);
+  });
+
+  it('leaves the balance alone when the rider has no credit', async () => {
+    const { service, credits, payments } = await priced();
+    const { reference } = await service.initializeSubscription('u1', 'monthly', ROUTE);
+    expect(await payments.findByReference(reference)).toMatchObject({
+      amount: FARE * RIDES,
+      appliedCreditPesewas: 0,
+    });
+    expect(await credits.balancePesewas('u1')).toBe(0);
+  });
+
+  it('never nets the charge below the Paystack floor; the rest stays on the ledger', async () => {
+    const { service, credits } = await priced();
+    const price = FARE * RIDES;
+    await grant(credits, 'u1', price + 10_000); // more credit than the whole plan
+
+    const checkout = await service.initializeSubscription('u1', 'monthly', ROUTE);
+
+    expect(checkout.chargePesewas).toBe(MIN_CHARGE_PESEWAS);
+    expect(checkout.appliedCreditPesewas).toBe(price - MIN_CHARGE_PESEWAS);
+
+    const { body, signature } = chargeSuccess(checkout.reference);
+    await service.handleWebhook(body, signature);
+    expect(await credits.balancePesewas('u1')).toBe(price + 10_000 - checkout.appliedCreditPesewas);
+  });
+
+  it('clamps the debit to the balance when two checkouts raced the same credit', async () => {
+    const { service, credits } = await priced();
+    await grant(credits, 'u1', 5_000);
+
+    // Both opened before either settled, so both were netted against 5000.
+    const first = await service.initializeSubscription('u1', 'monthly', ROUTE);
+    const second = await service.initializeSubscription('u1', 'monthly', ROUTE);
+    expect(second.appliedCreditPesewas).toBe(5_000);
+
+    for (const ref of [first.reference, second.reference]) {
+      const { body, signature } = chargeSuccess(ref);
+      await service.handleWebhook(body, signature);
+    }
+
+    // The second debit is clamped rather than driving the ledger negative.
+    expect(await credits.balancePesewas('u1')).toBe(0);
   });
 });

--- a/services/api/tests/pricing.test.ts
+++ b/services/api/tests/pricing.test.ts
@@ -5,6 +5,8 @@ import {
   derivePrice,
   deriveOperatorPayout,
   deriveRevenue,
+  MIN_CHARGE_PESEWAS,
+  netCharge,
   type PlanPricing,
 } from '../src/modules/payments/pricing';
 
@@ -99,5 +101,32 @@ describe('deriveRevenue', () => {
     // costs us money. The formula must show that rather than clamp it.
     const price = derivePrice(FARE, PARITY);
     expect(deriveRevenue(price, 50, 0)).toBeLessThan(0);
+  });
+});
+
+describe('netCharge', () => {
+  it('applies the whole balance when it is comfortably under the price', () => {
+    expect(netCharge(26_400, 5_000)).toEqual({
+      appliedCreditPesewas: 5_000,
+      chargePesewas: 21_400,
+    });
+  });
+
+  it('applies nothing when the rider has no credit', () => {
+    expect(netCharge(26_400, 0)).toEqual({ appliedCreditPesewas: 0, chargePesewas: 26_400 });
+  });
+
+  it('leaves the Paystack floor payable rather than charging zero', () => {
+    expect(netCharge(26_400, 30_000)).toEqual({
+      appliedCreditPesewas: 26_400 - MIN_CHARGE_PESEWAS,
+      chargePesewas: MIN_CHARGE_PESEWAS,
+    });
+  });
+
+  it('applies nothing when the price is already at or below the floor', () => {
+    expect(netCharge(MIN_CHARGE_PESEWAS, 9_999)).toEqual({
+      appliedCreditPesewas: 0,
+      chargePesewas: MIN_CHARGE_PESEWAS,
+    });
   });
 });


### PR DESCRIPTION
Closes #128

## The hole this closes

Since #162 shipped, the month-end job mints Ride Credit every period and `GET /me/rides` shows the balance. Nothing could spend it:

```
month_end_conversion   1 writer
compensation           0 writers
loyalty                0 writers
renewal_applied        0 writers   ← the spend path
```

The only consumer of `balancePesewas` was a read endpoint. Credit was an accruing liability with no discharge, and a number riders watch go up that does nothing.

## What changes

`POST /payments/subscribe` nets the balance off the price:

```
appliedCredit = min(balance, price − MIN_CHARGE_PESEWAS)
charge        = price − appliedCredit
```

The applied amount is frozen on the payment (`applied_credit_pesewas`, migration 030) alongside the other #103 snapshots, for the same reason those exist: the amount sent to Paystack is fixed the moment we call them.

The ledger is debited on `charge.success`, keyed `renewal:<reference>` — **not** at checkout. An abandoned checkout must not burn credit the rider never spent.

## Ordering and edges

- **Debit before activation.** A crash between the two leaves the rider without the subscription their retry will grant, rather than with a subscription whose credit half never settled. Same reasoning as grant-before-retire in the conversion job.
- **The debit is clamped to the live balance.** Two checkouts opened before either settles are both netted against the same balance; without the clamp the second drives the ledger negative. Clamped, the rider keeps the discount already charged — the cheaper side of that error. Tested.
- **No zero-amount charges.** Credit never nets below `MIN_CHARGE_PESEWAS`; the remainder stays on the ledger for the next renewal instead of producing a Paystack call for 0. At current numbers this is a guard, not a live path — max credit is 44 × 45 = GHS 19.80 against a GHS 264 plan, about 7%.

## API

The checkout response gains `pricePesewas`, `appliedCreditPesewas`, `chargePesewas`. Additive — no existing field changed shape or type, so the commuter app keeps working unchanged and can show the saving when it's ready.

## Deferred — decisions, not code

- **Credit expiry / carry-forward cap.** #104's open financial-liability question. Credit never expires today. Adding expiry later is a filter on the balance query plus a sweep; it does not rework this.
- **Card-on-file auto-renew.** Needs a stored Paystack mandate we do not have. `/admin/expire-subscriptions` still deliberately does not auto-charge.

## Verification

- 467 tests (+11), coverage 92.02%.
- Migration 030 applied to a scratch DB: idempotent on re-run, backfills existing rows to 0, and the CHECK rejects a negative.