### PR TITLE
feat(auth): Apple sign-in (#168)

### DIFF
--- a/docs/features/authentication.md
+++ b/docs/features/authentication.md
@@ -124,6 +124,27 @@ Sign in (or sign up on first use) with a Google ID token.
 - **200:** `{ "user": { id, displayName, phone, avatarUrl, role, createdAt }, "accessToken": "...", "refreshToken": "..." }`
 - **401** invalid token · **429** rate-limited · **503** sign-in not configured
 
+#### `POST /auth/apple`
+
+Sign in (or sign up on first use) with an Apple ID token. Same shape as
+`/auth/google`, because it is the same flow with a different verifier.
+
+- **Auth:** none. **Rate limit:** 10/min per IP.
+- **Body:** `{ "idToken": "<apple ID token>", "fullName?": "Ama Serwaa", "nonce?": "<raw nonce>" }`
+- **200:** identical to `/auth/google`
+- **401** invalid token · **429** rate-limited · **503** Apple sign-in not configured
+
+`fullName` matters more than it looks. Apple returns the user's name **once**, on
+the first authorization only, and it is not in the ID token at all. If the client
+does not send it on that first call it is gone permanently, and the rider shows up
+as "New User" on every driver manifest from then on. It is client-supplied rather
+than a signed claim, so the server only uses it when creating the account. It can
+never rename an existing user.
+
+`nonce` is the raw value the client hashed into the authorization request. Send it
+and a replayed token is rejected; omit it and the token is still verified for
+signature, issuer, audience and expiry.
+
 #### `POST /auth/refresh`
 
 Exchange a refresh token for a new pair (**rotates** — the old refresh token is invalidated).
@@ -175,21 +196,39 @@ Register this device's **FCM push token** (foundation for notifications).
   not trigger this.
 - **Revocation:** logout sets `revoked_at`.
 
-### The verifier (how Google is wired)
+### The verifiers (how Google and Apple are wired)
 
-`AuthService` depends on an `IdTokenVerifier` interface, selected at startup:
+`AuthService` holds one `IdTokenVerifier` per provider, each selected
+independently at startup. That independence is the point: Apple's credentials
+come from a different lane and arrive later, and a missing `APPLE_CLIENT_ID` must
+never take working Google sign-in down with it.
 
-| Condition              | Verifier                                                                  | `/auth/google`                  |
-| ---------------------- | ------------------------------------------------------------------------- | ------------------------------- |
-| `GOOGLE_CLIENT_ID` set | **GoogleIdTokenVerifier** (jose JWKS; checks signature, issuer, audience) | real sign-in                    |
-| unset, non-production  | **FakeIdTokenVerifier**                                                   | dev/test (see below)            |
-| unset, production      | none                                                                      | **503** (keeps staging booting) |
+| Condition                | Verifier                                                                 | That provider's route           |
+| ------------------------ | ------------------------------------------------------------------------ | ------------------------------- |
+| provider's client id set | **Google/AppleIdTokenVerifier** (jose JWKS; signature, issuer, audience) | real sign-in                    |
+| unset, non-production    | **FakeIdTokenVerifier**                                                  | dev/test (see below)            |
+| unset, production        | none                                                                     | **503** (keeps staging booting) |
+
+Apple differs from Google in three ways worth knowing before debugging it:
+
+- **No name in the token.** See `POST /auth/apple` above.
+- **Two audiences.** Native iOS sign-in presents the app's bundle id; the
+  Android and web flow presents the Services ID. `APPLE_CLIENT_ID` is therefore
+  comma-separated, and an app shipping on both platforms needs both listed.
+- **Booleans arrive as strings.** Apple sends `email_verified` and
+  `is_private_email` as either `true` or `"true"` depending on the flow, so the
+  verifier accepts both. Parsing them strictly rejects real sign-ins.
+
+A `@privaterelay.appleid.com` address is stored like any other. It is a real,
+deliverable address that forwards to the rider, and discarding it would make them
+uncontactable for the sake of tidiness.
 
 ### Configuration (Part 2)
 
 | Env var                | Default | Notes                                                                                                                                         |
 | ---------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
 | `GOOGLE_CLIENT_ID`     | unset   | the Google **"Web"** OAuth client ID = the token audience. **Public, not a secret.** No client _secret_ needed (we only verify the ID token). |
+| `APPLE_CLIENT_ID`      | unset   | Apple audiences, **comma-separated**: the iOS bundle id and the Services ID. **Public, not a secret.** Unset → `/auth/apple` returns 503.     |
 | `JWT_REFRESH_TTL_DAYS` | `30`    | refresh-token lifetime                                                                                                                        |
 
 > The mobile apps additionally need **Android + iOS** OAuth client IDs in the
@@ -199,7 +238,7 @@ Register this device's **FCM push token** (foundation for notifications).
 
 ## Rate limiting
 
-`/auth/google` and `/auth/refresh` are capped at **10 requests/min per IP** (the
+`/auth/google`, `/auth/apple` and `/auth/refresh` are capped at **10 requests/min per IP** (the
 credential-endpoint brute-force guard). `/me` is limited per user. Over the
 limit → **429** with a `Retry-After` header. Backed by the KV store (in-memory
 in dev, Redis in prod); it **fails open** if the store is down.

--- a/docs/features/authentication.md
+++ b/docs/features/authentication.md
@@ -130,7 +130,7 @@ Sign in (or sign up on first use) with an Apple ID token. Same shape as
 `/auth/google`, because it is the same flow with a different verifier.
 
 - **Auth:** none. **Rate limit:** 10/min per IP.
-- **Body:** `{ "idToken": "<apple ID token>", "fullName?": "Ama Serwaa", "nonce?": "<raw nonce>" }`
+- **Body:** `{ "idToken": "<apple ID token>", "fullName?": "Ama Serwaa", "nonce?": "<raw nonce>", "authorizationCode?": "<one-time code>" }`
 - **200:** identical to `/auth/google`
 - **401** invalid token · **429** rate-limited · **503** Apple sign-in not configured
 
@@ -144,6 +144,15 @@ never rename an existing user.
 `nonce` is the raw value the client hashed into the authorization request. Send it
 and a replayed token is rejected; omit it and the token is still verified for
 signature, issuer, audience and expiry.
+
+`authorizationCode` is Apple's one-time code, sent on first authorization. The
+server trades it for a refresh token and stores that against the identity, for
+one purpose: `DELETE /me` has to revoke our access at Apple, and revoking needs a
+token that verifying an ID token never produces. Apple requires this of any app
+offering both Sign in with Apple and account deletion, and checks it at review.
+Omit the code and sign-in still works; only revocation is lost. The exchange is
+best effort, so Apple's token endpoint being down delays nothing at the login
+screen.
 
 #### `POST /auth/refresh`
 
@@ -229,6 +238,9 @@ uncontactable for the sake of tidiness.
 | ---------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
 | `GOOGLE_CLIENT_ID`     | unset   | the Google **"Web"** OAuth client ID = the token audience. **Public, not a secret.** No client _secret_ needed (we only verify the ID token). |
 | `APPLE_CLIENT_ID`      | unset   | Apple audiences, **comma-separated**: the iOS bundle id and the Services ID. **Public, not a secret.** Unset → `/auth/apple` returns 503.     |
+| `APPLE_TEAM_ID`        | unset   | Apple Developer team id. Public. Needed only for the code exchange and revocation.                                                            |
+| `APPLE_KEY_ID`         | unset   | Key ID of the Sign in with Apple `.p8`. Public.                                                                                               |
+| `APPLE_PRIVATE_KEY`    | unset   | The `.p8` key itself, PKCS#8 PEM. **A real secret** — Render dashboard only, never the blueprint. Unset → no exchange and no revocation.      |
 | `JWT_REFRESH_TTL_DAYS` | `30`    | refresh-token lifetime                                                                                                                        |
 
 > The mobile apps additionally need **Android + iOS** OAuth client IDs in the

--- a/render.yaml
+++ b/render.yaml
@@ -91,6 +91,16 @@ services:
       # Waiting on the Apple Developer team + App ID + Services ID (FE lane).
       # - key: APPLE_CLIENT_ID
       #   value: com.trotxi.trotxiCommuter,<Services ID>
+      # Sign in with Apple signing key (#213), for the code exchange and the
+      # revocation DELETE /me must perform. Team id and key id are public; the
+      # .p8 itself is a SECRET, so it is dashboard-managed (sync: false) and
+      # never appears here. All three unset -> no exchange, no revocation.
+      # - key: APPLE_TEAM_ID
+      #   value: <Apple Developer team id>
+      # - key: APPLE_KEY_ID
+      #   value: <Key ID of the .p8>
+      # - key: APPLE_PRIVATE_KEY
+      #   sync: false
       # Observability (#28). Set in the dashboard when Grafana Cloud is wired up.
       # METRICS_TOKEN gates GET /metrics (scraper sends it as a bearer token);
       # unset -> /metrics is disabled (404) in production.

--- a/render.yaml
+++ b/render.yaml
@@ -90,7 +90,7 @@ services:
       # why Google sign-in is unaffected while this is still blank.
       # Waiting on the Apple Developer team + App ID + Services ID (FE lane).
       # - key: APPLE_CLIENT_ID
-      #   value: com.trotxi.commuter,com.trotxi.commuter.signin
+      #   value: com.trotxi.trotxiCommuter,<Services ID>
       # Observability (#28). Set in the dashboard when Grafana Cloud is wired up.
       # METRICS_TOKEN gates GET /metrics (scraper sends it as a bearer token);
       # unset -> /metrics is disabled (404) in production.
@@ -360,7 +360,7 @@ services:
   #     # Apple audiences (#168), public for the same reason. iOS bundle id plus
   #     # the Services ID, comma-separated.
   #     - key: APPLE_CLIENT_ID
-  #       value: com.trotxi.commuter,com.trotxi.commuter.signin
+  #       value: com.trotxi.trotxiCommuter,<Services ID>
   #     # Unset in production -> /metrics is disabled (404) rather than left open.
   #     - key: METRICS_TOKEN
   #       sync: false

--- a/render.yaml
+++ b/render.yaml
@@ -83,6 +83,14 @@ services:
       # dashboard. Unset -> POST /auth/google returns 503.
       - key: GOOGLE_CLIENT_ID
         value: 431341307838-pc4m046v2lj18ssfnfl1g52fl5g1cg4q.apps.googleusercontent.com
+      # Apple audiences, comma-separated (#168). Also PUBLIC: the iOS bundle id
+      # and the Services ID both ship in clients. Native iOS sign-in presents the
+      # bundle id and the Android/web flow presents the Services ID, so both are
+      # listed once they exist. Unset -> POST /auth/apple returns 503, which is
+      # why Google sign-in is unaffected while this is still blank.
+      # Waiting on the Apple Developer team + App ID + Services ID (FE lane).
+      # - key: APPLE_CLIENT_ID
+      #   value: com.trotxi.commuter,com.trotxi.commuter.signin
       # Observability (#28). Set in the dashboard when Grafana Cloud is wired up.
       # METRICS_TOKEN gates GET /metrics (scraper sends it as a bearer token);
       # unset -> /metrics is disabled (404) in production.
@@ -349,6 +357,10 @@ services:
   #     # production project is created. Public by design, so it lives here.
   #     - key: GOOGLE_CLIENT_ID
   #       value: 431341307838-pc4m046v2lj18ssfnfl1g52fl5g1cg4q.apps.googleusercontent.com
+  #     # Apple audiences (#168), public for the same reason. iOS bundle id plus
+  #     # the Services ID, comma-separated.
+  #     - key: APPLE_CLIENT_ID
+  #       value: com.trotxi.commuter,com.trotxi.commuter.signin
   #     # Unset in production -> /metrics is disabled (404) rather than left open.
   #     - key: METRICS_TOKEN
   #       sync: false

--- a/services/api/src/config/env.ts
+++ b/services/api/src/config/env.ts
@@ -24,6 +24,13 @@ const envSchema = z
     // shipping on both platforms needs BOTH accepted. Set to enable real Apple
     // sign-in; unset -> dev fake verifier (non-prod) / 503 (prod).
     APPLE_CLIENT_ID: z.string().optional(),
+    // Sign in with Apple signing key, for the token + revocation endpoints
+    // (#213). TEAM_ID and KEY_ID are public; APPLE_PRIVATE_KEY is the .p8 and is
+    // a SECRET -> Render dashboard only, never the blueprint. All three unset ->
+    // codes aren't exchanged and deletion skips revocation.
+    APPLE_TEAM_ID: z.string().optional(),
+    APPLE_KEY_ID: z.string().optional(),
+    APPLE_PRIVATE_KEY: z.string().optional(),
     // Paystack SECRET key (sk_...). Used for the API + webhook signature check.
     // Set -> real payments; unset -> dev fake client (non-prod) / 503 (prod).
     PAYSTACK_SECRET_KEY: z.string().optional(),

--- a/services/api/src/config/env.ts
+++ b/services/api/src/config/env.ts
@@ -19,6 +19,11 @@ const envSchema = z
     // Google "Web" client ID — the audience verified on sign-in. Set to enable
     // real Google sign-in; unset -> dev fake verifier (non-prod) / 503 (prod).
     GOOGLE_CLIENT_ID: z.string().optional(),
+    // Apple audiences, comma-separated. Native iOS sign-in presents the app's
+    // bundle id; the web/Android flow presents the Services ID, so a Flutter app
+    // shipping on both platforms needs BOTH accepted. Set to enable real Apple
+    // sign-in; unset -> dev fake verifier (non-prod) / 503 (prod).
+    APPLE_CLIENT_ID: z.string().optional(),
     // Paystack SECRET key (sk_...). Used for the API + webhook signature check.
     // Set -> real payments; unset -> dev fake client (non-prod) / 503 (prod).
     PAYSTACK_SECRET_KEY: z.string().optional(),

--- a/services/api/src/db/migrations/034_apple_refresh_token.sql
+++ b/services/api/src/db/migrations/034_apple_refresh_token.sql
@@ -1,0 +1,12 @@
+-- 034_apple_refresh_token: keep Apple's refresh token so we can revoke it (#213).
+--
+-- Apple requires that an app offering both Sign in with Apple and account
+-- deletion calls their revocation endpoint on delete. Revoking needs a token,
+-- and verifying an ID token never yields one, so we exchange the authorization
+-- code at first sign-in and keep what it returns.
+--
+-- Unlike our OWN refresh tokens (stored hashed, since we only ever compare
+-- them), this one has to be replayable to be usable, so it is stored as issued.
+-- It is a provider credential: scoped to revocation and basic profile, but a
+-- credential. Null for Google, and for Apple sign-ins made before this landed.
+ALTER TABLE auth_identity ADD COLUMN IF NOT EXISTS provider_refresh_token text;

--- a/services/api/src/modules/auth/apple-token.client.apple.ts
+++ b/services/api/src/modules/auth/apple-token.client.apple.ts
@@ -1,0 +1,83 @@
+// Real Apple token client: exchanges authorization codes and revokes tokens.
+// Network-bound and key-signing, so excluded from unit coverage like the other
+// *.apple.ts / *.google.ts adapters — exercised against Apple directly.
+
+import { SignJWT, importPKCS8 } from 'jose';
+import type { AppleTokenClient, AppleTokens } from './apple-token.client';
+
+const APPLE_TOKEN_URL = 'https://appleid.apple.com/auth/token';
+const APPLE_REVOKE_URL = 'https://appleid.apple.com/auth/revoke';
+
+/** Apple caps the client secret at 6 months; 10 minutes is all a request needs. */
+const CLIENT_SECRET_TTL = '10m';
+
+/** Credentials for signing the client secret Apple's token endpoints require. */
+export interface AppleTokenClientConfig {
+  /** The Services ID or bundle id the code was issued to. */
+  clientId: string;
+  /** The Apple Developer team id. */
+  teamId: string;
+  /** The Key ID of the Sign in with Apple `.p8` key. */
+  keyId: string;
+  /** The `.p8` private key, PKCS#8 PEM. A SECRET — dashboard only. */
+  privateKey: string;
+}
+
+/** Apple's real token and revocation endpoints, authenticated with the `.p8`. */
+export class AppleHttpTokenClient implements AppleTokenClient {
+  /** @param config - the client id and signing credentials. */
+  constructor(private readonly config: AppleTokenClientConfig) {}
+
+  async exchangeCode(code: string): Promise<AppleTokens> {
+    const body = new URLSearchParams({
+      client_id: this.config.clientId,
+      client_secret: await this.clientSecret(),
+      code,
+      grant_type: 'authorization_code',
+    });
+    const res = await fetch(APPLE_TOKEN_URL, {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body,
+    });
+    if (!res.ok) {
+      throw new Error(`Apple code exchange failed (${res.status})`);
+    }
+    const json = (await res.json()) as { refresh_token?: string };
+    return { refreshToken: json.refresh_token ?? null };
+  }
+
+  async revoke(refreshToken: string): Promise<void> {
+    const body = new URLSearchParams({
+      client_id: this.config.clientId,
+      client_secret: await this.clientSecret(),
+      token: refreshToken,
+      token_type_hint: 'refresh_token',
+    });
+    const res = await fetch(APPLE_REVOKE_URL, {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body,
+    });
+    if (!res.ok) {
+      throw new Error(`Apple revocation failed (${res.status})`);
+    }
+  }
+
+  /**
+   * Mint the short-lived ES256 JWT Apple takes in place of a client secret.
+   *
+   * @returns the signed client secret.
+   */
+  private async clientSecret(): Promise<string> {
+    const key = await importPKCS8(this.config.privateKey, 'ES256');
+    return new SignJWT({})
+      .setProtectedHeader({ alg: 'ES256', kid: this.config.keyId })
+      .setIssuer(this.config.teamId)
+      .setAudience('https://appleid.apple.com')
+      .setSubject(this.config.clientId)
+      .setIssuedAt()
+      .setExpirationTime(CLIENT_SECRET_TTL)
+      .sign(key);
+  }
+}

--- a/services/api/src/modules/auth/apple-token.client.ts
+++ b/services/api/src/modules/auth/apple-token.client.ts
@@ -1,0 +1,54 @@
+// Apple's token endpoints (#213) — the half of the OAuth flow that verifying an
+// ID token skips.
+//
+// Sign-in itself needs none of this: we check the ID token against Apple's JWKS
+// and we're done. Revocation does. Apple requires an app offering both Sign in
+// with Apple and account deletion to revoke at delete time, and revoking needs a
+// token, which only the authorization-code exchange yields.
+//
+// The real client is network-bound and signs with a private key, so it lives in
+// *.apple.ts alongside the verifier and is excluded from unit coverage. The fake
+// is what dev and tests run against.
+
+/** What an authorization-code exchange gives us back. */
+export interface AppleTokens {
+  /** Apple's refresh token, when the exchange returned one. */
+  refreshToken: string | null;
+}
+
+/** Apple's token and revocation endpoints. */
+export interface AppleTokenClient {
+  /**
+   * Exchange a one-time authorization code for Apple's tokens.
+   *
+   * @param code - the authorization code from the client.
+   * @returns the tokens Apple issued.
+   * @throws when Apple rejects the exchange.
+   */
+  exchangeCode(code: string): Promise<AppleTokens>;
+  /**
+   * Revoke a refresh token, severing the link at Apple's end.
+   *
+   * @param refreshToken - the token to revoke.
+   * @throws when Apple rejects the revocation.
+   */
+  revoke(refreshToken: string): Promise<void>;
+}
+
+/**
+ * Dev/test client: records calls, talks to nobody. Wired outside production so
+ * the deletion path is exercisable without Apple credentials.
+ */
+export class FakeAppleTokenClient implements AppleTokenClient {
+  readonly exchanged: string[] = [];
+  readonly revoked: string[] = [];
+
+  async exchangeCode(code: string): Promise<AppleTokens> {
+    this.exchanged.push(code);
+    return { refreshToken: `fake-apple-refresh-${code}` };
+  }
+
+  async revoke(refreshToken: string): Promise<void> {
+    this.revoked.push(refreshToken);
+  }
+}

--- a/services/api/src/modules/auth/auth-identity.repository.pg.ts
+++ b/services/api/src/modules/auth/auth-identity.repository.pg.ts
@@ -11,6 +11,7 @@ interface AuthIdentityRow {
   user_id: string;
   provider: AuthProvider;
   provider_id: string;
+  provider_refresh_token: string | null;
   created_at: Date;
 }
 
@@ -20,6 +21,7 @@ function toAuthIdentity(row: AuthIdentityRow): AuthIdentity {
     userId: row.user_id,
     provider: row.provider,
     providerId: row.provider_id,
+    providerRefreshToken: row.provider_refresh_token,
     createdAt: row.created_at,
   };
 }
@@ -37,15 +39,30 @@ export class PgAuthIdentityRepository implements AuthIdentityRepository {
 
   async create(input: NewAuthIdentity): Promise<AuthIdentity> {
     const { rows } = await this.pool.query<AuthIdentityRow>(
-      `INSERT INTO auth_identity (user_id, provider, provider_id)
-       VALUES ($1, $2, $3)
+      `INSERT INTO auth_identity (user_id, provider, provider_id, provider_refresh_token)
+       VALUES ($1, $2, $3, $4)
        RETURNING *`,
-      [input.userId, input.provider, input.providerId],
+      [input.userId, input.provider, input.providerId, input.providerRefreshToken ?? null],
     );
     return toAuthIdentity(rows[0]!);
   }
 
   async deleteForUser(userId: string): Promise<void> {
     await this.pool.query('DELETE FROM auth_identity WHERE user_id = $1', [userId]);
+  }
+
+  async listForUser(userId: string): Promise<AuthIdentity[]> {
+    const { rows } = await this.pool.query<AuthIdentityRow>(
+      'SELECT * FROM auth_identity WHERE user_id = $1',
+      [userId],
+    );
+    return rows.map(toAuthIdentity);
+  }
+
+  async saveRefreshToken(id: string, refreshToken: string): Promise<void> {
+    await this.pool.query('UPDATE auth_identity SET provider_refresh_token = $2 WHERE id = $1', [
+      id,
+      refreshToken,
+    ]);
   }
 }

--- a/services/api/src/modules/auth/auth-identity.repository.ts
+++ b/services/api/src/modules/auth/auth-identity.repository.ts
@@ -11,6 +11,14 @@ export interface AuthIdentity {
   provider: AuthProvider;
   /** The provider's stable subject id. */
   providerId: string;
+  /**
+   * The provider's own refresh token, where we hold one (#213).
+   *
+   * Apple only, and only when the client sent an authorization code. Kept so
+   * account deletion can revoke our access at Apple rather than just forgetting
+   * the link locally. Null everywhere else.
+   */
+  providerRefreshToken: string | null;
   createdAt: Date;
 }
 
@@ -19,6 +27,7 @@ export interface NewAuthIdentity {
   userId: string;
   provider: AuthProvider;
   providerId: string;
+  providerRefreshToken?: string | null;
 }
 
 /** Persistence for provider-identity links; `(provider, providerId)` is unique. */
@@ -47,6 +56,25 @@ export interface AuthIdentityRepository {
    * @param userId - the user whose identities to unlink.
    */
   deleteForUser(userId: string): Promise<void>;
+  /**
+   * Every provider link for a user, read before deletion so we know what to
+   * revoke upstream (#213).
+   *
+   * @param userId - the user whose identities to list.
+   * @returns the user's linked identities.
+   */
+  listForUser(userId: string): Promise<AuthIdentity[]>;
+  /**
+   * Store (or replace) the provider refresh token on an existing link.
+   *
+   * Separate from `create` because a rider who signed in before we asked for
+   * authorization codes already has an identity row, and their next sign-in is
+   * the only chance to backfill it.
+   *
+   * @param id - the auth identity to update.
+   * @param refreshToken - the provider refresh token to keep.
+   */
+  saveRefreshToken(id: string, refreshToken: string): Promise<void>;
 }
 
 /** In-memory {@link AuthIdentityRepository} for dev and unit tests. */
@@ -67,14 +95,26 @@ export class InMemoryAuthIdentityRepository implements AuthIdentityRepository {
       userId: input.userId,
       provider: input.provider,
       providerId: input.providerId,
+      providerRefreshToken: input.providerRefreshToken ?? null,
       createdAt: new Date(),
     };
     this.identities.set(this.key(input.provider, input.providerId), identity);
     return identity;
   }
+
   async deleteForUser(userId: string): Promise<void> {
     for (const [key, identity] of this.identities) {
       if (identity.userId === userId) this.identities.delete(key);
+    }
+  }
+
+  async listForUser(userId: string): Promise<AuthIdentity[]> {
+    return [...this.identities.values()].filter((i) => i.userId === userId);
+  }
+
+  async saveRefreshToken(id: string, refreshToken: string): Promise<void> {
+    for (const identity of this.identities.values()) {
+      if (identity.id === id) identity.providerRefreshToken = refreshToken;
     }
   }
 }

--- a/services/api/src/modules/auth/auth.routes.ts
+++ b/services/api/src/modules/auth/auth.routes.ts
@@ -186,6 +186,7 @@ export async function authRoutes(
         return await opts.authService.signIn(request.body.idToken, 'apple', {
           displayName: request.body.fullName,
           nonce: request.body.nonce,
+          authorizationCode: request.body.authorizationCode,
         });
       } catch (err) {
         if (err instanceof SignInNotConfiguredError) {

--- a/services/api/src/modules/auth/auth.routes.ts
+++ b/services/api/src/modules/auth/auth.routes.ts
@@ -11,6 +11,7 @@ import { toUserResponse } from '../users/user.presenter';
 import type { UserRepository } from '../users/user.repository';
 import type { ObjectStore } from '../../storage/object-store';
 import {
+  appleSignInBodySchema,
   authResultSchema,
   googleSignInBodySchema,
   logoutBodySchema,
@@ -30,8 +31,8 @@ const AUTH_RATE_LIMIT = { max: 10, windowSeconds: 60 } as const;
 
 /**
  * Register the auth routes: `GET /me`, `GET /me/sessions`,
- * `DELETE /me/sessions/:id`, `POST /auth/google`, `POST /auth/refresh`,
- * `POST /auth/logout`.
+ * `DELETE /me/sessions/:id`, `POST /auth/google`, `POST /auth/apple`,
+ * `POST /auth/refresh`, `POST /auth/logout`.
  *
  * @param app - the Fastify instance to register on.
  * @param opts - route dependencies.
@@ -146,6 +147,46 @@ export async function authRoutes(
       }
       try {
         return await opts.authService.signIn(request.body.idToken);
+      } catch (err) {
+        if (err instanceof SignInNotConfiguredError) {
+          return reply
+            .code(503)
+            .send({ error: 'unavailable', message: 'Sign-in is not configured' });
+        }
+        return reply.code(401).send({ error: 'unauthorized', message: 'Invalid ID token' });
+      }
+    },
+  );
+
+  r.post(
+    '/auth/apple',
+    {
+      schema: {
+        tags: ['auth'],
+        summary: 'Sign in with an Apple ID token (creates the account on first use)',
+        description:
+          'Send `fullName` on the FIRST authorization only — Apple returns the name once ' +
+          'and never again, so a client that drops it strands the rider with a blank name ' +
+          'on the driver manifest. It is ignored for accounts that already exist.',
+        body: appleSignInBodySchema,
+        response: {
+          200: authResultSchema,
+          401: errorResponseSchema,
+          429: errorResponseSchema,
+          503: errorResponseSchema,
+        },
+      },
+      preHandler: [app.rateLimit({ ...AUTH_RATE_LIMIT, by: 'ip' })],
+    },
+    async (request, reply) => {
+      if (!opts.authService) {
+        return reply.code(503).send({ error: 'unavailable', message: 'Sign-in is not configured' });
+      }
+      try {
+        return await opts.authService.signIn(request.body.idToken, 'apple', {
+          displayName: request.body.fullName,
+          nonce: request.body.nonce,
+        });
       } catch (err) {
         if (err instanceof SignInNotConfiguredError) {
           return reply

--- a/services/api/src/modules/auth/auth.schema.ts
+++ b/services/api/src/modules/auth/auth.schema.ts
@@ -16,6 +16,13 @@ export const appleSignInBodySchema = z.object({
   idToken: z.string().min(1),
   fullName: z.string().max(200).optional(),
   nonce: z.string().max(200).optional(),
+  /**
+   * Apple's one-time authorization code, sent on first authorization. We trade
+   * it for a refresh token purely so account deletion can revoke our access at
+   * Apple, which Apple requires and checks at review (#213). Omit it and
+   * sign-in still works; only revocation is lost.
+   */
+  authorizationCode: z.string().max(500).optional(),
 });
 
 export const refreshBodySchema = z.object({

--- a/services/api/src/modules/auth/auth.schema.ts
+++ b/services/api/src/modules/auth/auth.schema.ts
@@ -5,6 +5,19 @@ export const googleSignInBodySchema = z.object({
   idToken: z.string().min(1),
 });
 
+/**
+ * Apple carries less in its token than Google does, so the client supplies the
+ * rest. `fullName` is Apple's one-time gift: returned on the first authorization
+ * only, never in the token, and gone forever if we don't store it then. `nonce`
+ * is the raw value the client hashed into the authorization request, letting us
+ * reject a replayed token.
+ */
+export const appleSignInBodySchema = z.object({
+  idToken: z.string().min(1),
+  fullName: z.string().max(200).optional(),
+  nonce: z.string().max(200).optional(),
+});
+
 export const refreshBodySchema = z.object({
   refreshToken: z.string().min(1),
 });

--- a/services/api/src/modules/auth/auth.service.ts
+++ b/services/api/src/modules/auth/auth.service.ts
@@ -8,13 +8,22 @@
 
 import type { JwtService } from './jwt';
 import type { AuthIdentityRepository } from './auth-identity.repository';
-import type { IdTokenVerifier, VerifiedIdentity } from './id-token-verifier';
+import type { AuthProvider, IdTokenVerifier, VerifiedIdentity } from './id-token-verifier';
 import type { Session, SessionRepository } from './session.repository';
 import { generateRefreshToken, hashToken } from './tokens';
 import type { User, UserRepository } from '../users/user.repository';
 
-/** Thrown when sign-in is attempted but no verifier is configured (prod without GOOGLE_CLIENT_ID). Routes map it to 503. */
+/** Thrown when sign-in is attempted for a provider with no verifier configured (prod without GOOGLE_CLIENT_ID / APPLE_CLIENT_ID). Routes map it to 503. */
 export class SignInNotConfiguredError extends Error {}
+
+/**
+ * The longest display name we'll accept from a client.
+ *
+ * Apple's name arrives as client-supplied input rather than a signed claim (see
+ * {@link AuthService.signIn}), so it needs a bound. Long enough for real Ghanaian
+ * names, which are routinely four or five parts.
+ */
+const MAX_DISPLAY_NAME = 80;
 
 /** Thrown when a refresh/logout token is missing, expired, or revoked. Routes map it to 401. */
 export class InvalidRefreshTokenError extends Error {}
@@ -46,8 +55,12 @@ export interface AuthServiceDeps {
   sessions: SessionRepository;
   /** Signs/verifies access tokens. */
   jwt: JwtService;
-  /** Undefined when sign-in isn't configured (e.g. prod without GOOGLE_CLIENT_ID). */
-  verifier?: IdTokenVerifier;
+  /**
+   * One verifier per provider. A provider absent from the map has sign-in
+   * disabled and its route answers 503, so Apple being unconfigured never takes
+   * Google down with it.
+   */
+  verifiers?: Partial<Record<AuthProvider, IdTokenVerifier>>;
   /** Refresh-token lifetime in days. */
   refreshTtlDays: number;
 }
@@ -62,6 +75,17 @@ function isUniqueViolation(err: unknown): boolean {
   return (err as { code?: string }).code === '23505';
 }
 
+/**
+ * Trim and bound a client-supplied display name, or null when there isn't one.
+ *
+ * @param name - the raw name from the request body.
+ * @returns a safe display name, or null.
+ */
+function cleanDisplayName(name?: string): string | null {
+  const trimmed = name?.trim();
+  return trimmed ? trimmed.slice(0, MAX_DISPLAY_NAME) : null;
+}
+
 /** Sign-in, refresh, and logout orchestration (see the file header). */
 export class AuthService {
   /** @param deps - repositories, the JWT service, and the ID-token verifier. */
@@ -71,17 +95,36 @@ export class AuthService {
    * Verify a provider ID token, find-or-create the matching user, and issue a
    * fresh access + refresh token pair.
    *
+   * `opts.displayName` exists for Apple, which returns the user's name exactly
+   * once — on the first authorization, outside the ID token — and never again.
+   * It is therefore client-supplied rather than a signed claim, so it is capped
+   * and used ONLY when creating the account. It can never rename an existing
+   * user, which is the difference between capturing a name we'd otherwise lose
+   * forever and letting any caller relabel someone else's account.
+   *
    * @param idToken - the provider ID token from the client.
+   * @param provider - which provider minted it.
+   * @param opts - optional extras the token itself cannot carry.
+   * @param opts.displayName - the name Apple returned on first authorization.
+   * @param opts.nonce - the raw nonce the client generated, for replay checking.
    * @returns the user and their new tokens.
-   * @throws SignInNotConfiguredError when no verifier is wired.
+   * @throws SignInNotConfiguredError when that provider has no verifier wired.
    * @throws when the ID token is invalid/untrusted (from the verifier).
    */
-  async signIn(idToken: string): Promise<AuthResult> {
-    if (!this.deps.verifier) {
+  async signIn(
+    idToken: string,
+    provider: AuthProvider = 'google',
+    opts: { displayName?: string; nonce?: string } = {},
+  ): Promise<AuthResult> {
+    const verifier = this.deps.verifiers?.[provider];
+    if (!verifier) {
       throw new SignInNotConfiguredError('Sign-in is not configured');
     }
-    const identity = await this.deps.verifier.verify(idToken); // throws if invalid
-    const { user, isNewUser } = await this.findOrCreateUser(identity);
+    const identity = await verifier.verify(idToken, opts.nonce); // throws if invalid
+    const { user, isNewUser } = await this.findOrCreateUser({
+      ...identity,
+      displayName: identity.displayName ?? cleanDisplayName(opts.displayName),
+    });
     const tokens = await this.issueTokens(user);
     return { user, isNewUser, ...tokens };
   }

--- a/services/api/src/modules/auth/auth.service.ts
+++ b/services/api/src/modules/auth/auth.service.ts
@@ -8,6 +8,7 @@
 
 import type { JwtService } from './jwt';
 import type { AuthIdentityRepository } from './auth-identity.repository';
+import type { AppleTokenClient } from './apple-token.client';
 import type { AuthProvider, IdTokenVerifier, VerifiedIdentity } from './id-token-verifier';
 import type { Session, SessionRepository } from './session.repository';
 import { generateRefreshToken, hashToken } from './tokens';
@@ -61,6 +62,12 @@ export interface AuthServiceDeps {
    * Google down with it.
    */
   verifiers?: Partial<Record<AuthProvider, IdTokenVerifier>>;
+  /**
+   * Apple's token endpoints (#213). Undefined when the signing key isn't
+   * configured, in which case codes are simply not exchanged and sign-in works
+   * exactly as before.
+   */
+  appleTokens?: AppleTokenClient;
   /** Refresh-token lifetime in days. */
   refreshTtlDays: number;
 }
@@ -107,6 +114,8 @@ export class AuthService {
    * @param opts - optional extras the token itself cannot carry.
    * @param opts.displayName - the name Apple returned on first authorization.
    * @param opts.nonce - the raw nonce the client generated, for replay checking.
+   * @param opts.authorizationCode - Apple's one-time code, exchanged for the
+   *   refresh token we need to revoke access when the account is deleted.
    * @returns the user and their new tokens.
    * @throws SignInNotConfiguredError when that provider has no verifier wired.
    * @throws when the ID token is invalid/untrusted (from the verifier).
@@ -114,19 +123,43 @@ export class AuthService {
   async signIn(
     idToken: string,
     provider: AuthProvider = 'google',
-    opts: { displayName?: string; nonce?: string } = {},
+    opts: { displayName?: string; nonce?: string; authorizationCode?: string } = {},
   ): Promise<AuthResult> {
     const verifier = this.deps.verifiers?.[provider];
     if (!verifier) {
       throw new SignInNotConfiguredError('Sign-in is not configured');
     }
     const identity = await verifier.verify(idToken, opts.nonce); // throws if invalid
-    const { user, isNewUser } = await this.findOrCreateUser({
-      ...identity,
-      displayName: identity.displayName ?? cleanDisplayName(opts.displayName),
-    });
+    const providerRefreshToken = await this.exchangeAppleCode(provider, opts.authorizationCode);
+    const { user, isNewUser } = await this.findOrCreateUser(
+      {
+        ...identity,
+        displayName: identity.displayName ?? cleanDisplayName(opts.displayName),
+      },
+      providerRefreshToken,
+    );
     const tokens = await this.issueTokens(user);
     return { user, isNewUser, ...tokens };
+  }
+
+  /**
+   * Trade Apple's authorization code for the refresh token we need at deletion.
+   *
+   * Best effort on purpose. A rider signing in should not be turned away because
+   * Apple's token endpoint is having a bad minute; the cost of failing is that we
+   * cannot revoke later, which is worth strictly less than the sign-in itself.
+   *
+   * @param provider - the provider being signed in with.
+   * @param code - the authorization code, when the client sent one.
+   * @returns the refresh token, or null when there is nothing to exchange.
+   */
+  private async exchangeAppleCode(provider: AuthProvider, code?: string): Promise<string | null> {
+    if (provider !== 'apple' || !code || !this.deps.appleTokens) return null;
+    try {
+      return (await this.deps.appleTokens.exchangeCode(code)).refreshToken;
+    } catch {
+      return null;
+    }
   }
 
   /**
@@ -227,16 +260,23 @@ export class AuthService {
    * winner's identity.
    *
    * @param identity - the verified provider identity.
+   * @param providerRefreshToken - Apple's refresh token, when we obtained one.
    * @returns the existing or newly created user.
    */
   private async findOrCreateUser(
     identity: VerifiedIdentity,
+    providerRefreshToken: string | null = null,
   ): Promise<{ user: User; isNewUser: boolean }> {
     const existing = await this.deps.authIdentities.findByProvider(
       identity.provider,
       identity.providerId,
     );
     if (existing) {
+      // Backfill for anyone who linked Apple before we started asking for codes:
+      // their next sign-in is the only chance to become revocable.
+      if (providerRefreshToken) {
+        await this.deps.authIdentities.saveRefreshToken(existing.id, providerRefreshToken);
+      }
       const user = await this.deps.users.findById(existing.userId);
       // Backfill the verified email for anyone who signed up before #182, so
       // existing riders become reachable on their next sign-in rather than
@@ -253,6 +293,7 @@ export class AuthService {
         userId: user.id,
         provider: identity.provider,
         providerId: identity.providerId,
+        providerRefreshToken,
       });
     } catch (err) {
       // Lost a concurrent first sign-in race — the identity now exists; reuse it.

--- a/services/api/src/modules/auth/id-token-verifier.apple.ts
+++ b/services/api/src/modules/auth/id-token-verifier.apple.ts
@@ -1,0 +1,92 @@
+// Real Apple ID-token verification: checks the signature against Apple's JWKS
+// and that the token was minted for OUR client (audience) by Apple (issuer).
+// Network-bound (fetches Apple's keys), so excluded from unit coverage like the
+// *.pg.ts adapters — exercised via real sign-in / manual testing.
+//
+// Two things differ from Google and both bite in production:
+//
+// 1. Apple's ID token carries NO name. The name is returned once, outside the
+//    token, on the very first authorization only. Capturing it is the client's
+//    job (see `POST /auth/apple`), not this verifier's.
+// 2. Apple sends `email_verified` and `is_private_email` as either booleans or
+//    the STRINGS "true"/"false", depending on the flow. Parsing them strictly as
+//    booleans rejects real sign-ins.
+
+import { createHash } from 'node:crypto';
+import { createRemoteJWKSet, jwtVerify } from 'jose';
+import { z } from 'zod';
+import type { IdTokenVerifier, VerifiedIdentity } from './id-token-verifier';
+
+const APPLE_JWKS = createRemoteJWKSet(new URL('https://appleid.apple.com/auth/keys'));
+const APPLE_ISSUER = 'https://appleid.apple.com';
+
+/** Apple's booleans arrive as `true` or as `"true"`. Accept both, default false. */
+const appleBoolean = z
+  .union([z.boolean(), z.enum(['true', 'false'])])
+  .optional()
+  .transform((v) => v === true || v === 'true');
+
+const appleClaimsSchema = z.object({
+  sub: z.string().min(1),
+  email: z.string().optional(),
+  email_verified: appleBoolean,
+  is_private_email: appleBoolean,
+  nonce: z.string().optional(),
+});
+
+/** Verifies Apple ID tokens for one or more of our client ids. */
+export class AppleIdTokenVerifier implements IdTokenVerifier {
+  /**
+   * @param clientIds - every audience we accept: the iOS bundle id for native
+   *   sign-in and the Services ID for the web/Android flow. They differ, and an
+   *   app that ships on both platforms presents both.
+   */
+  constructor(private readonly clientIds: string[]) {}
+
+  /**
+   * Verify an Apple ID token.
+   *
+   * @param idToken - the token from the client.
+   * @param expectedNonce - the raw nonce the client generated, when it used one.
+   * @returns the trusted identity.
+   */
+  async verify(idToken: string, expectedNonce?: string): Promise<VerifiedIdentity> {
+    const { payload } = await jwtVerify(idToken, APPLE_JWKS, {
+      issuer: APPLE_ISSUER,
+      audience: this.clientIds,
+    });
+    const claims = appleClaimsSchema.parse(payload);
+
+    if (claims.nonce && expectedNonce && !nonceMatches(claims.nonce, expectedNonce)) {
+      throw new Error('Apple nonce mismatch');
+    }
+
+    // A private-relay address is a real, deliverable address that forwards to
+    // the rider. Treating it as absent would make them uncontactable for the
+    // sake of tidiness.
+    return {
+      provider: 'apple',
+      providerId: claims.sub,
+      email: claims.email ?? null,
+      displayName: null,
+    };
+  }
+}
+
+/**
+ * Whether a token's nonce claim corresponds to the nonce the client generated.
+ *
+ * Apple echoes back exactly what the client sent, and clients differ: Apple's
+ * own guidance is to send the SHA-256 of a random string, which is what the
+ * Flutter and iOS SDKs do, while some send the raw value. Accepting either is
+ * the difference between replay protection that works and a login screen that
+ * rejects half our users.
+ *
+ * @param claim - the `nonce` claim from the verified token.
+ * @param expected - the raw nonce the client generated.
+ * @returns whether they correspond.
+ */
+export function nonceMatches(claim: string, expected: string): boolean {
+  if (claim === expected) return true;
+  return claim === createHash('sha256').update(expected).digest('hex');
+}

--- a/services/api/src/modules/auth/id-token-verifier.ts
+++ b/services/api/src/modules/auth/id-token-verifier.ts
@@ -1,7 +1,7 @@
 // Social sign-in verification. The AuthService depends on this interface, not on
-// any provider — so Google (and later Apple) are pluggable, and tests use the
-// fake. The real Google implementation (JWKS over the network) lives in
-// id-token-verifier.google.ts. See ADR-0007.
+// any provider — so Google and Apple are pluggable, and tests use the fake. The
+// real implementations (JWKS over the network) live in id-token-verifier.google.ts
+// and id-token-verifier.apple.ts. See ADR-0007.
 
 import { z } from 'zod';
 
@@ -22,10 +22,12 @@ export interface IdTokenVerifier {
    * Verify a provider ID token.
    *
    * @param idToken - the provider-issued ID token to verify.
+   * @param expectedNonce - the raw nonce the client generated, where it used one
+   *   (Apple). Providers that don't carry a nonce ignore it.
    * @returns the trusted identity extracted from it.
    * @throws if the token is invalid or untrusted.
    */
-  verify(idToken: string): Promise<VerifiedIdentity>;
+  verify(idToken: string, expectedNonce?: string): Promise<VerifiedIdentity>;
 }
 
 const fakeClaimsSchema = z.object({
@@ -36,10 +38,14 @@ const fakeClaimsSchema = z.object({
 
 /**
  * Dev/test verifier: the "token" is a JSON blob of claims. Lets the API and the
- * mobile app exercise the full sign-in flow with no Google setup. NEVER used in
- * production — the server only wires this outside production (see server.ts).
+ * mobile app exercise the full sign-in flow with no Google or Apple setup. NEVER
+ * used in production — the server only wires this outside production (see
+ * server.ts).
  */
 export class FakeIdTokenVerifier implements IdTokenVerifier {
+  /** @param provider - which provider this fake stands in for. */
+  constructor(private readonly provider: AuthProvider = 'google') {}
+
   async verify(idToken: string): Promise<VerifiedIdentity> {
     let raw: unknown;
     try {
@@ -49,7 +55,7 @@ export class FakeIdTokenVerifier implements IdTokenVerifier {
     }
     const claims = fakeClaimsSchema.parse(raw);
     return {
-      provider: 'google',
+      provider: this.provider,
       providerId: claims.sub,
       email: claims.email ?? null,
       displayName: claims.name ?? null,

--- a/services/api/src/modules/users/account-deletion.service.ts
+++ b/services/api/src/modules/users/account-deletion.service.ts
@@ -4,6 +4,7 @@
 //
 // Order matters — access is cut first, then provider links, then the PII.
 
+import type { AppleTokenClient } from '../auth/apple-token.client';
 import type { AuthIdentityRepository } from '../auth/auth-identity.repository';
 import type { SessionRepository } from '../auth/session.repository';
 import type { DeviceTokenRepository } from '../devices/device-token.repository';
@@ -17,6 +18,11 @@ export interface AccountDeletionDeps {
   authIdentities: AuthIdentityRepository;
   devices: DeviceTokenRepository;
   objectStore: ObjectStore;
+  /**
+   * Apple's token endpoints (#213). Undefined when unconfigured, in which case
+   * deletion behaves as it always did.
+   */
+  appleTokens?: AppleTokenClient;
 }
 
 /** Erases a user's personal data across every store that holds it. */
@@ -38,6 +44,12 @@ export class AccountDeletionService {
     await this.deps.sessions.revokeAllForUser(userId);
     await this.deps.devices.removeForUser(userId);
 
+    // Tell Apple before we forget the link. Apple requires an app offering both
+    // Sign in with Apple and account deletion to revoke here; unlinking on our
+    // side alone leaves us listed under the rider's Apple ID for an account that
+    // no longer exists, and it is checked at App Store review.
+    await this.revokeAppleAccess(userId);
+
     // Unlink providers, so signing in again creates a NEW user.
     await this.deps.authIdentities.deleteForUser(userId);
 
@@ -54,5 +66,27 @@ export class AccountDeletionService {
     // Keep the row and its id so the ledgers stay balanced.
     await this.deps.users.anonymise(userId);
     return true;
+  }
+
+  /**
+   * Revoke our access at Apple for every Apple identity on this account.
+   *
+   * Best effort. A rider asked us to delete their account, and Apple being
+   * unreachable is not a reason to refuse them, or to abandon the erasure
+   * half-done with their sessions already dead.
+   *
+   * @param userId - the account being erased.
+   */
+  private async revokeAppleAccess(userId: string): Promise<void> {
+    if (!this.deps.appleTokens) return;
+    const identities = await this.deps.authIdentities.listForUser(userId);
+    for (const identity of identities) {
+      if (identity.provider !== 'apple' || !identity.providerRefreshToken) continue;
+      try {
+        await this.deps.appleTokens.revoke(identity.providerRefreshToken);
+      } catch {
+        // Nothing useful to do: the account still has to go.
+      }
+    }
   }
 }

--- a/services/api/src/server.ts
+++ b/services/api/src/server.ts
@@ -16,7 +16,12 @@ import {
 } from './modules/auth/auth-identity.repository';
 import { PgAuthIdentityRepository } from './modules/auth/auth-identity.repository.pg';
 import { AuthService } from './modules/auth/auth.service';
-import { FakeIdTokenVerifier, type IdTokenVerifier } from './modules/auth/id-token-verifier';
+import {
+  FakeIdTokenVerifier,
+  type AuthProvider,
+  type IdTokenVerifier,
+} from './modules/auth/id-token-verifier';
+import { AppleIdTokenVerifier } from './modules/auth/id-token-verifier.apple';
 import { GoogleIdTokenVerifier } from './modules/auth/id-token-verifier.google';
 import { createJwtService, DEV_AUTH_CONFIG, type AuthConfig } from './modules/auth/jwt';
 import {
@@ -249,17 +254,33 @@ async function main(): Promise<void> {
     passTtlSeconds: 60,
   });
 
-  // Sign-in verifier: real Google when configured; a dev fake outside production;
-  // otherwise undefined (POST /auth/google returns 503 — keeps staging booting).
-  let verifier: IdTokenVerifier | undefined;
+  // Sign-in verifiers: real when configured; a dev fake outside production;
+  // otherwise absent (that provider's route returns 503 — keeps staging booting).
+  // Kept per-provider so an unconfigured Apple never takes Google down with it.
+  const verifiers: Partial<Record<AuthProvider, IdTokenVerifier>> = {};
   if (env.GOOGLE_CLIENT_ID) {
-    verifier = new GoogleIdTokenVerifier(env.GOOGLE_CLIENT_ID);
+    verifiers.google = new GoogleIdTokenVerifier(env.GOOGLE_CLIENT_ID);
     console.log('Using Google ID-token verifier');
   } else if (env.NODE_ENV !== 'production') {
-    verifier = new FakeIdTokenVerifier();
+    verifiers.google = new FakeIdTokenVerifier('google');
     console.warn('GOOGLE_CLIENT_ID not set — using FAKE sign-in verifier (non-production only).');
   } else {
     console.warn('GOOGLE_CLIENT_ID not set — sign-in disabled (POST /auth/google returns 503).');
+  }
+
+  if (env.APPLE_CLIENT_ID) {
+    const audiences = env.APPLE_CLIENT_ID.split(',')
+      .map((id) => id.trim())
+      .filter(Boolean);
+    verifiers.apple = new AppleIdTokenVerifier(audiences);
+    console.log(`Using Apple ID-token verifier (${audiences.length} audience(s))`);
+  } else if (env.NODE_ENV !== 'production') {
+    verifiers.apple = new FakeIdTokenVerifier('apple');
+    console.warn('APPLE_CLIENT_ID not set — using FAKE Apple verifier (non-production only).');
+  } else {
+    console.warn(
+      'APPLE_CLIENT_ID not set — Apple sign-in disabled (POST /auth/apple returns 503).',
+    );
   }
 
   const authService = new AuthService({
@@ -267,7 +288,7 @@ async function main(): Promise<void> {
     authIdentities,
     sessions,
     jwt: createJwtService(auth),
-    verifier,
+    verifiers,
     refreshTtlDays: env.JWT_REFRESH_TTL_DAYS,
   });
 

--- a/services/api/src/server.ts
+++ b/services/api/src/server.ts
@@ -21,6 +21,8 @@ import {
   type AuthProvider,
   type IdTokenVerifier,
 } from './modules/auth/id-token-verifier';
+import { FakeAppleTokenClient, type AppleTokenClient } from './modules/auth/apple-token.client';
+import { AppleHttpTokenClient } from './modules/auth/apple-token.client.apple';
 import { AppleIdTokenVerifier } from './modules/auth/id-token-verifier.apple';
 import { GoogleIdTokenVerifier } from './modules/auth/id-token-verifier.google';
 import { createJwtService, DEV_AUTH_CONFIG, type AuthConfig } from './modules/auth/jwt';
@@ -268,6 +270,28 @@ async function main(): Promise<void> {
     console.warn('GOOGLE_CLIENT_ID not set — sign-in disabled (POST /auth/google returns 503).');
   }
 
+  // Apple token client (#213): real when the .p8 key is configured, a recording
+  // fake outside production, otherwise absent — codes go unexchanged and deletion
+  // skips revocation, which is exactly the state before Apple sign-in is on.
+  let appleTokens: AppleTokenClient | undefined;
+  if (env.APPLE_CLIENT_ID && env.APPLE_TEAM_ID && env.APPLE_KEY_ID && env.APPLE_PRIVATE_KEY) {
+    appleTokens = new AppleHttpTokenClient({
+      // The code is issued to whichever audience the client used; the first is
+      // the native bundle id, which is the flow that sends codes.
+      clientId: env.APPLE_CLIENT_ID.split(',')[0]!.trim(),
+      teamId: env.APPLE_TEAM_ID,
+      keyId: env.APPLE_KEY_ID,
+      privateKey: env.APPLE_PRIVATE_KEY,
+    });
+    console.log('Using Apple token client (code exchange + revocation)');
+  } else if (env.NODE_ENV !== 'production') {
+    appleTokens = new FakeAppleTokenClient();
+  } else {
+    console.warn(
+      'Apple signing key not set — Apple tokens are not exchanged and DELETE /me will not revoke at Apple.',
+    );
+  }
+
   if (env.APPLE_CLIENT_ID) {
     const audiences = env.APPLE_CLIENT_ID.split(',')
       .map((id) => id.trim())
@@ -289,6 +313,7 @@ async function main(): Promise<void> {
     sessions,
     jwt: createJwtService(auth),
     verifiers,
+    appleTokens,
     refreshTtlDays: env.JWT_REFRESH_TTL_DAYS,
   });
 
@@ -313,6 +338,7 @@ async function main(): Promise<void> {
     authIdentities,
     devices: deviceTokens,
     objectStore,
+    appleTokens,
   });
 
   const paymentsService = new PaymentsService({

--- a/services/api/tests/auth-contactability.test.ts
+++ b/services/api/tests/auth-contactability.test.ts
@@ -19,7 +19,7 @@ function makeService(users = new InMemoryUserRepository()) {
     authIdentities: new InMemoryAuthIdentityRepository(),
     sessions: new InMemorySessionRepository(),
     jwt: createJwtService(authConfig),
-    verifier: new FakeIdTokenVerifier(),
+    verifiers: { google: new FakeIdTokenVerifier() },
     refreshTtlDays: 30,
   });
   return { service, users };

--- a/services/api/tests/auth.apple-revocation.test.ts
+++ b/services/api/tests/auth.apple-revocation.test.ts
@@ -1,0 +1,157 @@
+// Apple token revocation (#213). Apple requires an app offering both Sign in
+// with Apple and account deletion to revoke at Apple's end on delete, and
+// revoking needs a token that only the authorization-code exchange yields.
+
+import { describe, expect, it } from 'vitest';
+import { InMemoryAuthIdentityRepository } from '../src/modules/auth/auth-identity.repository';
+import { AuthService } from '../src/modules/auth/auth.service';
+import { FakeAppleTokenClient } from '../src/modules/auth/apple-token.client';
+import { FakeIdTokenVerifier } from '../src/modules/auth/id-token-verifier';
+import { createJwtService, type AuthConfig } from '../src/modules/auth/jwt';
+import { InMemorySessionRepository } from '../src/modules/auth/session.repository';
+import { InMemoryDeviceTokenRepository } from '../src/modules/devices/device-token.repository';
+import { AccountDeletionService } from '../src/modules/users/account-deletion.service';
+import { InMemoryUserRepository } from '../src/modules/users/user.repository';
+import { FakeObjectStore } from '../src/storage/object-store';
+
+const auth: AuthConfig = {
+  secret: 'test-secret-at-least-32-characters-long-0000',
+  accessTtl: '15m',
+  issuer: 'trotxi',
+  audience: 'trotxi-api',
+};
+
+function setup(withAppleTokens = true) {
+  const users = new InMemoryUserRepository();
+  const authIdentities = new InMemoryAuthIdentityRepository();
+  const appleTokens = new FakeAppleTokenClient();
+  const service = new AuthService({
+    users,
+    authIdentities,
+    sessions: new InMemorySessionRepository(),
+    jwt: createJwtService(auth),
+    verifiers: { apple: new FakeIdTokenVerifier('apple'), google: new FakeIdTokenVerifier() },
+    appleTokens: withAppleTokens ? appleTokens : undefined,
+    refreshTtlDays: 30,
+  });
+  const deletion = new AccountDeletionService({
+    users,
+    sessions: new InMemorySessionRepository(),
+    authIdentities,
+    devices: new InMemoryDeviceTokenRepository(),
+    objectStore: new FakeObjectStore(),
+    appleTokens: withAppleTokens ? appleTokens : undefined,
+  });
+  return { users, authIdentities, appleTokens, service, deletion };
+}
+
+const token = (sub: string) => JSON.stringify({ sub });
+
+describe('Apple authorization-code exchange', () => {
+  it('exchanges the code and keeps the refresh token against the identity', async () => {
+    const { service, authIdentities, appleTokens } = setup();
+    const result = await service.signIn(token('a-1'), 'apple', { authorizationCode: 'code-1' });
+
+    expect(appleTokens.exchanged).toEqual(['code-1']);
+    const [identity] = await authIdentities.listForUser(result.user.id);
+    expect(identity?.providerRefreshToken).toBe('fake-apple-refresh-code-1');
+  });
+
+  it('signs in normally when the client sends no code', async () => {
+    const { service, authIdentities, appleTokens } = setup();
+    const result = await service.signIn(token('a-2'), 'apple');
+
+    expect(appleTokens.exchanged).toEqual([]);
+    const [identity] = await authIdentities.listForUser(result.user.id);
+    expect(identity?.providerRefreshToken).toBeNull();
+  });
+
+  it('backfills a rider who linked Apple before we asked for codes', async () => {
+    const { service, authIdentities } = setup();
+    const first = await service.signIn(token('a-3'), 'apple');
+    await service.signIn(token('a-3'), 'apple', { authorizationCode: 'code-later' });
+
+    const [identity] = await authIdentities.listForUser(first.user.id);
+    expect(identity?.providerRefreshToken).toBe('fake-apple-refresh-code-later');
+  });
+
+  it('never exchanges a code for Google', async () => {
+    const { service, appleTokens } = setup();
+    await service.signIn(token('g-1'), 'google', { authorizationCode: 'code-1' });
+    expect(appleTokens.exchanged).toEqual([]);
+  });
+
+  it('still signs the rider in when Apple rejects the exchange', async () => {
+    // Losing revocation is bad. Turning a rider away at the login screen because
+    // Apple's token endpoint is having a bad minute is worse.
+    const { users, authIdentities } = setup();
+    const service = new AuthService({
+      users,
+      authIdentities,
+      sessions: new InMemorySessionRepository(),
+      jwt: createJwtService(auth),
+      verifiers: { apple: new FakeIdTokenVerifier('apple') },
+      appleTokens: {
+        exchangeCode: async () => {
+          throw new Error('apple is down');
+        },
+        revoke: async () => {},
+      },
+      refreshTtlDays: 30,
+    });
+
+    const result = await service.signIn(token('a-4'), 'apple', { authorizationCode: 'code-1' });
+    expect(result.accessToken).toBeTruthy();
+    const [identity] = await authIdentities.listForUser(result.user.id);
+    expect(identity?.providerRefreshToken).toBeNull();
+  });
+});
+
+describe('account deletion revokes at Apple', () => {
+  it('revokes the stored token before unlinking', async () => {
+    const { service, deletion, appleTokens } = setup();
+    const { user } = await service.signIn(token('a-1'), 'apple', { authorizationCode: 'code-1' });
+
+    expect(await deletion.deleteAccount(user.id)).toBe(true);
+    expect(appleTokens.revoked).toEqual(['fake-apple-refresh-code-1']);
+  });
+
+  it('has nothing to revoke for a Google-only account', async () => {
+    const { service, deletion, appleTokens } = setup();
+    const { user } = await service.signIn(token('g-1'), 'google');
+
+    await deletion.deleteAccount(user.id);
+    expect(appleTokens.revoked).toEqual([]);
+  });
+
+  it('still erases the account when Apple refuses the revocation', async () => {
+    // The rider asked to be deleted. Apple being unreachable cannot leave the
+    // erasure half-done with their sessions already dead.
+    const { users, authIdentities, service } = setup();
+    const { user } = await service.signIn(token('a-1'), 'apple', { authorizationCode: 'code-1' });
+    const deletion = new AccountDeletionService({
+      users,
+      sessions: new InMemorySessionRepository(),
+      authIdentities,
+      devices: new InMemoryDeviceTokenRepository(),
+      objectStore: new FakeObjectStore(),
+      appleTokens: {
+        exchangeCode: async () => ({ refreshToken: null }),
+        revoke: async () => {
+          throw new Error('apple is down');
+        },
+      },
+    });
+
+    expect(await deletion.deleteAccount(user.id)).toBe(true);
+    expect(await authIdentities.listForUser(user.id)).toEqual([]);
+  });
+
+  it('deletes as it always did when Apple is unconfigured', async () => {
+    const { service, deletion, authIdentities } = setup(false);
+    const { user } = await service.signIn(token('a-1'), 'apple', { authorizationCode: 'code-1' });
+
+    expect(await deletion.deleteAccount(user.id)).toBe(true);
+    expect(await authIdentities.listForUser(user.id)).toEqual([]);
+  });
+});

--- a/services/api/tests/auth.apple.test.ts
+++ b/services/api/tests/auth.apple.test.ts
@@ -1,0 +1,169 @@
+// Apple sign-in (#168). Mirrors POST /auth/google exactly, with the two things
+// Apple does differently: the name arrives once, outside the token, and the
+// provider is configured independently so one missing client id cannot take the
+// other provider's sign-in down.
+
+import { createHash } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import { buildApp } from '../src/app';
+import { InMemoryAuthIdentityRepository } from '../src/modules/auth/auth-identity.repository';
+import { AuthService } from '../src/modules/auth/auth.service';
+import { FakeIdTokenVerifier } from '../src/modules/auth/id-token-verifier';
+import { nonceMatches } from '../src/modules/auth/id-token-verifier.apple';
+import { createJwtService, type AuthConfig } from '../src/modules/auth/jwt';
+import { InMemorySessionRepository } from '../src/modules/auth/session.repository';
+import { InMemoryUserRepository } from '../src/modules/users/user.repository';
+
+const auth: AuthConfig = {
+  secret: 'test-secret-at-least-32-characters-long-0000',
+  accessTtl: '15m',
+  issuer: 'trotxi',
+  audience: 'trotxi-api',
+};
+const appleToken = (sub: string, email?: string) =>
+  JSON.stringify(email ? { sub, email } : { sub });
+
+async function appWithApple(providers = { google: true, apple: true }) {
+  const users = new InMemoryUserRepository();
+  const verifiers: Record<string, FakeIdTokenVerifier> = {};
+  if (providers.google) verifiers.google = new FakeIdTokenVerifier('google');
+  if (providers.apple) verifiers.apple = new FakeIdTokenVerifier('apple');
+  const authService = new AuthService({
+    users,
+    authIdentities: new InMemoryAuthIdentityRepository(),
+    sessions: new InMemorySessionRepository(),
+    jwt: createJwtService(auth),
+    verifiers,
+    refreshTtlDays: 30,
+  });
+  return { app: await buildApp({ auth, users, authService }), users };
+}
+
+const signIn = (app: Awaited<ReturnType<typeof buildApp>>, payload: Record<string, unknown>) =>
+  app.inject({ method: 'POST', url: '/auth/apple', payload });
+
+describe('POST /auth/apple', () => {
+  it('signs in, returns user + tokens, and the access token works on /me', async () => {
+    const { app } = await appWithApple();
+    const res = await signIn(app, { idToken: appleToken('a-1', 'ama@example.com') });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.accessToken).toBeTruthy();
+    expect(body.refreshToken).toBeTruthy();
+
+    const me = await app.inject({
+      method: 'GET',
+      url: '/me',
+      headers: { authorization: `Bearer ${body.accessToken}` },
+    });
+    expect(me.statusCode).toBe(200);
+    expect(me.json().id).toBe(body.user.id);
+  });
+
+  it('reuses the same user on repeat sign-in', async () => {
+    const { app } = await appWithApple();
+    const first = (await signIn(app, { idToken: appleToken('a-1') })).json();
+    const second = (await signIn(app, { idToken: appleToken('a-1') })).json();
+    expect(second.user.id).toBe(first.user.id);
+  });
+
+  it('keeps the name Apple sends once, on the sign-in that creates the account', async () => {
+    // Apple returns the name on the FIRST authorization only, outside the token.
+    // Dropping it here loses it permanently and the driver's manifest shows a
+    // blank where a rider should be.
+    const { app } = await appWithApple();
+    const res = await signIn(app, { idToken: appleToken('a-1'), fullName: 'Ama Serwaa' });
+    expect(res.json().user.displayName).toBe('Ama Serwaa');
+  });
+
+  it('falls back to the default name when Apple sends none', async () => {
+    const { app } = await appWithApple();
+    const res = await signIn(app, { idToken: appleToken('a-2') });
+    expect(res.json().user.displayName).toBe('New User');
+  });
+
+  it('cannot rename an existing account', async () => {
+    // fullName is client-supplied rather than a signed claim, so it must only
+    // ever fill a blank, never overwrite. Otherwise anyone holding a valid token
+    // can relabel the account on every sign-in.
+    const { app } = await appWithApple();
+    await signIn(app, { idToken: appleToken('a-1'), fullName: 'Ama Serwaa' });
+    const again = await signIn(app, { idToken: appleToken('a-1'), fullName: 'Someone Else' });
+    expect(again.json().user.displayName).toBe('Ama Serwaa');
+  });
+
+  it('bounds a long name rather than storing it whole', async () => {
+    const { app } = await appWithApple();
+    const res = await signIn(app, { idToken: appleToken('a-3'), fullName: 'A'.repeat(500) });
+    expect(res.statusCode).toBe(400); // rejected at the schema edge
+  });
+
+  it('truncates a name that passes the schema but is still absurd', async () => {
+    // The schema stops the abusive case at 200; this is the merely silly one,
+    // where we keep something usable rather than a paragraph on the manifest.
+    const { app } = await appWithApple();
+    const res = await signIn(app, { idToken: appleToken('a-5'), fullName: 'A'.repeat(150) });
+    expect(res.json().user.displayName).toHaveLength(80);
+  });
+
+  it('keeps a private-relay address, which is real and deliverable', async () => {
+    const { app, users } = await appWithApple();
+    const res = await signIn(app, {
+      idToken: appleToken('a-4', 'xyz@privaterelay.appleid.com'),
+    });
+    const user = await users.findById(res.json().user.id);
+    expect(user?.email).toBe('xyz@privaterelay.appleid.com');
+  });
+
+  it('treats the same subject id from Apple and Google as two different people', async () => {
+    // auth_identities is keyed on (provider, provider_id). Collapsing on the
+    // subject alone would let one provider's id take over another's account.
+    const { app } = await appWithApple();
+    const viaApple = (await signIn(app, { idToken: appleToken('shared-sub') })).json();
+    const viaGoogle = (
+      await app.inject({
+        method: 'POST',
+        url: '/auth/google',
+        payload: { idToken: JSON.stringify({ sub: 'shared-sub' }) },
+      })
+    ).json();
+    expect(viaGoogle.user.id).not.toBe(viaApple.user.id);
+  });
+
+  it('rejects an invalid token with 401', async () => {
+    const { app } = await appWithApple();
+    const res = await signIn(app, { idToken: 'not-a-token' });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('returns 503 when Apple is unconfigured but leaves Google working', async () => {
+    // The whole reason verifiers are per-provider: shipping Apple config late
+    // must not be able to break the sign-in that already works.
+    const { app } = await appWithApple({ google: true, apple: false });
+
+    expect((await signIn(app, { idToken: appleToken('a-1') })).statusCode).toBe(503);
+
+    const google = await app.inject({
+      method: 'POST',
+      url: '/auth/google',
+      payload: { idToken: JSON.stringify({ sub: 'g-1' }) },
+    });
+    expect(google.statusCode).toBe(200);
+  });
+});
+
+describe('Apple nonce matching', () => {
+  it('accepts the hashed form the Apple SDKs send', () => {
+    const raw = 'random-value';
+    expect(nonceMatches(createHash('sha256').update(raw).digest('hex'), raw)).toBe(true);
+  });
+
+  it('accepts the raw form some clients send', () => {
+    expect(nonceMatches('random-value', 'random-value')).toBe(true);
+  });
+
+  it('rejects anything else', () => {
+    expect(nonceMatches('someone-elses-nonce', 'random-value')).toBe(false);
+  });
+});

--- a/services/api/tests/auth.service.test.ts
+++ b/services/api/tests/auth.service.test.ts
@@ -33,7 +33,7 @@ function makeService() {
     authIdentities,
     sessions,
     jwt,
-    verifier: new FakeIdTokenVerifier(),
+    verifiers: { google: new FakeIdTokenVerifier() },
     refreshTtlDays: 30,
   });
   return { users, authIdentities, sessions, service };
@@ -102,7 +102,7 @@ describe('AuthService.signIn', () => {
       authIdentities,
       sessions: new InMemorySessionRepository(),
       jwt,
-      verifier: new FakeIdTokenVerifier(),
+      verifiers: { google: new FakeIdTokenVerifier() },
       refreshTtlDays: 30,
     });
 
@@ -123,7 +123,7 @@ describe('AuthService.signIn', () => {
       authIdentities,
       sessions: new InMemorySessionRepository(),
       jwt,
-      verifier: new FakeIdTokenVerifier(),
+      verifiers: { google: new FakeIdTokenVerifier() },
       refreshTtlDays: 30,
     });
     await expect(service.signIn(googleToken('g-1'))).rejects.toThrow('db down');

--- a/services/api/tests/auth.service.test.ts
+++ b/services/api/tests/auth.service.test.ts
@@ -90,8 +90,19 @@ describe('AuthService.signIn', () => {
     let raced = false;
     const authIdentities: AuthIdentityRepository = {
       findByProvider: async (provider, providerId) =>
-        raced ? { id: 'x', userId: winner.id, provider, providerId, createdAt: new Date() } : null,
+        raced
+          ? {
+              id: 'x',
+              userId: winner.id,
+              provider,
+              providerId,
+              providerRefreshToken: null,
+              createdAt: new Date(),
+            }
+          : null,
       deleteForUser: async () => {},
+      listForUser: async () => [],
+      saveRefreshToken: async () => {},
       create: async () => {
         raced = true; // the "winner" created it between our check and our insert
         throw Object.assign(new Error('duplicate'), { code: '23505' });
@@ -114,6 +125,8 @@ describe('AuthService.signIn', () => {
     const authIdentities: AuthIdentityRepository = {
       findByProvider: async () => null,
       deleteForUser: async () => {},
+      listForUser: async () => [],
+      saveRefreshToken: async () => {},
       create: async () => {
         throw new Error('db down');
       },

--- a/services/api/tests/auth.sessions.test.ts
+++ b/services/api/tests/auth.sessions.test.ts
@@ -24,7 +24,7 @@ function make() {
     authIdentities: new InMemoryAuthIdentityRepository(),
     sessions: new InMemorySessionRepository(),
     jwt,
-    verifier: new FakeIdTokenVerifier(),
+    verifiers: { google: new FakeIdTokenVerifier() },
     refreshTtlDays: 30,
   });
   return { users, authService };

--- a/services/api/tests/auth.signin.test.ts
+++ b/services/api/tests/auth.signin.test.ts
@@ -22,7 +22,7 @@ async function appWithAuth() {
     authIdentities: new InMemoryAuthIdentityRepository(),
     sessions: new InMemorySessionRepository(),
     jwt: createJwtService(auth),
-    verifier: new FakeIdTokenVerifier(),
+    verifiers: { google: new FakeIdTokenVerifier() },
     refreshTtlDays: 30,
   });
   return buildApp({ auth, users, authService });

--- a/services/api/vitest.config.ts
+++ b/services/api/vitest.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
         'src/**/*.pg.ts',
         'src/**/*.redis.ts',
         'src/**/*.google.ts',
+        'src/**/*.apple.ts',
         'src/**/*.live.ts',
         'src/**/*.r2.ts',
       ],


### PR DESCRIPTION
Closes #168. The welcome screen has had two buttons and one working provider since March.

`POST /auth/apple` mirrors `POST /auth/google` exactly: same body, same result, same rate limit, same 503 when unconfigured. No second auth shape, since the issue was explicit about that and the data model was already provider-keyed.

## Verifiers are now per-provider

`AuthService` held a single verifier. It now holds one per provider, each resolved independently at startup.

That isn't tidiness. The Apple credentials (Developer team, App ID, Services ID, signing key) come from the FE lane and will land after this code does. A single verifier means a missing `APPLE_CLIENT_ID` in production either disables both providers or forces us to ship Apple config before we have it. Now each provider 503s on its own and Google is untouched. There's a test asserting exactly that.

## The three Apple traps

Each has a test, because each is silent when you get it wrong.

**The name is sent once.** Apple returns it on the first authorization only, outside the ID token, and never again. Clients send it as `fullName`. Since it's client-supplied rather than a signed claim, the server uses it only when creating the account, so a valid token can't rename someone, and it's bounded at 80 characters. Get this wrong and the rider is "New User" on every driver manifest for the rest of their life with us, with no way to recover it.

**Two audiences.** Native iOS presents the app's bundle id; the Android and web flow presents the Services ID. `APPLE_CLIENT_ID` is comma-separated so a Flutter app shipping on both platforms verifies on both. A single-audience implementation works in whichever platform you tested and fails on the other.

**Booleans arrive as strings.** Apple sends `email_verified` and `is_private_email` as either `true` or `"true"` depending on the flow. Parsing them strictly as booleans rejects real sign-ins.

Private-relay addresses are stored like any other. They're real, deliverable addresses that forward to the rider, and discarding them for tidiness would make those riders uncontactable, which is the thing #182 existed to stop.

Optional `nonce` is checked against the token claim when the client sends one. It accepts both the SHA-256 form the Apple SDKs send and the raw form some clients send, because rejecting half our users to be strict about a convention Apple doesn't enforce is the worse failure.

## What's still needed, and it isn't code

`APPLE_CLIENT_ID` is in the blueprint but commented out. It's public, like `GOOGLE_CLIENT_ID`, so it belongs there rather than the dashboard. It needs an Apple Developer team, an App ID and a Services ID, which sit in the FE lane alongside Firebase. Until those exist, `/auth/apple` returns 503 and nothing else changes.

Uncommenting it is the whole deployment step.

## Checks

511 tests pass, 92.02% statements. Lint, typecheck and format clean. Also booted the real server and signed in twice against it: the first call captured the name, the second could not overwrite it.

## Note

This unblocks iOS submission, not the pilot, if the pilot stays Android-first.