### PR TITLE
fix(api): unseated reservations (#210) + alphanumeric boarding codes

### DIFF
--- a/docs/features/boarding.md
+++ b/docs/features/boarding.md
@@ -66,7 +66,7 @@ The trip's confirmed riders (driver only) — the photo pass.
 
 #### `POST /boarding/verify-pin`
 
-Board a rider by their daily 4-digit PIN (driver only) — verification layer 2.
+Board a rider by their daily boarding code (driver only) — verification layer 2.
 
 - **Auth:** `Bearer` + **role `driver`**. **Rate limit:** per user.
 - **Body:** `{ "reservationId": "<uuid>", "pin": "1234" }`

--- a/docs/features/reservations.md
+++ b/docs/features/reservations.md
@@ -28,15 +28,20 @@ Ask-dispatch targets a trip's riders via `findActiveByRoute(trip.routeId)`.
 One reservation per **rider × travel day × direction** (`morning` | `evening`).
 
 - **status:** `pending` (asked, awaiting reply) → `reserved` (travelling) |
-  `declined`; then `boarded` | `no_show` (E4), `released` (E6),
-  `operator_cancelled`.
+  `declined` | `unseated` (the trip filled up before the cutoff reached them,
+  #210 — terminal, no ride deducted); then `boarded` | `no_show` (E4),
+  `released` (E6), `operator_cancelled`.
 - **source:** `confirmation` (rider answered), `default` (no reply → defaulted),
   `standby` (E6).
 
 **Confirmation windows** (from the master doc; drive the future cron):
 morning ask 18:00–20:45, **cutoff 21:00**; evening ask 12:00–13:45,
 **cutoff 14:00**. At each cutoff, `markDefaultTravelling(date, direction)` flips
-the still-`pending` rows to `reserved`/`default`.
+the still-`pending` rows to `reserved`/`default`, oldest ask first. Once a trip's
+vehicle has no seats left the remaining rows become `unseated` rather than
+staying `pending`, so the rider is told the van filled up instead of being asked
+again about a seat they can't have. Trips with no vehicle assigned have no
+ceiling to enforce, so nobody is unseated on them.
 
 ---
 
@@ -50,7 +55,8 @@ Confirm or decline (an upsert per day+direction).
 - **Body:** `{ "tripId?": "<uuid>", "travelDate": "YYYY-MM-DD", "direction": "morning"|"evening", "travelling": true|false }`
 - **200:** the reservation `{ id, tripId, travelDate, direction, status, source, pin? }`
   (`reserved` when travelling, else `declined`). On a **confirm**, `pin` is the
-  rider's daily **4-digit boarding PIN** — returned **once** here; only its keyed
+  rider's daily **boarding code** (four characters, e.g. `B7K9`) — returned
+  **once** here; only its keyed
   hash (`daily_pin_hash`) is stored. The driver types it against the manifest to
   board (E4, `POST /boarding/verify-pin`). · **400** bad date · **401** · **429** · **503**
 

--- a/services/api/src/db/migrations/033_unseated_reservations.sql
+++ b/services/api/src/db/migrations/033_unseated_reservations.sql
@@ -1,0 +1,14 @@
+-- 033_unseated_reservations: a terminal status for riders the cutoff could not
+-- seat (#210). The capacity-aware default-yes skipped them and left them
+-- `pending`, which is indistinguishable from a rider who never answered — so
+-- the app kept asking them to confirm a trip they could not be on.
+--
+-- Distinct from the neighbours on purpose: `declined` is the rider's choice,
+-- `released` frees a seat to the standby pool (E6), and `operator_cancelled`
+-- means the whole run was pulled. This one is "the van filled up first".
+ALTER TABLE reservations DROP CONSTRAINT IF EXISTS reservations_status_check;
+ALTER TABLE reservations
+  ADD CONSTRAINT reservations_status_check CHECK (
+    status IN ('pending', 'reserved', 'declined', 'boarded', 'no_show',
+               'released', 'operator_cancelled', 'unseated')
+  );

--- a/services/api/src/modules/boarding/boarding.routes.ts
+++ b/services/api/src/modules/boarding/boarding.routes.ts
@@ -100,7 +100,7 @@ export async function boardingRoutes(
     {
       schema: {
         tags: ['boarding'],
-        summary: 'Board a rider via their daily 4-digit PIN (driver only)',
+        summary: 'Board a rider via their daily boarding code (driver only)',
         security: [{ bearerAuth: [] }],
         body: verifyPinBodySchema,
         response: {

--- a/services/api/src/modules/boarding/boarding.schema.ts
+++ b/services/api/src/modules/boarding/boarding.schema.ts
@@ -24,8 +24,15 @@ export const scanResponseSchema = z.object({
 export const verifyPinBodySchema = z.object({
   /** The reservation the driver picked off the manifest. */
   reservationId: z.string().uuid(),
-  /** The rider's daily 4-digit PIN. */
-  pin: z.string().regex(/^\d{4}$/, 'expected a 4-digit PIN'),
+  /**
+   * The rider's daily boarding code, case-insensitive (for example `B7K9`).
+   *
+   * Deliberately looser than the generator's alphabet: codes issued before the
+   * alphanumeric switch are four digits, including the `0` and `1` the new
+   * alphabet omits, and rejecting those at the edge would strand riders holding
+   * one. The HMAC comparison is the real gate.
+   */
+  pin: z.string().regex(/^[0-9A-Za-z]{4}$/, 'expected a 4-character boarding code'),
 });
 
 export const verifyPinResponseSchema = z.object({

--- a/services/api/src/modules/boarding/boarding.service.ts
+++ b/services/api/src/modules/boarding/boarding.service.ts
@@ -41,7 +41,7 @@ export interface VerifyScanResult {
 export interface VerifyPinInput {
   /** The reservation the driver picked off the manifest. */
   reservationId: string;
-  /** The 4-digit PIN the rider presented. */
+  /** The boarding code the rider presented, any case. */
   pin: string;
   /** The driver performing the verification. */
   scannedBy: string;

--- a/services/api/src/modules/reservations/pin.ts
+++ b/services/api/src/modules/reservations/pin.ts
@@ -1,39 +1,73 @@
-// Daily boarding PIN (ADR-0014, E4 layer 2). A rider gets a 4-digit code when
-// they confirm; the driver types it against the manifest to board offline. Low
-// entropy by design (4 digits), so the protection is layered: it's verified only
-// for a specific reservation the driver already sees on the manifest, the
-// verify endpoint is driver-gated + rate limited, and the stored value is a
-// KEYED hash (HMAC-SHA256 with the server secret) so a DB leak doesn't reveal it.
+// Daily boarding code (ADR-0014, E4 layer 2). A rider gets a short code when
+// they confirm; the driver types it against the manifest to board offline.
+// Four characters is still low entropy, so the protection stays layered: it's
+// verified only for a specific reservation the driver already sees on the
+// manifest, the verify endpoint is driver-gated + rate limited, and the stored
+// value is a KEYED hash (HMAC-SHA256 with the server secret) so a DB leak
+// doesn't reveal it.
 
 import { createHmac, randomInt, timingSafeEqual } from 'node:crypto';
 
 /**
- * Generate a random 4-digit PIN (`"0000"`–`"9999"`).
+ * Characters a boarding code can contain.
  *
- * @returns the plaintext PIN.
+ * Digits and uppercase letters minus the pairs people misread aloud or mistype
+ * off a phone screen: `0`/`O`, `1`/`I`/`L`, and `U` (which turns short codes
+ * into words nobody wants to read out). 30 characters gives 810,000 codes
+ * against 10,000 for the four-digit PIN this replaced. The full 36-character
+ * alphabet would reach 1.68m, but a driver retyping a code at the kerb in the
+ * dark is the likelier failure than someone guessing one.
+ */
+const CODE_ALPHABET = '23456789ABCDEFGHJKMNPQRSTVWXYZ';
+
+/** How many characters a generated boarding code has. */
+const CODE_LENGTH = 4;
+
+/**
+ * Generate a random boarding code (for example `B7K9`).
+ *
+ * @returns the plaintext code, uppercase.
  */
 export function generatePin(): string {
-  return String(randomInt(0, 10000)).padStart(4, '0');
+  let code = '';
+  for (let i = 0; i < CODE_LENGTH; i++) {
+    code += CODE_ALPHABET[randomInt(0, CODE_ALPHABET.length)];
+  }
+  return code;
 }
 
 /**
- * Keyed hash of a PIN for storage (HMAC-SHA256 with the server secret).
+ * Canonical form of a code as typed by a driver: trimmed and uppercased.
  *
- * @param pin - the plaintext PIN.
+ * Applied on both sides of the hash, so a driver typing `b7k9` boards the rider
+ * and the keypad doesn't have to force case. Digit-only codes issued before the
+ * alphanumeric switch are unaffected by uppercasing, so they keep verifying.
+ *
+ * @param pin - the code as presented.
+ * @returns the canonical code.
+ */
+export function normalizePin(pin: string): string {
+  return pin.trim().toUpperCase();
+}
+
+/**
+ * Keyed hash of a boarding code for storage (HMAC-SHA256 with the server secret).
+ *
+ * @param pin - the plaintext code.
  * @param secret - the server signing key.
  * @returns the hex-encoded hash.
  */
 export function hashPin(pin: string, secret: string): string {
-  return createHmac('sha256', secret).update(pin).digest('hex');
+  return createHmac('sha256', secret).update(normalizePin(pin)).digest('hex');
 }
 
 /**
- * Constant-time check of a PIN against a stored hash.
+ * Constant-time check of a boarding code against a stored hash.
  *
- * @param pin - the presented plaintext PIN.
- * @param hash - the stored hash (or null when the reservation has no PIN).
+ * @param pin - the presented plaintext code.
+ * @param hash - the stored hash (or null when the reservation has no code).
  * @param secret - the server signing key.
- * @returns whether the PIN matches.
+ * @returns whether the code matches.
  */
 export function verifyPin(pin: string, hash: string | null, secret: string): boolean {
   if (!hash) return false;

--- a/services/api/src/modules/reservations/reservation.repository.pg.ts
+++ b/services/api/src/modules/reservations/reservation.repository.pg.ts
@@ -196,6 +196,15 @@ export class PgReservationRepository implements ReservationRepository {
         }
         const free = remaining.get(row.trip_id)!;
         if (free <= 0) {
+          // Leaving this `pending` was #210: the rider kept being asked to
+          // confirm a seat that no longer existed, and nothing ever told them
+          // why. Terminal, and no ride is deducted.
+          await this.pool.query(
+            `UPDATE reservations
+               SET status = 'unseated', source = 'default', updated_at = now()
+             WHERE id = $1`,
+            [row.id],
+          );
           skippedFull++;
           continue;
         }

--- a/services/api/src/modules/reservations/reservation.repository.ts
+++ b/services/api/src/modules/reservations/reservation.repository.ts
@@ -16,7 +16,8 @@ export type ReservationStatus =
   | 'boarded' // verified onto the vehicle (E4)
   | 'no_show' // confirmed but didn't board — deducted (E4)
   | 'released' // freed to the standby pool (E6)
-  | 'operator_cancelled'; // Trotxi couldn't run it — no deduction
+  | 'operator_cancelled' // Trotxi couldn't run it — no deduction
+  | 'unseated'; // the van filled up before we reached them (#210) — no deduction
 
 /**
  * The statuses that occupy a seat (#161). A `no_show` deliberately does not:
@@ -118,9 +119,14 @@ export interface ReservationRepository {
    * day+direction to `reserved` (source `default`). Declined/confirmed rows are
    * untouched.
    *
+   * Riders the trip has no room for become `unseated` rather than staying
+   * `pending` (#210), so the app can say the van filled up instead of asking
+   * them again. Oldest first, so the ceiling falls on whoever was asked last.
+   *
    * @param travelDate - the travel day (`YYYY-MM-DD`).
    * @param direction - morning or evening.
-   * @returns how many reservations were defaulted.
+   * @param capacityOf - resolves a trip's seat ceiling; omit to skip the check.
+   * @returns how many were defaulted, and how many were left unseated.
    */
   markDefaultTravelling(
     travelDate: string,
@@ -317,6 +323,12 @@ export class InMemoryReservationRepository implements ReservationRepository {
         if (capacityOf && r.tripId) {
           const capacity = await capacityOf(r.tripId);
           if (capacity !== null && (await this.countSeatsTaken(r.tripId)) >= capacity) {
+            // Leaving this `pending` was #210: the rider kept being asked to
+            // confirm a seat that no longer existed, and nothing ever told them
+            // why. Terminal, and no ride is deducted.
+            r.status = 'unseated';
+            r.source = 'default';
+            r.updatedAt = now;
             skippedFull++;
             continue;
           }

--- a/services/api/src/modules/reservations/reservations.schema.ts
+++ b/services/api/src/modules/reservations/reservations.schema.ts
@@ -36,10 +36,12 @@ export const reservationResponseSchema = z.object({
     'no_show',
     'released',
     'operator_cancelled',
+    'unseated',
   ]),
   source: z.enum(['confirmation', 'default', 'standby']),
-  /** The daily 4-digit boarding PIN — returned ONLY when confirming (travelling
-   * true); the rider shows it if the QR can't be scanned. Absent otherwise. */
+  /** The daily boarding code (for example `B7K9`) — returned ONLY when
+   * confirming (travelling true); the rider shows it if the QR can't be
+   * scanned. Absent otherwise. */
   pin: z.string().optional(),
 });
 

--- a/services/api/tests/boarding.pin.test.ts
+++ b/services/api/tests/boarding.pin.test.ts
@@ -1,12 +1,12 @@
-// Daily PIN boarding (#20, E4 layer 2). A rider gets a 4-digit PIN on confirm;
-// the driver types it against the manifest to board offline — same debit as the
-// QR scan, idempotent per reservation.
+// Daily boarding-code boarding (#20, E4 layer 2). A rider gets a four-character
+// code on confirm; the driver types it against the manifest to board offline —
+// same debit as the QR scan, idempotent per reservation.
 
 import { describe, expect, it } from 'vitest';
 import { buildApp } from '../src/app';
 import { InMemoryReservationRepository } from '../src/modules/reservations/reservation.repository';
 import { InMemoryEntitlementLedgerRepository } from '../src/modules/entitlements/entitlement-ledger.repository';
-import { hashPin, verifyPin } from '../src/modules/reservations/pin';
+import { generatePin, hashPin, verifyPin } from '../src/modules/reservations/pin';
 import { createJwtService, type AuthConfig } from '../src/modules/auth/jwt';
 
 const auth: AuthConfig = {
@@ -74,7 +74,7 @@ describe('POST /me/reservations issues a PIN', () => {
   it('returns a 4-digit pin on confirm, none on decline, and never stores plaintext', async () => {
     const { app, reservations, riderToken, riderId } = await setup();
     const body = (await confirm(app, riderToken)).json();
-    expect(body.pin).toMatch(/^\d{4}$/);
+    expect(body.pin).toMatch(/^[23456789ABCDEFGHJKMNPQRSTVWXYZ]{4}$/);
     // stored value is the hash, not the plaintext
     const stored = await reservations.find(riderId, today(), 'morning');
     expect(stored?.pinHash).toBe(hashPin(body.pin, auth.secret));
@@ -138,9 +138,55 @@ describe('POST /boarding/verify-pin', () => {
     expect(res.json()).toMatchObject({ valid: false, reason: 'not_found', deducted: false });
   });
 
-  it('rejects a non-4-digit PIN (400)', async () => {
+  it('rejects a code that is not four characters (400)', async () => {
     const { app, driverToken } = await setup();
     const res = await verify(app, driverToken, crypto.randomUUID(), '12');
     expect(res.statusCode).toBe(400);
+  });
+
+  it('boards a rider whose code the driver typed in lowercase', async () => {
+    // The keypad should not have to force case, and a rejected board at the
+    // kerb costs far more than accepting either case here.
+    const { app, riderToken, driverToken } = await setup();
+    const confirmed = await confirm(app, riderToken);
+    const { id, pin } = confirmed.json();
+
+    const res = await verify(app, driverToken, id, String(pin).toLowerCase());
+    expect(res.json()).toMatchObject({ valid: true, reason: 'ok', deducted: true });
+  });
+});
+
+describe('boarding code generation', () => {
+  it('is four characters from the unambiguous alphabet', () => {
+    for (let i = 0; i < 200; i++) {
+      expect(generatePin()).toMatch(/^[23456789ABCDEFGHJKMNPQRSTVWXYZ]{4}$/);
+    }
+  });
+
+  it('never emits the characters drivers misread', () => {
+    // 0/O and 1/I/L are the pairs that turn a valid code into a failed board.
+    const codes = Array.from({ length: 500 }, () => generatePin()).join('');
+    expect(codes).not.toMatch(/[01ILOU]/);
+  });
+
+  it('is not the old 10,000-code space', () => {
+    // A weak assertion of a real property: over 200 draws from 810,000 codes,
+    // all-digit results should be vanishingly rare, and repeats rarer still.
+    const codes = new Set(Array.from({ length: 200 }, () => generatePin()));
+    expect(codes.size).toBeGreaterThan(190);
+  });
+
+  it('still verifies the digit PINs issued before the switch', () => {
+    // Outstanding codes were four digits. Uppercasing leaves them untouched,
+    // so nobody holding one gets stranded by the deploy.
+    const h = hashPin('0142', 'secret');
+    expect(verifyPin('0142', h, 'secret')).toBe(true);
+  });
+
+  it('verifies a generated code regardless of the case it is typed in', () => {
+    const code = generatePin();
+    const h = hashPin(code, 'secret');
+    expect(verifyPin(code.toLowerCase(), h, 'secret')).toBe(true);
+    expect(verifyPin(`  ${code.toLowerCase()}  `, h, 'secret')).toBe(true);
   });
 });

--- a/services/api/tests/seat-capacity.test.ts
+++ b/services/api/tests/seat-capacity.test.ts
@@ -114,4 +114,54 @@ describe('cutoff default-yes respects capacity', () => {
     const result = await repo.markDefaultTravelling(DATE, 'morning', async () => null);
     expect(result).toEqual({ defaulted: 4, skippedFull: 0 });
   });
+
+  it('marks the riders it could not seat `unseated`, not `pending` (#210)', async () => {
+    // Leaving them pending was the bug: the app kept asking them to confirm a
+    // seat that no longer existed, and nothing ever explained why.
+    const repo = new InMemoryReservationRepository();
+    await pending(repo, 4);
+
+    await repo.markDefaultTravelling(DATE, 'morning', async () => 2);
+
+    const statuses = (await repo.listForTrip(TRIP)).map((r) => r.status).sort();
+    expect(statuses).toEqual(['reserved', 'reserved', 'unseated', 'unseated']);
+    expect(await repo.listReserved(DATE, 'morning')).toHaveLength(2);
+  });
+
+  it('unseats the riders asked last, keeping the queue explainable', async () => {
+    const repo = new InMemoryReservationRepository();
+    await pending(repo, 3);
+
+    await repo.markDefaultTravelling(DATE, 'morning', async () => 1);
+
+    const byUser = new Map((await repo.listForTrip(TRIP)).map((r) => [r.userId, r.status]));
+    expect(byUser.get('p0')).toBe('reserved');
+    expect(byUser.get('p1')).toBe('unseated');
+    expect(byUser.get('p2')).toBe('unseated');
+  });
+
+  it('an unseated rider holds no seat and is never swept up as a no-show', async () => {
+    // The whole point of the status: they were never on the van, so they must
+    // not be charged a ride for missing it.
+    const repo = new InMemoryReservationRepository();
+    await pending(repo, 3);
+
+    await repo.markDefaultTravelling(DATE, 'morning', async () => 1);
+
+    expect(await repo.countSeatsTaken(TRIP)).toBe(1);
+    const reserved = await repo.listReserved(DATE, 'morning');
+    expect(reserved.every((r) => r.status === 'reserved')).toBe(true);
+    expect(reserved).toHaveLength(1);
+  });
+
+  it('leaves a second cutoff run with nothing to do', async () => {
+    const repo = new InMemoryReservationRepository();
+    await pending(repo, 3);
+
+    await repo.markDefaultTravelling(DATE, 'morning', async () => 1);
+    const again = await repo.markDefaultTravelling(DATE, 'morning', async () => 1);
+
+    // Unseated is terminal, so a re-run cannot resurrect or re-skip anyone.
+    expect(again).toEqual({ defaulted: 0, skippedFull: 0 });
+  });
 });


### PR DESCRIPTION
Two reservation-lifecycle changes. Closes #210, and implements the boarding code format agreed on #199.

## Riders the van had no room for (#210)

The capacity-aware cutoff already refused to default riders into seats that don't exist. It just did it silently: those reservations stayed `pending`, which is the same state as a rider who never answered. So the app kept asking them to confirm a seat that had gone, right up until the trip ran, and then nothing happened and nobody told them why. Ops couldn't distinguish a trip that turned riders away from one whose riders ignored the prompt.

They now become `unseated`, a terminal status set exactly where the skip already happened, in both repositories.

Kept distinct from its neighbours deliberately. `declined` is the rider's own choice, `released` frees a seat to the standby pool (E6), and `operator_cancelled` means we pulled the run. None of them say "the van filled up first".

No ride is deducted. `unseated` isn't seat-consuming, and `listReserved` only returns `reserved`, so the no-show sweep can't charge someone for missing a van that had no room for them. There's a test asserting that, because it's the part that would actually cost a rider money if it regressed.

Migration 033 verified against Postgres: `unseated` rejected before it, accepted after, bogus values still rejected, and a second run is a clean no-op.

## Boarding codes

Adopts `B7K9` from the designs. Four characters from digits plus uppercase letters, minus the pairs people misread off a phone screen or mistype at the kerb: `0`/`O`, `1`/`I`/`L`, and `U`. 810,000 codes against 10,000 for the four-digit PIN.

The full 36-character alphabet would reach 1.68m, but I'd rather have the smaller space than have a driver fail a board at 6am because they read `O` as `0`. `pin.ts` was already explicit that this layer is low-entropy by design and leans on driver gating, per-reservation scoping and rate limiting.

Codes are trimmed and uppercased on both sides of the hash, so the keypad doesn't have to force case and a driver typing `b7k9` boards the rider.

**Nothing is renamed on the wire.** Still the `pin` field, still `daily_pin_hash`, still `POST /boarding/verify-pin`. Renaming would break clients for no functional gain, and the driver app hasn't built its keypad yet, so the format change lands clean either way.

The verify schema accepts any four alphanumerics rather than just the generator's alphabet. Codes issued before this deploy are four digits, including the `0` and `1` the new alphabet omits, so a stricter regex would strand riders holding one mid-transition. The HMAC is the real gate. There's a test covering an old-format code still verifying.

## Checks

497 tests pass, 92.01% statements. Lint, typecheck, format and the migration-prefix guard all clean.

## Follow-ups, not in this PR

- `unseated` needs a design state. Raised with @mmbaccah on #199 alongside `no_show`, `declined` and `operator_cancelled`.
- Capacity is only enforced once a trip has a vehicle with a recorded capacity. Trips without one are treated as unlimited on purpose so ops can create runs before crewing them, which means a late small-bus assignment can still overfill a trip. Separate problem, worth its own issue.
- ADR-0014 still describes the four-digit PIN. Left as-is since it records a decision at a point in time.