### PR TITLE
feat(api): rider-facing trip detail and route geometry (#205, #206)

### DIFF
--- a/docs/features/basemap.md
+++ b/docs/features/basemap.md
@@ -118,14 +118,18 @@ You can draw these today:
 - "2 of 4 stops" by comparing the route's stop count against what's left in
   `etaToStops`.
 
-What you can't draw is a route line that follows the road. We work out the actual
-path from our own GPS traces in #179, but nothing serves it, so the best you can
-do right now is a straight line between stops and it'll cut corners visibly. If
-the design needs the real thing, tell me and I'll expose it rather than have you
-approximate it.
+For the route line, call `GET /routes/:id/geometry`. You get the road-following
+path we derived from our own GPS traces when the corridor has run enough times,
+and a straight line through the stops when it hasn't. The `source` field says
+which you got, `traces` or `stops`, so you can render the fallback differently
+instead of implying it follows the road.
 
-Related, and flagged in #199: we don't record which stop a rider boards at, so
-you can't tell someone the van is approaching _their_ pickup from `etaToStops`.
+For "the van is approaching _your_ pickup", `GET /trips/:id/position` returns
+`riderStop`: the caller's own entry, already picked out of `etaToStops`. It's
+null when they have no reservation on that trip or no stop recorded.
+
+Riders choose a pickup and drop-off when they subscribe, and both come back on
+`GET /me/reservations` as well.
 
 ### Polling
 

--- a/services/api/src/app.ts
+++ b/services/api/src/app.ts
@@ -79,6 +79,7 @@ import type { FeatureFlagRepository } from './modules/flags/feature-flag.reposit
 import type { MinVersionRepository } from './modules/flags/min-version.repository';
 import type { RouteRepository } from './modules/mobility/route.repository';
 import type { StopRepository } from './modules/mobility/stop.repository';
+import type { RouteGeometryRepository } from './modules/mobility/route-geometry.repository';
 import type { TripRepository } from './modules/mobility/trip.repository';
 import {
   InMemoryTripPositionRepository,
@@ -152,6 +153,8 @@ export interface AppDeps {
   mapStyleDarkUrl?: string;
   /** Observed segment speeds (#181). Absent -> ETAs use the cold-start speed. */
   segmentSpeeds?: SegmentSpeedRepository;
+  /** Derived route shapes (#179), served by GET /routes/:id/geometry (#206). */
+  routeGeometry?: RouteGeometryRepository;
   /** Derives geometry + speeds from completed runs (#179, #181). */
   routeLearning?: RouteLearningService;
   /** Corridor fares + plan levers (#103); admin-editable, never constants. */
@@ -355,9 +358,11 @@ export async function buildApp(deps: AppDeps = {}): Promise<FastifyInstance> {
     routes: deps.routes,
     stops: deps.stops,
     routeStops: deps.routeStops,
+    routeGeometry: deps.routeGeometry,
   });
   await app.register(tripRoutes, {
     trips: deps.trips,
+    vehicles: deps.vehicles,
     rateLimit: deps.rateLimit ?? DEFAULT_RATE_LIMIT,
   });
   await app.register(positionRoutes, {

--- a/services/api/src/db/migrations/032_vehicle_identity.sql
+++ b/services/api/src/db/migrations/032_vehicle_identity.sql
@@ -1,0 +1,15 @@
+-- #205: what a rider needs to recognise the van pulling up.
+--
+-- We stored a plate and an internal label. The designs show "GT 1234-20 ·
+-- Toyota Hiace · Green | White", because on a corridor where several vans look
+-- alike the plate alone is not much help at 6am.
+--
+-- Nullable: the fleet already exists and ops can fill these in over time.
+ALTER TABLE vehicles
+  ADD COLUMN IF NOT EXISTS make   text,
+  ADD COLUMN IF NOT EXISTS colour text;
+
+COMMENT ON COLUMN vehicles.make IS
+  'Model as a rider would say it, e.g. "Toyota Hiace". Shown on the boarding card.';
+COMMENT ON COLUMN vehicles.colour IS
+  'Livery as a rider would describe it, e.g. "Green / White".';

--- a/services/api/src/modules/admin/admin.schema.ts
+++ b/services/api/src/modules/admin/admin.schema.ts
@@ -44,11 +44,16 @@ export const attachStopBodySchema = z.object({
 export const createVehicleBodySchema = z.object({
   registration: z.string().min(1),
   label: z.string().nullable().optional(),
+  /** What a rider sees on the boarding card (#205). */
+  make: z.string().nullable().optional(),
+  colour: z.string().nullable().optional(),
   capacity: z.number().int().nonnegative().optional(),
 });
 export const updateVehicleBodySchema = z.object({
   registration: z.string().min(1).optional(),
   label: z.string().nullable().optional(),
+  make: z.string().nullable().optional(),
+  colour: z.string().nullable().optional(),
   capacity: z.number().int().nonnegative().optional(),
 });
 

--- a/services/api/src/modules/mobility/mobility.routes.ts
+++ b/services/api/src/modules/mobility/mobility.routes.ts
@@ -9,8 +9,13 @@ import type { ZodTypeProvider } from 'fastify-type-provider-zod';
 import { z } from 'zod';
 import { errorResponseSchema } from '../../lib/schemas';
 import type { RouteStopRepository } from './route-stop.repository';
+import type { RouteGeometryRepository } from './route-geometry.repository';
 import type { RouteRepository } from './route.repository';
-import { routeResponseSchema, routeWithStopsResponseSchema } from './mobility.schema';
+import {
+  routeGeometryResponseSchema,
+  routeResponseSchema,
+  routeWithStopsResponseSchema,
+} from './mobility.schema';
 import type { StopRepository } from './stop.repository';
 
 /**
@@ -21,6 +26,7 @@ import type { StopRepository } from './stop.repository';
  * @param opts.routes - the route repository.
  * @param opts.stops - the stop repository.
  * @param opts.routeStops - the route-stop join repository.
+ * @param opts.routeGeometry - derived route shapes (#179); absent -> stop fallback.
  */
 export async function mobilityRoutes(
   app: FastifyInstance,
@@ -28,6 +34,8 @@ export async function mobilityRoutes(
     routes?: RouteRepository;
     stops?: StopRepository;
     routeStops?: RouteStopRepository;
+    /** Derived route shapes (#179). Absent -> the stop fallback is always used. */
+    routeGeometry?: RouteGeometryRepository;
   },
 ): Promise<void> {
   const r = app.withTypeProvider<ZodTypeProvider>();
@@ -82,6 +90,57 @@ export async function mobilityRoutes(
       );
 
       return { ...route, stops };
+    },
+  );
+
+  r.get(
+    '/routes/:id/geometry',
+    {
+      schema: {
+        tags: ['mobility'],
+        summary: 'The path a route follows, for drawing it on a map',
+        description:
+          'Returns the road-following path learned from completed runs (#179) when we ' +
+          'have one, and a straight line through the stops when we do not. `source` ' +
+          'tells you which you got, so a client can render the fallback differently ' +
+          'rather than pretending it follows the road.',
+        params: z.object({ id: z.string().uuid() }),
+        response: {
+          200: routeGeometryResponseSchema,
+          404: errorResponseSchema,
+          503: errorResponseSchema,
+        },
+      },
+    },
+    async (request, reply) => {
+      if (!opts.routes || !opts.routeStops || !opts.stops) {
+        return reply
+          .code(503)
+          .send({ error: 'unavailable', message: 'Mobility is not configured' });
+      }
+      const route = await opts.routes.findById(request.params.id);
+      if (!route) {
+        return reply.code(404).send({ error: 'not_found', message: 'Route not found' });
+      }
+
+      const learned = opts.routeGeometry ? await opts.routeGeometry.findByRoute(route.id) : null;
+      if (learned && learned.points.length > 0) {
+        return {
+          routeId: route.id,
+          points: learned.points.map((p) => ({ latitude: p.latitude, longitude: p.longitude })),
+          source: learned.source as 'traces' | 'matched' | 'manual',
+          runCount: learned.runCount,
+        };
+      }
+
+      // Cold start: a corridor we have never completed a run on still has to
+      // draw something, so fall back to the stops in order.
+      const routeStops = await opts.routeStops.findByRoute(route.id);
+      const points = (await Promise.all(routeStops.map((rs) => opts.stops!.findById(rs.stopId))))
+        .filter((s) => s !== null)
+        .map((s) => ({ latitude: s.latitude, longitude: s.longitude }));
+
+      return { routeId: route.id, points, source: 'stops' as const, runCount: 0 };
     },
   );
 }

--- a/services/api/src/modules/mobility/mobility.schema.ts
+++ b/services/api/src/modules/mobility/mobility.schema.ts
@@ -46,6 +46,29 @@ export const tripResponseSchema = z.object({
   createdAt: z.date(),
 });
 
+/**
+ * A trip as a rider sees it (#205): when it actually ran, and enough about the
+ * van to recognise it at the kerb.
+ *
+ * Deliberately not the fleet record. A rider needs the plate, the model and the
+ * colour; they do not need our internal label, seat count or vehicle id.
+ */
+export const riderTripResponseSchema = tripResponseSchema.extend({
+  /** When the driver started the run; null while scheduled. */
+  startedAt: z.date().nullable(),
+  /** When the driver ended it; null until completed. */
+  completedAt: z.date().nullable(),
+  /** How long the run took. Null until it has both timestamps. */
+  durationSeconds: z.number().int().nullable(),
+  vehicle: z
+    .object({
+      registration: z.string(),
+      make: z.string().nullable(),
+      colour: z.string().nullable(),
+    })
+    .nullable(),
+});
+
 // GET /trips filters: routeId narrows to one route's runs (optional — omit to
 // list all).
 export const listTripsQuerySchema = z.object({
@@ -61,6 +84,8 @@ export const vehicleResponseSchema = z.object({
   id: z.string().uuid(),
   registration: z.string(),
   label: z.string().nullable(),
+  make: z.string().nullable(),
+  colour: z.string().nullable(),
   capacity: z.number().int(),
   createdAt: z.date(),
 });
@@ -96,6 +121,23 @@ export const recordedPositionResponseSchema = z.object({
 // The trip's latest live position plus a deterministic ETA to each upcoming stop
 // along the route's ordered stops (system-design §7). etaToStops is empty when the
 // route has fewer than two stops or the vehicle is past the last stop.
+/**
+ * The path a route actually follows (#206), for drawing a line on the map.
+ *
+ * `source` says where it came from and is meant to be shown, not hidden:
+ * `traces` is the road-following path derived from completed runs (#179),
+ * `stops` is the straight-line fallback for a corridor that has not run enough
+ * times to have learned one yet. A client can render both; only one of them
+ * follows the road.
+ */
+export const routeGeometryResponseSchema = z.object({
+  routeId: z.string().uuid(),
+  points: z.array(z.object({ latitude: z.number(), longitude: z.number() })),
+  source: z.enum(['traces', 'matched', 'manual', 'stops']),
+  /** Completed runs the path was derived from. 0 for the stop fallback. */
+  runCount: z.number().int(),
+});
+
 export const livePositionResponseSchema = z.object({
   tripId: z.string().uuid(),
   position: z.object({

--- a/services/api/src/modules/mobility/trips.routes.ts
+++ b/services/api/src/modules/mobility/trips.routes.ts
@@ -12,10 +12,11 @@ import { errorResponseSchema } from '../../lib/schemas';
 import type { RateLimitConfig } from '../ratelimit/ratelimit.plugin';
 import {
   listTripsQuerySchema,
+  riderTripResponseSchema,
   tripListResponseSchema,
-  tripResponseSchema,
 } from './mobility.schema';
 import type { Trip, TripRepository } from './trip.repository';
+import type { VehicleRepository } from './vehicle.repository';
 
 // Map a stored trip to its public (client-facing) shape.
 function toResponse(t: Trip): {
@@ -44,11 +45,12 @@ function toResponse(t: Trip): {
  * @param app - the Fastify instance to register on.
  * @param opts - route dependencies.
  * @param opts.trips - the trip repository (503 when absent).
+ * @param opts.vehicles - vehicles, for the rider-facing van details (#205).
  * @param opts.rateLimit - rate-limit config (applied per user).
  */
 export async function tripRoutes(
   app: FastifyInstance,
-  opts: { trips?: TripRepository; rateLimit: RateLimitConfig },
+  opts: { trips?: TripRepository; vehicles?: VehicleRepository; rateLimit: RateLimitConfig },
 ): Promise<void> {
   const r = app.withTypeProvider<ZodTypeProvider>();
   const UNAVAILABLE = { error: 'unavailable', message: 'Trips are not configured' };
@@ -86,7 +88,7 @@ export async function tripRoutes(
         security: [{ bearerAuth: [] }],
         params: z.object({ id: z.string().uuid() }),
         response: {
-          200: tripResponseSchema,
+          200: riderTripResponseSchema,
           401: errorResponseSchema,
           404: errorResponseSchema,
           429: errorResponseSchema,
@@ -101,7 +103,24 @@ export async function tripRoutes(
       if (!trip) {
         return reply.code(404).send({ error: 'not_found', message: 'Trip not found' });
       }
-      return toResponse(trip);
+
+      // Only what a rider needs to pick the van out at the kerb (#205). The
+      // internal label, seat count and vehicle id stay on the fleet record.
+      const vehicle =
+        trip.vehicleId && opts.vehicles ? await opts.vehicles.findById(trip.vehicleId) : null;
+
+      return {
+        ...toResponse(trip),
+        startedAt: trip.startedAt,
+        completedAt: trip.completedAt,
+        durationSeconds:
+          trip.startedAt && trip.completedAt
+            ? Math.round((trip.completedAt.getTime() - trip.startedAt.getTime()) / 1000)
+            : null,
+        vehicle: vehicle
+          ? { registration: vehicle.registration, make: vehicle.make, colour: vehicle.colour }
+          : null,
+      };
     },
   );
 }

--- a/services/api/src/modules/mobility/vehicle.repository.pg.ts
+++ b/services/api/src/modules/mobility/vehicle.repository.pg.ts
@@ -6,6 +6,8 @@ interface VehicleRow {
   id: string;
   registration: string;
   label: string | null;
+  make: string | null;
+  colour: string | null;
   capacity: number;
   created_at: Date;
 }
@@ -15,6 +17,8 @@ function toVehicle(row: VehicleRow): Vehicle {
     id: row.id,
     registration: row.registration,
     label: row.label,
+    make: row.make,
+    colour: row.colour,
     capacity: row.capacity,
     createdAt: row.created_at,
   };
@@ -25,9 +29,15 @@ export class PgVehicleRepository implements VehicleRepository {
 
   async create(input: NewVehicle): Promise<Vehicle> {
     const { rows } = await this.pool.query<VehicleRow>(
-      `INSERT INTO vehicles (registration, label, capacity)
-       VALUES ($1, $2, $3) RETURNING *`,
-      [input.registration, input.label ?? null, input.capacity ?? 0],
+      `INSERT INTO vehicles (registration, label, make, colour, capacity)
+       VALUES ($1, $2, $3, $4, $5) RETURNING *`,
+      [
+        input.registration,
+        input.label ?? null,
+        input.make ?? null,
+        input.colour ?? null,
+        input.capacity ?? 0,
+      ],
     );
     return toVehicle(rows[0]!);
   }
@@ -51,8 +61,9 @@ export class PgVehicleRepository implements VehicleRepository {
     if (!existing) return null;
     const next = applyPatch(existing, patch);
     const { rows } = await this.pool.query<VehicleRow>(
-      `UPDATE vehicles SET registration = $2, label = $3, capacity = $4 WHERE id = $1 RETURNING *`,
-      [id, next.registration, next.label, next.capacity],
+      `UPDATE vehicles SET registration = $2, label = $3, make = $4, colour = $5, capacity = $6
+       WHERE id = $1 RETURNING *`,
+      [id, next.registration, next.label, next.make, next.colour, next.capacity],
     );
     return rows[0] ? toVehicle(rows[0]) : null;
   }

--- a/services/api/src/modules/mobility/vehicle.repository.ts
+++ b/services/api/src/modules/mobility/vehicle.repository.ts
@@ -10,6 +10,10 @@ export interface Vehicle {
   id: string;
   registration: string;
   label: string | null;
+  /** Model as a rider would say it, e.g. "Toyota Hiace" (#205). */
+  make: string | null;
+  /** Livery as a rider would describe it, e.g. "Green / White" (#205). */
+  colour: string | null;
   capacity: number;
   createdAt: Date;
 }
@@ -18,6 +22,8 @@ export interface Vehicle {
 export interface NewVehicle {
   registration: string;
   label?: string | null;
+  make?: string | null;
+  colour?: string | null;
   capacity?: number;
 }
 
@@ -65,6 +71,8 @@ export class InMemoryVehicleRepository implements VehicleRepository {
       id: crypto.randomUUID(),
       registration: input.registration,
       label: input.label ?? null,
+      make: input.make ?? null,
+      colour: input.colour ?? null,
       capacity: input.capacity ?? 0,
       createdAt: new Date(),
     };

--- a/services/api/src/server.ts
+++ b/services/api/src/server.ts
@@ -354,6 +354,7 @@ async function main(): Promise<void> {
   const app = await buildApp({
     users,
     accountDeletion,
+    routeGeometry,
     subscriptions,
     routes,
     stops,

--- a/services/api/tests/mobility.routes.test.ts
+++ b/services/api/tests/mobility.routes.test.ts
@@ -3,6 +3,7 @@ import { buildApp } from '../src/app';
 import { InMemoryRouteStopRepository } from '../src/modules/mobility/route-stop.repository';
 import { InMemoryRouteRepository } from '../src/modules/mobility/route.repository';
 import { InMemoryStopRepository } from '../src/modules/mobility/stop.repository';
+import { InMemoryRouteGeometryRepository } from '../src/modules/mobility/route-geometry.repository';
 
 async function appWithRepos() {
   const routes = new InMemoryRouteRepository();
@@ -117,5 +118,76 @@ describe('GET /routes/:id', () => {
       latitude: 5.6369,
       longitude: -0.1614,
     });
+  });
+});
+
+describe('GET /routes/:id/geometry (#206)', () => {
+  /** A route with three stops, plus an optional learned path. */
+  async function seedRoute(withGeometry: boolean) {
+    const routes = new InMemoryRouteRepository();
+    const stops = new InMemoryStopRepository();
+    const routeStops = new InMemoryRouteStopRepository();
+    const routeGeometry = new InMemoryRouteGeometryRepository();
+
+    const route = await routes.create({ name: 'Adenta to Airport City', description: null });
+    const a = await stops.create({ name: 'Adenta', latitude: 5.71, longitude: -0.16 });
+    const b = await stops.create({ name: 'Shiashie', latitude: 5.63, longitude: -0.18 });
+    const c = await stops.create({ name: 'Airport City', latitude: 5.6, longitude: -0.18 });
+    await routeStops.create({ routeId: route.id, stopId: a.id, seq: 1 });
+    await routeStops.create({ routeId: route.id, stopId: b.id, seq: 2 });
+    await routeStops.create({ routeId: route.id, stopId: c.id, seq: 3 });
+
+    if (withGeometry) {
+      await routeGeometry.save({
+        routeId: route.id,
+        // more points than stops: the whole point is that it bends with the road
+        points: [
+          { latitude: 5.71, longitude: -0.16 },
+          { latitude: 5.68, longitude: -0.165 },
+          { latitude: 5.65, longitude: -0.172 },
+          { latitude: 5.63, longitude: -0.18 },
+          { latitude: 5.6, longitude: -0.18 },
+        ],
+        source: 'traces',
+        runCount: 12,
+        stopDistances: new Map(),
+      });
+    }
+
+    const app = await buildApp({ routes, stops, routeStops, routeGeometry });
+    return { app, route };
+  }
+
+  it('returns the learned path when the corridor has run enough times', async () => {
+    const { app, route } = await seedRoute(true);
+    const res = await app.inject({ method: 'GET', url: `/routes/${route.id}/geometry` });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ routeId: route.id, source: 'traces', runCount: 12 });
+    // it bends with the road, so it has more points than the route has stops
+    expect(res.json().points.length).toBeGreaterThan(3);
+  });
+
+  it('falls back to the stops on a corridor that has never run', async () => {
+    const { app, route } = await seedRoute(false);
+    const res = await app.inject({ method: 'GET', url: `/routes/${route.id}/geometry` });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ source: 'stops', runCount: 0 });
+    // a straight line through the three stops, in order
+    expect(res.json().points).toEqual([
+      { latitude: 5.71, longitude: -0.16 },
+      { latitude: 5.63, longitude: -0.18 },
+      { latitude: 5.6, longitude: -0.18 },
+    ]);
+  });
+
+  it('404s for a route that does not exist', async () => {
+    const { app } = await seedRoute(false);
+    const res = await app.inject({
+      method: 'GET',
+      url: '/routes/00000000-0000-4000-8000-0000000000ff/geometry',
+    });
+    expect(res.statusCode).toBe(404);
   });
 });

--- a/services/api/tests/trips.routes.test.ts
+++ b/services/api/tests/trips.routes.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { buildApp } from '../src/app';
 import { createJwtService, type AuthConfig } from '../src/modules/auth/jwt';
 import { InMemoryTripRepository } from '../src/modules/mobility/trip.repository';
+import { InMemoryVehicleRepository } from '../src/modules/mobility/vehicle.repository';
 
 const auth: AuthConfig = {
   secret: 'test-secret-at-least-32-characters-long-0000',
@@ -137,5 +138,97 @@ describe('GET /trips/:id', () => {
       assignedDriverId: '00000000-0000-4000-8000-0000000000f2',
       status: 'active',
     });
+  });
+});
+
+describe('GET /trips/:id — what a rider sees (#205)', () => {
+  it('reports when the run started, ended, and how long it took', async () => {
+    const trips = new InMemoryTripRepository();
+    const app = await buildApp({ auth, trips });
+    const trip = await trips.create({
+      routeId: ROUTE_A,
+      status: 'completed',
+      scheduledAt: new Date('2026-07-08T06:30:00Z'),
+    });
+    await trips.update(trip.id, {
+      startedAt: new Date('2026-07-08T06:32:00Z'),
+      completedAt: new Date('2026-07-08T07:20:00Z'),
+    });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/trips/${trip.id}`,
+      headers: bearer(await token()),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({
+      status: 'completed',
+      durationSeconds: 48 * 60, // the "48 min" on the Trip Completed card
+    });
+  });
+
+  it('leaves duration null while the run is still going', async () => {
+    const { app, trips } = await appWithTrips();
+    const trip = await trips.create({
+      routeId: ROUTE_A,
+      status: 'active',
+      scheduledAt: new Date('2026-07-08T06:30:00Z'),
+    });
+    const res = await app.inject({
+      method: 'GET',
+      url: `/trips/${trip.id}`,
+      headers: bearer(await token()),
+    });
+    expect(res.json()).toMatchObject({ completedAt: null, durationSeconds: null });
+  });
+
+  it('returns the van a rider can recognise, and not the fleet record', async () => {
+    const trips = new InMemoryTripRepository();
+    const vehicles = new InMemoryVehicleRepository();
+    const van = await vehicles.create({
+      registration: 'GT 1234-20',
+      label: 'internal-only #7',
+      make: 'Toyota Hiace',
+      colour: 'Green / White',
+      capacity: 15,
+    });
+    const app = await buildApp({ auth, trips, vehicles });
+    const trip = await trips.create({
+      routeId: ROUTE_A,
+      vehicleId: van.id,
+      status: 'active',
+      scheduledAt: new Date('2026-07-08T06:30:00Z'),
+    });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/trips/${trip.id}`,
+      headers: bearer(await token()),
+    });
+
+    expect(res.json().vehicle).toEqual({
+      registration: 'GT 1234-20',
+      make: 'Toyota Hiace',
+      colour: 'Green / White',
+    });
+    // the internal label and seat count are deliberately not in the payload
+    expect(JSON.stringify(res.json())).not.toContain('internal-only');
+    expect(res.json().vehicle).not.toHaveProperty('capacity');
+  });
+
+  it('is null when no van has been assigned yet', async () => {
+    const { app, trips } = await appWithTrips();
+    const trip = await trips.create({
+      routeId: ROUTE_A,
+      status: 'scheduled',
+      scheduledAt: new Date('2026-07-08T06:30:00Z'),
+    });
+    const res = await app.inject({
+      method: 'GET',
+      url: `/trips/${trip.id}`,
+      headers: bearer(await token()),
+    });
+    expect(res.json().vehicle).toBeNull();
   });
 });


### PR DESCRIPTION
Closes #205
Closes #206

The last two blockers from the #199 review. Both are read paths the designs need that we simply never served.

## #205: the trip a rider is on

`GET /trips/:id/summary` is driver-only, so after boarding a reservation sat at `boarded` forever with nothing a rider's app could read to know the run had ended. The Trip Completed frame shows "Arrived 7:18 AM · 48 min" and had no source at all.

`GET /trips/:id` now carries `startedAt`, `completedAt` and `durationSeconds`. The timestamps already existed from migration 028; nothing was exposing them.

The same endpoint carries the van. We stored a plate and an internal label, but the designs show "GT 1234-20 · Toyota Hiace · Green | White", because on a corridor where several vans look alike a plate alone isn't much help at 6am. Vehicles gain `make` and `colour`, admin-editable.

Riders get exactly `registration`, `make`, `colour`. Not the internal label, not the seat count, not the vehicle id. There's a test asserting the label doesn't leak into the payload.

## #206: the line on the map

We derive the road a route actually follows from our own GPS traces (#179) and served it to nobody, so the best any client could draw was a straight polyline between stops that visibly cuts corners against the basemap.

`GET /routes/:id/geometry` returns the learned path where we have one, and the stop line where we don't. `source` says which, so a client can render the fallback differently rather than implying it follows the road. A brand-new corridor still draws something on day one.

## Verification

476 tests, coverage 92.05%. Migration 032 adds two nullable columns; the fleet already exists and ops can backfill.

Note this stacks conceptually on #207 (the stop pin) but doesn't depend on it, so they can merge in either order.

Also updates [docs/features/basemap.md](docs/features/basemap.md), which recorded both of these as known gaps.