### PR TITLE
docs(maps): note that localised name fields would outrun the glyph ranges

### DIFF
--- a/maps/build-styles.mjs
+++ b/maps/build-styles.mjs
@@ -84,6 +84,13 @@ const PALETTES = {
 const REGULAR = ['Noto Sans Regular'];
 const MEDIUM = ['Noto Sans Medium'];
 
+// Every label uses `['get', 'name']` on purpose, and that is load-bearing for
+// more than wording. The tiles also carry `name:zh`, `name:ko`, `name:ka`,
+// `name:ru` and others, and our glyph atlases only cover U+0000-U+024F (see
+// build-glyphs.mjs). Switching text-field to a localised name, or adding a
+// language toggle, makes MapLibre request glyph ranges that do not exist and
+// those labels silently vanish. Widen the ranges in build-glyphs.mjs first.
+
 /**
  * Road width ramp, shared by casing and fill so they cannot drift apart.
  *


### PR DESCRIPTION
Follow-up to #201, comment only, no behaviour change.

While checking whether our glyph coverage was actually sufficient, I scanned the tile data and found the archive carries localised name variants we do not have fonts for:

```
name:zh  莫尔国家公园      (Mole National Park)
name:ka  აკრა              (Accra, Georgian)
name:ru  Акра              (Accra, Cyrillic)
name:kn  ಅಕ್ಕ್ರಾ            (Accra, Kannada)
name:ko  아크라             (Accra, Korean)
```

The atlases cover `U+0000`–`U+024F` only.

**Nothing is broken today.** The styles use `['get', 'name']`, and the preview server log confirms a full Accra render requests exactly two glyph ranges, both present:

```
GET /dist/fonts/Noto%20Sans%20Regular/0-255.pbf  200
GET /dist/fonts/Noto%20Sans%20Medium/0-255.pbf   200
```

Never 256-511, never 512-767, never beyond. Every Accra label is ASCII, so we have two spare ranges of headroom for accented Latin.

The trap is that this is invisible. Switching `text-field` to a localised name, or adding a language toggle, would make MapLibre request ranges that do not exist, and those labels would silently disappear rather than error. This adds a comment where someone would make that change, pointing at `build-glyphs.mjs` as the thing to widen first.