### PR TITLE
feat(api): pin riders to a pickup and drop-off stop (#204)

### DIFF
--- a/services/api/src/app.ts
+++ b/services/api/src/app.ts
@@ -367,6 +367,7 @@ export async function buildApp(deps: AppDeps = {}): Promise<FastifyInstance> {
     stops: deps.stops,
     tripPositions: deps.tripPositions ?? new InMemoryTripPositionRepository(),
     segmentSpeeds: deps.segmentSpeeds,
+    reservations,
     kv,
     rateLimit: deps.rateLimit ?? DEFAULT_RATE_LIMIT,
   });

--- a/services/api/src/db/migrations/031_rider_stops.sql
+++ b/services/api/src/db/migrations/031_rider_stops.sql
@@ -1,0 +1,33 @@
+-- #204: record where a rider actually boards and alights.
+--
+-- Until now a rider was pinned to a route and nothing finer. GET
+-- /trips/:id/position returns an ETA to every stop on that route, and the
+-- client had no way to know which one was theirs, so "your van is 6 minutes
+-- from Adenta" could not be built at all.
+--
+-- Nullable throughout. Riders who subscribed before this have no stops, and
+-- the endpoints fall back to route-level behaviour rather than failing.
+
+ALTER TABLE subscriptions
+  ADD COLUMN IF NOT EXISTS pickup_stop_id  uuid REFERENCES stops (id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS dropoff_stop_id uuid REFERENCES stops (id) ON DELETE SET NULL;
+
+-- Frozen on the payment at checkout for the same reason as the #103 price
+-- snapshot: minutes pass before charge.success, and the subscription should be
+-- activated with exactly what the rider chose and paid against.
+ALTER TABLE payments
+  ADD COLUMN IF NOT EXISTS pickup_stop_id  uuid,
+  ADD COLUMN IF NOT EXISTS dropoff_stop_id uuid;
+
+-- Copied onto each reservation so a travel day keeps the stops that were in
+-- force when it was seeded. A rider who edits their subscription mid-month
+-- does not retroactively change where yesterday's van was supposed to meet
+-- them, which matters when a no-show is disputed.
+ALTER TABLE reservations
+  ADD COLUMN IF NOT EXISTS pickup_stop_id  uuid REFERENCES stops (id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS dropoff_stop_id uuid REFERENCES stops (id) ON DELETE SET NULL;
+
+COMMENT ON COLUMN subscriptions.pickup_stop_id IS
+  'Where this rider boards. NULL for subscriptions created before #204.';
+COMMENT ON COLUMN reservations.pickup_stop_id IS
+  'Frozen from the subscription when the reservation was seeded (#204).';

--- a/services/api/src/modules/mobility/mobility.schema.ts
+++ b/services/api/src/modules/mobility/mobility.schema.ts
@@ -112,4 +112,22 @@ export const livePositionResponseSchema = z.object({
       etaSeconds: z.number(),
     }),
   ),
+  /**
+   * The caller's own pickup stop on this trip (#204), already picked out of
+   * `etaToStops`. Null when the rider has no reservation on this trip, has no
+   * pickup stop recorded, or the van is already past it.
+   *
+   * Served rather than left to the client because every client would otherwise
+   * reimplement the same "which of these is mine" lookup, and "your van is 6
+   * minutes away" is the whole point of the screen.
+   */
+  riderStop: z
+    .object({
+      stopId: z.string().uuid(),
+      seq: z.number().int(),
+      name: z.string(),
+      distanceMeters: z.number(),
+      etaSeconds: z.number(),
+    })
+    .nullable(),
 });

--- a/services/api/src/modules/mobility/positions.routes.ts
+++ b/services/api/src/modules/mobility/positions.routes.ts
@@ -23,6 +23,7 @@ import {
   reportPositionBodySchema,
 } from './mobility.schema';
 import type { RouteStopRepository } from './route-stop.repository';
+import type { ReservationRepository } from '../reservations/reservation.repository';
 import type { StopRepository } from './stop.repository';
 import type { TripPositionRepository } from './trip-position.repository';
 import type { TripRepository } from './trip.repository';
@@ -43,6 +44,7 @@ const cacheKey = (tripId: string): string => `trip:position:${tripId}`;
  *
  * @param app - the Fastify instance to register on.
  * @param opts - route dependencies (503 when the repos they need are unwired).
+ * @param opts.reservations - reservations, to resolve the caller's own stop (#204).
  * @param opts.trips - trip lookup (existence + assignedDriverId).
  * @param opts.drivers - resolves the signed-in user to their driver record (authz).
  * @param opts.routeStops - the route's ordered stop placements (for ETA).
@@ -62,6 +64,8 @@ export async function positionRoutes(
     tripPositions?: TripPositionRepository;
     /** Observed segment speeds (#181). Absent -> ETAs use the cold-start speed. */
     segmentSpeeds?: SegmentSpeedRepository;
+    /** Reservations, to resolve the caller's own pickup stop (#204). */
+    reservations?: ReservationRepository;
     kv: KvStore;
     rateLimit: RateLimitConfig;
   },
@@ -193,11 +197,22 @@ export async function positionRoutes(
         ? await opts.segmentSpeeds.findByRoute(trip.routeId, directionOf(trip.scheduledAt))
         : undefined;
 
-      return {
-        tripId: trip.id,
-        position,
-        etaToStops: computeEtas(position, stopPoints, speeds),
-      };
+      const etaToStops = computeEtas(position, stopPoints, speeds);
+
+      // Which of those stops is the caller's. Absent reservations store, no
+      // reservation on this trip, or no stop recorded all mean null rather
+      // than an error: the trip's ETAs are still useful without it.
+      let riderStop = null;
+      if (opts.reservations) {
+        const mine = (await opts.reservations.listForTrip(trip.id)).find(
+          (res) => res.userId === request.user!.id,
+        );
+        if (mine?.pickupStopId) {
+          riderStop = etaToStops.find((e) => e.stopId === mine.pickupStopId) ?? null;
+        }
+      }
+
+      return { tripId: trip.id, position, etaToStops, riderStop };
     },
   );
 }

--- a/services/api/src/modules/notifications/ask-dispatch.service.ts
+++ b/services/api/src/modules/notifications/ask-dispatch.service.ts
@@ -68,6 +68,10 @@ export class AskDispatchService {
           tripId: trip.id,
           travelDate,
           direction,
+          // Frozen per travel day (#204): editing the subscription later must
+          // not rewrite where yesterday's van was meant to meet them.
+          pickupStopId: sub.pickupStopId,
+          dropoffStopId: sub.dropoffStopId,
         });
         await this.deps.notifier.send({
           userId: sub.userId,

--- a/services/api/src/modules/payments/payment.repository.pg.ts
+++ b/services/api/src/modules/payments/payment.repository.pg.ts
@@ -15,6 +15,8 @@ interface PaymentRow {
   purpose: PaymentPurpose;
   plan: SubscriptionPlan | null;
   route_id: string | null;
+  pickup_stop_id: string | null;
+  dropoff_stop_id: string | null;
   amount: number;
   applied_credit_pesewas: number;
   rides_granted: number | null;
@@ -34,6 +36,8 @@ function toPayment(row: PaymentRow): Payment {
     purpose: row.purpose,
     plan: row.plan,
     routeId: row.route_id,
+    pickupStopId: row.pickup_stop_id,
+    dropoffStopId: row.dropoff_stop_id,
     amount: row.amount,
     appliedCreditPesewas: row.applied_credit_pesewas,
     ridesGranted: row.rides_granted,
@@ -53,8 +57,8 @@ export class PgPaymentRepository implements PaymentRepository {
     const { rows } = await this.pool.query<PaymentRow>(
       `INSERT INTO payments (user_id, reference, purpose, plan, route_id, amount, currency,
                              rides_granted, fare_pesewas, credit_pesewas_per_ride,
-                             applied_credit_pesewas)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+                             applied_credit_pesewas, pickup_stop_id, dropoff_stop_id)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
        RETURNING *`,
       [
         input.userId,
@@ -68,6 +72,8 @@ export class PgPaymentRepository implements PaymentRepository {
         input.farePesewas ?? null,
         input.creditPesewasPerRide ?? null,
         input.appliedCreditPesewas ?? 0,
+        input.pickupStopId ?? null,
+        input.dropoffStopId ?? null,
       ],
     );
     return toPayment(rows[0]!);

--- a/services/api/src/modules/payments/payment.repository.ts
+++ b/services/api/src/modules/payments/payment.repository.ts
@@ -24,6 +24,10 @@ export interface Payment {
   plan: SubscriptionPlan | null;
   /** The route the rider is subscribing to (E3); carried to the subscription on activation. */
   routeId: string | null;
+  /** Where the rider boards, frozen at checkout (#204). */
+  pickupStopId: string | null;
+  /** Where the rider alights, frozen at checkout (#204). */
+  dropoffStopId: string | null;
   /** Rides this payment buys, frozen at checkout (#103). Null for pre-#103 rows. */
   ridesGranted: number | null;
   /** The corridor fare the price was derived from, frozen at checkout. */
@@ -49,6 +53,10 @@ export interface NewPayment {
   purpose: PaymentPurpose;
   plan: SubscriptionPlan | null;
   routeId?: string | null;
+  /** Where the rider boards, frozen at checkout (#204). */
+  pickupStopId?: string | null;
+  /** Where the rider alights, frozen at checkout (#204). */
+  dropoffStopId?: string | null;
   /** Amount CHARGED in pesewas, already net of `appliedCreditPesewas`. */
   amount: number;
   /** Ride Credit netted off this checkout (#128). Defaults to 0. */
@@ -99,6 +107,8 @@ export class InMemoryPaymentRepository implements PaymentRepository {
       purpose: input.purpose,
       plan: input.plan,
       routeId: input.routeId ?? null,
+      pickupStopId: input.pickupStopId ?? null,
+      dropoffStopId: input.dropoffStopId ?? null,
       amount: input.amount,
       appliedCreditPesewas: input.appliedCreditPesewas ?? 0,
       currency: input.currency,

--- a/services/api/src/modules/payments/payments.routes.ts
+++ b/services/api/src/modules/payments/payments.routes.ts
@@ -15,6 +15,7 @@ import {
   webhookResponseSchema,
 } from './payments.schema';
 import {
+  InvalidStopsError,
   InvalidWebhookError,
   NotPricedError,
   PaymentsNotConfiguredError,
@@ -52,6 +53,7 @@ export async function paymentRoutes(
         body: subscribeBodySchema,
         response: {
           200: checkoutResponseSchema,
+          400: errorResponseSchema,
           401: errorResponseSchema,
           409: errorResponseSchema,
           429: errorResponseSchema,
@@ -67,9 +69,15 @@ export async function paymentRoutes(
           request.user!.id,
           request.body.plan,
           request.body.routeId,
+          { pickupStopId: request.body.pickupStopId, dropoffStopId: request.body.dropoffStopId },
         );
       } catch (err) {
         if (err instanceof PaymentsNotConfiguredError) return reply.code(503).send(UNAVAILABLE);
+        // 400: the rider picked stops that are not both on the route, or the
+        // wrong way round. Their choice is wrong, not our state.
+        if (err instanceof InvalidStopsError) {
+          return reply.code(400).send({ error: 'invalid_stops', message: err.message });
+        }
         // 409, not 500: the request is well-formed, the corridor simply has no
         // fare set yet. Deliberately not falling back to a default — charging a
         // number nobody chose is what #103 exists to prevent.

--- a/services/api/src/modules/payments/payments.schema.ts
+++ b/services/api/src/modules/payments/payments.schema.ts
@@ -14,6 +14,13 @@ export const subscribeBodySchema = z.object({
    * ask-dispatch knows which riders to prompt (E3).
    */
   routeId: z.string().uuid(),
+  /**
+   * Where the rider boards and alights (#204). Optional so existing clients keep
+   * working; without them the rider is pinned to the corridor only, and the
+   * live-position response cannot say which stop is theirs.
+   */
+  pickupStopId: z.string().uuid().optional(),
+  dropoffStopId: z.string().uuid().optional(),
 });
 
 export const checkoutResponseSchema = z.object({

--- a/services/api/src/modules/payments/payments.service.ts
+++ b/services/api/src/modules/payments/payments.service.ts
@@ -22,6 +22,7 @@ import type {
 import type { UserRepository } from '../users/user.repository';
 import { periodFor } from '../subscriptions/period';
 import { derivePrice, netCharge, type DerivedPrice } from './pricing';
+import type { RouteStopRepository } from '../mobility/route-stop.repository';
 import type { PricingRepository } from './pricing.repository';
 import type { NewPayment, Payment, PaymentRepository } from './payment.repository';
 import type { PaystackClient } from './paystack.client';
@@ -47,6 +48,13 @@ export class NotPricedError extends Error {}
 export class InvalidWebhookError extends Error {}
 
 /**
+ * Thrown when the chosen pickup/drop-off stops are not both on the subscribed
+ * route, or are the wrong way round. Routes map it to HTTP 400: this is a
+ * malformed choice rather than a server problem.
+ */
+export class InvalidStopsError extends Error {}
+
+/**
  * Fallback ride count for payments created before #103, whose rows carry no
  * frozen `ridesGranted`. Live pricing comes from `plan_pricing`; this only
  * exists so replaying an old webhook still allocates something sane.
@@ -69,6 +77,8 @@ export interface PaymentsServiceDeps {
   users: UserRepository;
   /** Corridor fares + plan levers (#103). Prices are derived, never stored. */
   pricing: PricingRepository;
+  /** Route/stop placements, for validating the rider's chosen stops (#204). */
+  routeStops?: RouteStopRepository;
   /** Rides allocated per activated period (placeholder until E1b tiers). */
   ridesPerPeriod: number;
 }
@@ -126,6 +136,9 @@ export class PaymentsService {
    * @param plan - membership tier (`monthly` | `annual`); selects the fee.
    * @param routeId - the rider's pinned route/corridor (E3), carried to the
    *   subscription on activation.
+   * @param stops - the rider's chosen boarding and alighting stops (#204).
+   * @param stops.pickupStopId - where they board; omit both to skip stop pinning.
+   * @param stops.dropoffStopId - where they alight.
    * @returns the Paystack `authorizationUrl` and our payment `reference`.
    * @throws PaymentsNotConfiguredError when no Paystack client is wired.
    */
@@ -133,7 +146,9 @@ export class PaymentsService {
     userId: string,
     plan: SubscriptionPlan,
     routeId: string,
+    stops: { pickupStopId?: string; dropoffStopId?: string } = {},
   ): Promise<CheckoutResult> {
+    await this.assertStopsOnRoute(routeId, stops);
     const price = await this.priceFor(plan, routeId);
     const balance = this.deps.credits ? await this.deps.credits.balancePesewas(userId) : 0;
     const { appliedCreditPesewas, chargePesewas } = netCharge(price.pricePesewas, balance);
@@ -150,8 +165,55 @@ export class PaymentsService {
       ridesGranted: price.ridesGranted,
       farePesewas: price.farePesewas,
       creditPesewasPerRide: price.creditPesewasPerRide,
+      pickupStopId: stops.pickupStopId ?? null,
+      dropoffStopId: stops.dropoffStopId ?? null,
     });
     return { ...checkout, pricePesewas: price.pricePesewas, appliedCreditPesewas, chargePesewas };
+  }
+
+  /**
+   * Check the rider's chosen stops before taking any money.
+   *
+   * Both must sit on the route they are subscribing to, and pickup must come
+   * before drop-off in stop order. Boarding after your destination is not a
+   * thing, and catching it here beats discovering it when the van arrives.
+   *
+   * A no-op when neither stop was supplied, so clients predating #204 are
+   * unaffected, and when no route-stop store is wired.
+   *
+   * @param routeId - the corridor being subscribed to.
+   * @param stops - the rider's chosen pickup and drop-off.
+   * @param stops.pickupStopId - where they board.
+   * @param stops.dropoffStopId - where they alight.
+   * @throws InvalidStopsError when a stop is off-route or the pair is reversed.
+   */
+  private async assertStopsOnRoute(
+    routeId: string,
+    stops: { pickupStopId?: string; dropoffStopId?: string },
+  ): Promise<void> {
+    const { pickupStopId, dropoffStopId } = stops;
+    if (!pickupStopId && !dropoffStopId) return;
+    if (!this.deps.routeStops) return;
+    if (!pickupStopId || !dropoffStopId) {
+      throw new InvalidStopsError('Provide both pickupStopId and dropoffStopId, or neither');
+    }
+    if (pickupStopId === dropoffStopId) {
+      throw new InvalidStopsError('Pickup and drop-off cannot be the same stop');
+    }
+
+    const placements = await this.deps.routeStops.findByRoute(routeId);
+    const seqOf = (stopId: string) => placements.find((p) => p.stopId === stopId)?.seq;
+    const pickupSeq = seqOf(pickupStopId);
+    const dropoffSeq = seqOf(dropoffStopId);
+    if (pickupSeq === undefined) {
+      throw new InvalidStopsError(`Stop ${pickupStopId} is not on route ${routeId}`);
+    }
+    if (dropoffSeq === undefined) {
+      throw new InvalidStopsError(`Stop ${dropoffStopId} is not on route ${routeId}`);
+    }
+    if (pickupSeq >= dropoffSeq) {
+      throw new InvalidStopsError('Pickup must come before drop-off on the route');
+    }
   }
 
   /**
@@ -346,12 +408,20 @@ export class PaymentsService {
         userId,
         plan,
         routeId,
+        // Where they board and alight, chosen at checkout (#204).
+        pickupStopId: payment.pickupStopId,
+        dropoffStopId: payment.dropoffStopId,
         // The billing window this payment buys (#162).
         periodStart: period.start,
         periodEnd: period.end,
         // From the payment, so a fare change cannot move what this rider owes
         // (ADR-0015 §3). New prices apply at renewal.
-        pricePesewas: payment.amount,
+        //
+        // Cash charged PLUS credit applied: since #128 `amount` is only the
+        // cash half, and recording that alone would understate the period's
+        // price by whatever credit was spent, making revenue look worse than
+        // it was.
+        pricePesewas: payment.amount + payment.appliedCreditPesewas,
         ridesGranted: payment.ridesGranted,
         farePesewas: payment.farePesewas,
         creditPesewasPerRide: payment.creditPesewasPerRide,

--- a/services/api/src/modules/reservations/reservation.repository.pg.ts
+++ b/services/api/src/modules/reservations/reservation.repository.pg.ts
@@ -14,6 +14,8 @@ interface ReservationRow {
   id: string;
   user_id: string;
   trip_id: string | null;
+  pickup_stop_id: string | null;
+  dropoff_stop_id: string | null;
   travel_date: string; // pg returns DATE as 'YYYY-MM-DD'
   direction: ReservationDirection;
   status: ReservationStatus;
@@ -29,6 +31,8 @@ function toReservation(row: ReservationRow): Reservation {
     id: row.id,
     userId: row.user_id,
     tripId: row.trip_id,
+    pickupStopId: row.pickup_stop_id,
+    dropoffStopId: row.dropoff_stop_id,
     travelDate: row.travel_date,
     direction: row.direction,
     status: row.status,
@@ -70,11 +74,19 @@ export class PgReservationRepository implements ReservationRepository {
 
   async createPending(input: PendingReservation): Promise<Reservation> {
     const { rows } = await this.pool.query<ReservationRow>(
-      `INSERT INTO reservations (user_id, trip_id, travel_date, direction, status, source)
-       VALUES ($1, $2, $3, $4, 'pending', 'confirmation')
+      `INSERT INTO reservations (user_id, trip_id, travel_date, direction, status, source,
+                                 pickup_stop_id, dropoff_stop_id)
+       VALUES ($1, $2, $3, $4, 'pending', 'confirmation', $5, $6)
        ON CONFLICT (user_id, travel_date, direction) DO UPDATE SET updated_at = reservations.updated_at
        RETURNING *`,
-      [input.userId, input.tripId ?? null, input.travelDate, input.direction],
+      [
+        input.userId,
+        input.tripId ?? null,
+        input.travelDate,
+        input.direction,
+        input.pickupStopId ?? null,
+        input.dropoffStopId ?? null,
+      ],
     );
     return toReservation(rows[0]!);
   }

--- a/services/api/src/modules/reservations/reservation.repository.ts
+++ b/services/api/src/modules/reservations/reservation.repository.ts
@@ -34,6 +34,10 @@ export interface Reservation {
   userId: string;
   /** The trip, when known (no FK yet — trips are #18). */
   tripId: string | null;
+  /** Where the rider boards, frozen from the subscription when seeded (#204). */
+  pickupStopId: string | null;
+  /** Where the rider alights (#204). */
+  dropoffStopId: string | null;
   /** The travel day as `YYYY-MM-DD`. */
   travelDate: string;
   direction: ReservationDirection;
@@ -66,6 +70,9 @@ export interface PendingReservation {
   tripId?: string | null;
   travelDate: string;
   direction: ReservationDirection;
+  /** Copied from the rider's subscription when the row is seeded (#204). */
+  pickupStopId?: string | null;
+  dropoffStopId?: string | null;
 }
 
 /** Persistence for daily reservations (Postgres in prod, in-memory in dev/tests). */
@@ -232,6 +239,8 @@ export class InMemoryReservationRepository implements ReservationRepository {
       id: crypto.randomUUID(),
       userId: input.userId,
       tripId: input.tripId ?? null,
+      pickupStopId: null,
+      dropoffStopId: null,
       travelDate: input.travelDate,
       direction: input.direction,
       status,
@@ -253,6 +262,8 @@ export class InMemoryReservationRepository implements ReservationRepository {
       id: crypto.randomUUID(),
       userId: input.userId,
       tripId: input.tripId ?? null,
+      pickupStopId: input.pickupStopId ?? null,
+      dropoffStopId: input.dropoffStopId ?? null,
       travelDate: input.travelDate,
       direction: input.direction,
       status: 'pending',

--- a/services/api/src/modules/reservations/reservations.routes.ts
+++ b/services/api/src/modules/reservations/reservations.routes.ts
@@ -25,6 +25,8 @@ function toResponse(
 ): {
   id: string;
   tripId: string | null;
+  pickupStopId: string | null;
+  dropoffStopId: string | null;
   travelDate: string;
   direction: Reservation['direction'];
   status: Reservation['status'];
@@ -34,6 +36,8 @@ function toResponse(
   return {
     id: r.id,
     tripId: r.tripId,
+    pickupStopId: r.pickupStopId,
+    dropoffStopId: r.dropoffStopId,
     travelDate: r.travelDate,
     direction: r.direction,
     status: r.status,

--- a/services/api/src/modules/reservations/reservations.schema.ts
+++ b/services/api/src/modules/reservations/reservations.schema.ts
@@ -23,6 +23,9 @@ export const listReservationsQuerySchema = z.object({
 export const reservationResponseSchema = z.object({
   id: z.string().uuid(),
   tripId: z.string().nullable(),
+  /** Where this rider boards and alights on the day (#204). */
+  pickupStopId: z.string().nullable(),
+  dropoffStopId: z.string().nullable(),
   travelDate: z.string(),
   direction: directionSchema,
   status: z.enum([

--- a/services/api/src/modules/subscriptions/subscription.repository.pg.ts
+++ b/services/api/src/modules/subscriptions/subscription.repository.pg.ts
@@ -13,6 +13,8 @@ interface SubscriptionRow {
   plan: SubscriptionPlan;
   status: SubscriptionStatus;
   route_id: string | null;
+  pickup_stop_id: string | null;
+  dropoff_stop_id: string | null;
   price_pesewas: number | null;
   rides_granted: number | null;
   fare_pesewas: number | null;
@@ -29,6 +31,8 @@ function toSubscription(row: SubscriptionRow): Subscription {
     plan: row.plan,
     status: row.status,
     routeId: row.route_id,
+    pickupStopId: row.pickup_stop_id,
+    dropoffStopId: row.dropoff_stop_id,
     pricePesewas: row.price_pesewas,
     ridesGranted: row.rides_granted,
     farePesewas: row.fare_pesewas,
@@ -47,8 +51,8 @@ export class PgSubscriptionRepository implements SubscriptionRepository {
     const { rows } = await this.pool.query<SubscriptionRow>(
       `INSERT INTO subscriptions (user_id, plan, route_id,
                                   price_pesewas, rides_granted, fare_pesewas, credit_pesewas_per_ride,
-                                  period_start, period_end)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+                                  period_start, period_end, pickup_stop_id, dropoff_stop_id)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
        RETURNING *`,
       [
         input.userId,
@@ -60,6 +64,8 @@ export class PgSubscriptionRepository implements SubscriptionRepository {
         input.creditPesewasPerRide ?? null,
         input.periodStart ?? null,
         input.periodEnd ?? null,
+        input.pickupStopId ?? null,
+        input.dropoffStopId ?? null,
       ],
     );
     return toSubscription(rows[0]!);

--- a/services/api/src/modules/subscriptions/subscription.repository.ts
+++ b/services/api/src/modules/subscriptions/subscription.repository.ts
@@ -9,6 +9,10 @@ export interface Subscription {
   status: SubscriptionStatus;
   /** The rider's pinned route/corridor (E3); null for pre-E3 subscriptions. */
   routeId: string | null;
+  /** Where the rider boards (#204); null for subscriptions predating it. */
+  pickupStopId: string | null;
+  /** Where the rider alights (#204). */
+  dropoffStopId: string | null;
   /** What this rider actually paid, frozen at activation (#103). */
   pricePesewas: number | null;
   /** Rides granted for the period, frozen at activation. */
@@ -26,6 +30,10 @@ export interface Subscription {
 
 /** Fields needed to create a subscription. */
 export interface NewSubscription {
+  /** Where the rider boards (#204). */
+  pickupStopId?: string | null;
+  /** Where the rider alights (#204). */
+  dropoffStopId?: string | null;
   userId: string;
   plan: SubscriptionPlan;
   routeId?: string | null;
@@ -108,6 +116,8 @@ export class InMemorySubscriptionRepository implements SubscriptionRepository {
       plan: input.plan,
       status: 'active',
       routeId: input.routeId ?? null,
+      pickupStopId: input.pickupStopId ?? null,
+      dropoffStopId: input.dropoffStopId ?? null,
       pricePesewas: input.pricePesewas ?? null,
       ridesGranted: input.ridesGranted ?? null,
       farePesewas: input.farePesewas ?? null,

--- a/services/api/src/server.ts
+++ b/services/api/src/server.ts
@@ -302,6 +302,7 @@ async function main(): Promise<void> {
     users,
     paystack,
     pricing,
+    routeStops,
     ridesPerPeriod: PLACEHOLDER_RIDES_PER_PERIOD,
   });
 

--- a/services/api/tests/payments.service.test.ts
+++ b/services/api/tests/payments.service.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { InMemoryPaymentRepository } from '../src/modules/payments/payment.repository';
 import { FakePaystackClient, paystackSignature } from '../src/modules/payments/paystack.client';
 import {
+  InvalidStopsError,
   InvalidWebhookError,
   NotPricedError,
   PaymentsNotConfiguredError,
@@ -15,6 +16,7 @@ import { InMemoryEntitlementLedgerRepository } from '../src/modules/entitlements
 import { InMemoryCreditLedgerRepository } from '../src/modules/entitlements/credit-ledger.repository';
 import { InMemoryUserRepository } from '../src/modules/users/user.repository';
 import { InMemoryPricingRepository } from '../src/modules/payments/pricing.repository';
+import { InMemoryRouteStopRepository } from '../src/modules/mobility/route-stop.repository';
 import { MIN_CHARGE_PESEWAS } from '../src/modules/payments/pricing';
 
 const FAKE_SECRET = 'fake-paystack-secret';
@@ -28,6 +30,7 @@ function make(subscriptions: SubscriptionRepository = new InMemorySubscriptionRe
   const entitlements = new InMemoryEntitlementLedgerRepository();
   const pricing = new InMemoryPricingRepository();
   const credits = new InMemoryCreditLedgerRepository();
+  const routeStops = new InMemoryRouteStopRepository();
   const service = new PaymentsService({
     payments,
     subscriptions,
@@ -36,9 +39,10 @@ function make(subscriptions: SubscriptionRepository = new InMemorySubscriptionRe
     paystack: new FakePaystackClient(FAKE_SECRET),
     users: new InMemoryUserRepository(),
     pricing,
+    routeStops,
     ridesPerPeriod: RIDES,
   });
-  return { payments, subscriptions, entitlements, credits, pricing, service };
+  return { payments, subscriptions, entitlements, credits, pricing, routeStops, service };
 }
 
 /** A priced corridor: without a fare in force there is no price to charge. */
@@ -312,5 +316,119 @@ describe('credit-netted checkout (#128)', () => {
 
     // The second debit is clamped rather than driving the ledger negative.
     expect(await credits.balancePesewas('u1')).toBe(0);
+  });
+});
+
+describe('rider stop pin (#204)', () => {
+  const STOP_A = '22222222-2222-4222-8222-222222222222'; // seq 1
+  const STOP_B = '33333333-3333-4333-8333-333333333333'; // seq 2
+  const OFF_ROUTE = '44444444-4444-4444-8444-444444444444';
+
+  /** A priced corridor with two stops in order, which is what a real route has. */
+  async function withStops() {
+    const ctx = await priced();
+    await ctx.routeStops.create({ routeId: ROUTE, stopId: STOP_A, seq: 1 });
+    await ctx.routeStops.create({ routeId: ROUTE, stopId: STOP_B, seq: 2 });
+    return ctx;
+  }
+
+  it('freezes the chosen stops on the payment', async () => {
+    const { service, payments } = await withStops();
+    const { reference } = await service.initializeSubscription('u1', 'monthly', ROUTE, {
+      pickupStopId: STOP_A,
+      dropoffStopId: STOP_B,
+    });
+    expect(await payments.findByReference(reference)).toMatchObject({
+      pickupStopId: STOP_A,
+      dropoffStopId: STOP_B,
+    });
+  });
+
+  it('carries them onto the subscription when the webhook activates it', async () => {
+    const { service, subscriptions } = await withStops();
+    const { reference } = await service.initializeSubscription('u1', 'monthly', ROUTE, {
+      pickupStopId: STOP_A,
+      dropoffStopId: STOP_B,
+    });
+    const { body, signature } = chargeSuccess(reference);
+    await service.handleWebhook(body, signature);
+
+    expect(await subscriptions.findActiveByUser('u1')).toMatchObject({
+      pickupStopId: STOP_A,
+      dropoffStopId: STOP_B,
+    });
+  });
+
+  it('rejects a stop that is not on the route', async () => {
+    const { service } = await withStops();
+    await expect(
+      service.initializeSubscription('u1', 'monthly', ROUTE, {
+        pickupStopId: STOP_A,
+        dropoffStopId: OFF_ROUTE,
+      }),
+    ).rejects.toBeInstanceOf(InvalidStopsError);
+  });
+
+  it('rejects boarding after the destination', async () => {
+    const { service } = await withStops();
+    await expect(
+      service.initializeSubscription('u1', 'monthly', ROUTE, {
+        pickupStopId: STOP_B,
+        dropoffStopId: STOP_A,
+      }),
+    ).rejects.toBeInstanceOf(InvalidStopsError);
+  });
+
+  it('rejects the same stop for both', async () => {
+    const { service } = await withStops();
+    await expect(
+      service.initializeSubscription('u1', 'monthly', ROUTE, {
+        pickupStopId: STOP_A,
+        dropoffStopId: STOP_A,
+      }),
+    ).rejects.toBeInstanceOf(InvalidStopsError);
+  });
+
+  it('rejects one stop without the other', async () => {
+    const { service } = await withStops();
+    await expect(
+      service.initializeSubscription('u1', 'monthly', ROUTE, { pickupStopId: STOP_A }),
+    ).rejects.toBeInstanceOf(InvalidStopsError);
+  });
+
+  it('still works for clients that send no stops at all', async () => {
+    const { service, payments, subscriptions } = await withStops();
+    const { reference } = await service.initializeSubscription('u1', 'monthly', ROUTE);
+    expect(await payments.findByReference(reference)).toMatchObject({
+      pickupStopId: null,
+      dropoffStopId: null,
+    });
+    const { body, signature } = chargeSuccess(reference);
+    await service.handleWebhook(body, signature);
+    expect(await subscriptions.findActiveByUser('u1')).toMatchObject({ pickupStopId: null });
+  });
+});
+
+describe('subscription price records cash plus credit (#128 follow-up)', () => {
+  it('records the full period price, not just the cash charged', async () => {
+    const { service, subscriptions, credits } = await priced();
+    await credits.record({
+      userId: 'u1',
+      deltaPesewas: 5_000,
+      reason: 'month_end_conversion',
+      idempotencyKey: 'grant:u1',
+    });
+
+    const checkout = await service.initializeSubscription('u1', 'monthly', ROUTE);
+    expect(checkout.chargePesewas).toBe(FARE * RIDES - 5_000); // cash is netted
+
+    const { body, signature } = chargeSuccess(checkout.reference);
+    await service.handleWebhook(body, signature);
+
+    // ...but the period was still worth the full price. Recording only the cash
+    // half would make revenue look worse than it was.
+    expect(await subscriptions.findActiveByUser('u1')).toMatchObject({
+      pricePesewas: FARE * RIDES,
+    });
   });
 });

--- a/services/api/tests/positions.routes.test.ts
+++ b/services/api/tests/positions.routes.test.ts
@@ -8,6 +8,7 @@ import { InMemoryRouteRepository } from '../src/modules/mobility/route.repositor
 import { InMemoryStopRepository } from '../src/modules/mobility/stop.repository';
 import { InMemoryTripPositionRepository } from '../src/modules/mobility/trip-position.repository';
 import { InMemoryTripRepository } from '../src/modules/mobility/trip.repository';
+import { InMemoryReservationRepository } from '../src/modules/reservations/reservation.repository';
 
 const auth: AuthConfig = {
   secret: 'test-secret-at-least-32-characters-long-0000',
@@ -32,6 +33,7 @@ async function seed() {
   const trips = new InMemoryTripRepository();
   const drivers = new InMemoryDriverRepository();
   const tripPositions = new InMemoryTripPositionRepository();
+  const reservations = new InMemoryReservationRepository();
   const kv = new InMemoryKvStore();
 
   const route = await routes.create({ name: 'Circle → Kaneshie', description: null });
@@ -58,9 +60,10 @@ async function seed() {
     trips,
     drivers,
     tripPositions,
+    reservations,
     kv,
   });
-  return { app, trips, drivers, tripPositions, trip, driver };
+  return { app, trips, drivers, tripPositions, reservations, trip, driver, stops: [s1, s2, s3] };
 }
 
 const report = async (
@@ -219,5 +222,62 @@ describe('GET /trips/:id/position (latest position + ETA)', () => {
       headers: bearer(await access('rider-1')),
     });
     expect(res.statusCode).toBe(503);
+  });
+});
+
+describe("GET /trips/:id/position — the rider's own stop (#204)", () => {
+  it("picks out the caller's pickup stop from the ETA list", async () => {
+    const { app, trip, reservations, stops } = await seed();
+    await reservations.createPending({
+      userId: 'rider-1',
+      tripId: trip.id,
+      travelDate: '2026-07-08',
+      direction: 'morning',
+      pickupStopId: stops[1]!.id, // the middle stop, not the first
+      dropoffStopId: stops[2]!.id,
+    });
+    await report(app, trip.id, await access(DRIVER_USER, 'driver'));
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/trips/${trip.id}/position`,
+      headers: bearer(await access('rider-1')),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.riderStop).toMatchObject({ stopId: stops[1]!.id, name: 'Kwame Nkrumah' });
+    // and it is genuinely one of the entries, not a recomputation
+    expect(body.etaToStops).toContainEqual(body.riderStop);
+  });
+
+  it('is null for a rider with no reservation on this trip', async () => {
+    const { app, trip } = await seed();
+    await report(app, trip.id, await access(DRIVER_USER, 'driver'));
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/trips/${trip.id}/position`,
+      headers: bearer(await access('someone-else')),
+    });
+    expect(res.json().riderStop).toBeNull();
+  });
+
+  it('is null when the reservation predates stops being recorded', async () => {
+    const { app, trip, reservations } = await seed();
+    await reservations.createPending({
+      userId: 'rider-2',
+      tripId: trip.id,
+      travelDate: '2026-07-08',
+      direction: 'morning',
+    });
+    await report(app, trip.id, await access(DRIVER_USER, 'driver'));
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/trips/${trip.id}/position`,
+      headers: bearer(await access('rider-2')),
+    });
+    expect(res.json().riderStop).toBeNull();
   });
 });


### PR DESCRIPTION
Closes #204. First of the three blockers from the #199 review.

## The problem

Nothing recorded where a rider boards. Subscriptions held `route_id`, reservations held `trip_id`, and there was no `stop_id` in the schema at all.

`GET /trips/:id/position` returns `etaToStops[]`, an ETA to *every* stop on the route, and no client had any way to know which entry was theirs. The Vehicle Approaching and Ready to Board frames are entirely about the van arriving at *your* pickup, so both were unbuildable.

## What changes

Riders pick both stops at subscribe. From there the value is carried, not re-derived:

```
POST /payments/subscribe   validated against the route, frozen on the payment
        │
        ▼  charge.success
   subscription             copied from the payment at activation
        │
        ▼  ask-dispatch seeds the day
   reservation              copied again, frozen per travel day
```

That last copy is deliberate. Editing your subscription mid-month must not rewrite where yesterday's van was supposed to meet you, which matters the moment a no-show is disputed.

`GET /trips/:id/position` gains `riderStop`: the caller's own entry, already picked out of `etaToStops`. Served rather than left to clients because otherwise the rider app, driver app and ops console each reimplement the same "which of these is mine" lookup.

## Validation

Refuses a stop that isn't on the route, a reversed pair, the same stop twice, and one stop without the other. `400`, not `409`: the rider's choice is wrong, not our state.

## Backwards compatible

Both fields are optional on the request and nullable everywhere in the schema. @adomfosugit the commuter app keeps working untouched; the new fields are additive and you can adopt them when the subscribe screen is ready. Riders who subscribed before this have no stops and `riderStop` is simply `null`.

## One bug found along the way

Activation recorded `pricePesewas` as `payment.amount`, which since #128's credit netting is only the *cash* half. A rider who spent GHS 20 of credit had their period recorded GHS 20 cheaper than it was, quietly understating revenue in anything reading that column. Now records cash plus credit applied, with a test.

## Verification

480 tests (+11), coverage 91.94%. Migration 031 applied to a scratch DB: idempotent on re-run, and the FK rejects a stop that doesn't exist.