### PR TITLE
feat(auth): revoke Apple tokens on account deletion (#213)

### DIFF
--- a/docs/features/authentication.md
+++ b/docs/features/authentication.md
@@ -130,7 +130,7 @@ Sign in (or sign up on first use) with an Apple ID token. Same shape as
 `/auth/google`, because it is the same flow with a different verifier.
 
 - **Auth:** none. **Rate limit:** 10/min per IP.
-- **Body:** `{ "idToken": "<apple ID token>", "fullName?": "Ama Serwaa", "nonce?": "<raw nonce>" }`
+- **Body:** `{ "idToken": "<apple ID token>", "fullName?": "Ama Serwaa", "nonce?": "<raw nonce>", "authorizationCode?": "<one-time code>" }`
 - **200:** identical to `/auth/google`
 - **401** invalid token · **429** rate-limited · **503** Apple sign-in not configured
 
@@ -144,6 +144,15 @@ never rename an existing user.
 `nonce` is the raw value the client hashed into the authorization request. Send it
 and a replayed token is rejected; omit it and the token is still verified for
 signature, issuer, audience and expiry.
+
+`authorizationCode` is Apple's one-time code, sent on first authorization. The
+server trades it for a refresh token and stores that against the identity, for
+one purpose: `DELETE /me` has to revoke our access at Apple, and revoking needs a
+token that verifying an ID token never produces. Apple requires this of any app
+offering both Sign in with Apple and account deletion, and checks it at review.
+Omit the code and sign-in still works; only revocation is lost. The exchange is
+best effort, so Apple's token endpoint being down delays nothing at the login
+screen.
 
 #### `POST /auth/refresh`
 
@@ -229,6 +238,9 @@ uncontactable for the sake of tidiness.
 | ---------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
 | `GOOGLE_CLIENT_ID`     | unset   | the Google **"Web"** OAuth client ID = the token audience. **Public, not a secret.** No client _secret_ needed (we only verify the ID token). |
 | `APPLE_CLIENT_ID`      | unset   | Apple audiences, **comma-separated**: the iOS bundle id and the Services ID. **Public, not a secret.** Unset → `/auth/apple` returns 503.     |
+| `APPLE_TEAM_ID`        | unset   | Apple Developer team id. Public. Needed only for the code exchange and revocation.                                                            |
+| `APPLE_KEY_ID`         | unset   | Key ID of the Sign in with Apple `.p8`. Public.                                                                                               |
+| `APPLE_PRIVATE_KEY`    | unset   | The `.p8` key itself, PKCS#8 PEM. **A real secret** — Render dashboard only, never the blueprint. Unset → no exchange and no revocation.      |
 | `JWT_REFRESH_TTL_DAYS` | `30`    | refresh-token lifetime                                                                                                                        |
 
 > The mobile apps additionally need **Android + iOS** OAuth client IDs in the

--- a/render.yaml
+++ b/render.yaml
@@ -91,6 +91,16 @@ services:
       # Waiting on the Apple Developer team + App ID + Services ID (FE lane).
       # - key: APPLE_CLIENT_ID
       #   value: com.trotxi.trotxiCommuter,<Services ID>
+      # Sign in with Apple signing key (#213), for the code exchange and the
+      # revocation DELETE /me must perform. Team id and key id are public; the
+      # .p8 itself is a SECRET, so it is dashboard-managed (sync: false) and
+      # never appears here. All three unset -> no exchange, no revocation.
+      # - key: APPLE_TEAM_ID
+      #   value: <Apple Developer team id>
+      # - key: APPLE_KEY_ID
+      #   value: <Key ID of the .p8>
+      # - key: APPLE_PRIVATE_KEY
+      #   sync: false
       # Observability (#28). Set in the dashboard when Grafana Cloud is wired up.
       # METRICS_TOKEN gates GET /metrics (scraper sends it as a bearer token);
       # unset -> /metrics is disabled (404) in production.

--- a/services/api/src/config/env.ts
+++ b/services/api/src/config/env.ts
@@ -24,6 +24,13 @@ const envSchema = z
     // shipping on both platforms needs BOTH accepted. Set to enable real Apple
     // sign-in; unset -> dev fake verifier (non-prod) / 503 (prod).
     APPLE_CLIENT_ID: z.string().optional(),
+    // Sign in with Apple signing key, for the token + revocation endpoints
+    // (#213). TEAM_ID and KEY_ID are public; APPLE_PRIVATE_KEY is the .p8 and is
+    // a SECRET -> Render dashboard only, never the blueprint. All three unset ->
+    // codes aren't exchanged and deletion skips revocation.
+    APPLE_TEAM_ID: z.string().optional(),
+    APPLE_KEY_ID: z.string().optional(),
+    APPLE_PRIVATE_KEY: z.string().optional(),
     // Paystack SECRET key (sk_...). Used for the API + webhook signature check.
     // Set -> real payments; unset -> dev fake client (non-prod) / 503 (prod).
     PAYSTACK_SECRET_KEY: z.string().optional(),

--- a/services/api/src/db/migrations/034_apple_refresh_token.sql
+++ b/services/api/src/db/migrations/034_apple_refresh_token.sql
@@ -1,0 +1,12 @@
+-- 034_apple_refresh_token: keep Apple's refresh token so we can revoke it (#213).
+--
+-- Apple requires that an app offering both Sign in with Apple and account
+-- deletion calls their revocation endpoint on delete. Revoking needs a token,
+-- and verifying an ID token never yields one, so we exchange the authorization
+-- code at first sign-in and keep what it returns.
+--
+-- Unlike our OWN refresh tokens (stored hashed, since we only ever compare
+-- them), this one has to be replayable to be usable, so it is stored as issued.
+-- It is a provider credential: scoped to revocation and basic profile, but a
+-- credential. Null for Google, and for Apple sign-ins made before this landed.
+ALTER TABLE auth_identity ADD COLUMN IF NOT EXISTS provider_refresh_token text;

--- a/services/api/src/modules/auth/apple-token.client.apple.ts
+++ b/services/api/src/modules/auth/apple-token.client.apple.ts
@@ -1,0 +1,83 @@
+// Real Apple token client: exchanges authorization codes and revokes tokens.
+// Network-bound and key-signing, so excluded from unit coverage like the other
+// *.apple.ts / *.google.ts adapters — exercised against Apple directly.
+
+import { SignJWT, importPKCS8 } from 'jose';
+import type { AppleTokenClient, AppleTokens } from './apple-token.client';
+
+const APPLE_TOKEN_URL = 'https://appleid.apple.com/auth/token';
+const APPLE_REVOKE_URL = 'https://appleid.apple.com/auth/revoke';
+
+/** Apple caps the client secret at 6 months; 10 minutes is all a request needs. */
+const CLIENT_SECRET_TTL = '10m';
+
+/** Credentials for signing the client secret Apple's token endpoints require. */
+export interface AppleTokenClientConfig {
+  /** The Services ID or bundle id the code was issued to. */
+  clientId: string;
+  /** The Apple Developer team id. */
+  teamId: string;
+  /** The Key ID of the Sign in with Apple `.p8` key. */
+  keyId: string;
+  /** The `.p8` private key, PKCS#8 PEM. A SECRET — dashboard only. */
+  privateKey: string;
+}
+
+/** Apple's real token and revocation endpoints, authenticated with the `.p8`. */
+export class AppleHttpTokenClient implements AppleTokenClient {
+  /** @param config - the client id and signing credentials. */
+  constructor(private readonly config: AppleTokenClientConfig) {}
+
+  async exchangeCode(code: string): Promise<AppleTokens> {
+    const body = new URLSearchParams({
+      client_id: this.config.clientId,
+      client_secret: await this.clientSecret(),
+      code,
+      grant_type: 'authorization_code',
+    });
+    const res = await fetch(APPLE_TOKEN_URL, {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body,
+    });
+    if (!res.ok) {
+      throw new Error(`Apple code exchange failed (${res.status})`);
+    }
+    const json = (await res.json()) as { refresh_token?: string };
+    return { refreshToken: json.refresh_token ?? null };
+  }
+
+  async revoke(refreshToken: string): Promise<void> {
+    const body = new URLSearchParams({
+      client_id: this.config.clientId,
+      client_secret: await this.clientSecret(),
+      token: refreshToken,
+      token_type_hint: 'refresh_token',
+    });
+    const res = await fetch(APPLE_REVOKE_URL, {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body,
+    });
+    if (!res.ok) {
+      throw new Error(`Apple revocation failed (${res.status})`);
+    }
+  }
+
+  /**
+   * Mint the short-lived ES256 JWT Apple takes in place of a client secret.
+   *
+   * @returns the signed client secret.
+   */
+  private async clientSecret(): Promise<string> {
+    const key = await importPKCS8(this.config.privateKey, 'ES256');
+    return new SignJWT({})
+      .setProtectedHeader({ alg: 'ES256', kid: this.config.keyId })
+      .setIssuer(this.config.teamId)
+      .setAudience('https://appleid.apple.com')
+      .setSubject(this.config.clientId)
+      .setIssuedAt()
+      .setExpirationTime(CLIENT_SECRET_TTL)
+      .sign(key);
+  }
+}

--- a/services/api/src/modules/auth/apple-token.client.ts
+++ b/services/api/src/modules/auth/apple-token.client.ts
@@ -1,0 +1,54 @@
+// Apple's token endpoints (#213) — the half of the OAuth flow that verifying an
+// ID token skips.
+//
+// Sign-in itself needs none of this: we check the ID token against Apple's JWKS
+// and we're done. Revocation does. Apple requires an app offering both Sign in
+// with Apple and account deletion to revoke at delete time, and revoking needs a
+// token, which only the authorization-code exchange yields.
+//
+// The real client is network-bound and signs with a private key, so it lives in
+// *.apple.ts alongside the verifier and is excluded from unit coverage. The fake
+// is what dev and tests run against.
+
+/** What an authorization-code exchange gives us back. */
+export interface AppleTokens {
+  /** Apple's refresh token, when the exchange returned one. */
+  refreshToken: string | null;
+}
+
+/** Apple's token and revocation endpoints. */
+export interface AppleTokenClient {
+  /**
+   * Exchange a one-time authorization code for Apple's tokens.
+   *
+   * @param code - the authorization code from the client.
+   * @returns the tokens Apple issued.
+   * @throws when Apple rejects the exchange.
+   */
+  exchangeCode(code: string): Promise<AppleTokens>;
+  /**
+   * Revoke a refresh token, severing the link at Apple's end.
+   *
+   * @param refreshToken - the token to revoke.
+   * @throws when Apple rejects the revocation.
+   */
+  revoke(refreshToken: string): Promise<void>;
+}
+
+/**
+ * Dev/test client: records calls, talks to nobody. Wired outside production so
+ * the deletion path is exercisable without Apple credentials.
+ */
+export class FakeAppleTokenClient implements AppleTokenClient {
+  readonly exchanged: string[] = [];
+  readonly revoked: string[] = [];
+
+  async exchangeCode(code: string): Promise<AppleTokens> {
+    this.exchanged.push(code);
+    return { refreshToken: `fake-apple-refresh-${code}` };
+  }
+
+  async revoke(refreshToken: string): Promise<void> {
+    this.revoked.push(refreshToken);
+  }
+}

--- a/services/api/src/modules/auth/auth-identity.repository.pg.ts
+++ b/services/api/src/modules/auth/auth-identity.repository.pg.ts
@@ -11,6 +11,7 @@ interface AuthIdentityRow {
   user_id: string;
   provider: AuthProvider;
   provider_id: string;
+  provider_refresh_token: string | null;
   created_at: Date;
 }
 
@@ -20,6 +21,7 @@ function toAuthIdentity(row: AuthIdentityRow): AuthIdentity {
     userId: row.user_id,
     provider: row.provider,
     providerId: row.provider_id,
+    providerRefreshToken: row.provider_refresh_token,
     createdAt: row.created_at,
   };
 }
@@ -37,15 +39,30 @@ export class PgAuthIdentityRepository implements AuthIdentityRepository {
 
   async create(input: NewAuthIdentity): Promise<AuthIdentity> {
     const { rows } = await this.pool.query<AuthIdentityRow>(
-      `INSERT INTO auth_identity (user_id, provider, provider_id)
-       VALUES ($1, $2, $3)
+      `INSERT INTO auth_identity (user_id, provider, provider_id, provider_refresh_token)
+       VALUES ($1, $2, $3, $4)
        RETURNING *`,
-      [input.userId, input.provider, input.providerId],
+      [input.userId, input.provider, input.providerId, input.providerRefreshToken ?? null],
     );
     return toAuthIdentity(rows[0]!);
   }
 
   async deleteForUser(userId: string): Promise<void> {
     await this.pool.query('DELETE FROM auth_identity WHERE user_id = $1', [userId]);
+  }
+
+  async listForUser(userId: string): Promise<AuthIdentity[]> {
+    const { rows } = await this.pool.query<AuthIdentityRow>(
+      'SELECT * FROM auth_identity WHERE user_id = $1',
+      [userId],
+    );
+    return rows.map(toAuthIdentity);
+  }
+
+  async saveRefreshToken(id: string, refreshToken: string): Promise<void> {
+    await this.pool.query('UPDATE auth_identity SET provider_refresh_token = $2 WHERE id = $1', [
+      id,
+      refreshToken,
+    ]);
   }
 }

--- a/services/api/src/modules/auth/auth-identity.repository.ts
+++ b/services/api/src/modules/auth/auth-identity.repository.ts
@@ -11,6 +11,14 @@ export interface AuthIdentity {
   provider: AuthProvider;
   /** The provider's stable subject id. */
   providerId: string;
+  /**
+   * The provider's own refresh token, where we hold one (#213).
+   *
+   * Apple only, and only when the client sent an authorization code. Kept so
+   * account deletion can revoke our access at Apple rather than just forgetting
+   * the link locally. Null everywhere else.
+   */
+  providerRefreshToken: string | null;
   createdAt: Date;
 }
 
@@ -19,6 +27,7 @@ export interface NewAuthIdentity {
   userId: string;
   provider: AuthProvider;
   providerId: string;
+  providerRefreshToken?: string | null;
 }
 
 /** Persistence for provider-identity links; `(provider, providerId)` is unique. */
@@ -47,6 +56,25 @@ export interface AuthIdentityRepository {
    * @param userId - the user whose identities to unlink.
    */
   deleteForUser(userId: string): Promise<void>;
+  /**
+   * Every provider link for a user, read before deletion so we know what to
+   * revoke upstream (#213).
+   *
+   * @param userId - the user whose identities to list.
+   * @returns the user's linked identities.
+   */
+  listForUser(userId: string): Promise<AuthIdentity[]>;
+  /**
+   * Store (or replace) the provider refresh token on an existing link.
+   *
+   * Separate from `create` because a rider who signed in before we asked for
+   * authorization codes already has an identity row, and their next sign-in is
+   * the only chance to backfill it.
+   *
+   * @param id - the auth identity to update.
+   * @param refreshToken - the provider refresh token to keep.
+   */
+  saveRefreshToken(id: string, refreshToken: string): Promise<void>;
 }
 
 /** In-memory {@link AuthIdentityRepository} for dev and unit tests. */
@@ -67,14 +95,26 @@ export class InMemoryAuthIdentityRepository implements AuthIdentityRepository {
       userId: input.userId,
       provider: input.provider,
       providerId: input.providerId,
+      providerRefreshToken: input.providerRefreshToken ?? null,
       createdAt: new Date(),
     };
     this.identities.set(this.key(input.provider, input.providerId), identity);
     return identity;
   }
+
   async deleteForUser(userId: string): Promise<void> {
     for (const [key, identity] of this.identities) {
       if (identity.userId === userId) this.identities.delete(key);
+    }
+  }
+
+  async listForUser(userId: string): Promise<AuthIdentity[]> {
+    return [...this.identities.values()].filter((i) => i.userId === userId);
+  }
+
+  async saveRefreshToken(id: string, refreshToken: string): Promise<void> {
+    for (const identity of this.identities.values()) {
+      if (identity.id === id) identity.providerRefreshToken = refreshToken;
     }
   }
 }

--- a/services/api/src/modules/auth/auth.routes.ts
+++ b/services/api/src/modules/auth/auth.routes.ts
@@ -186,6 +186,7 @@ export async function authRoutes(
         return await opts.authService.signIn(request.body.idToken, 'apple', {
           displayName: request.body.fullName,
           nonce: request.body.nonce,
+          authorizationCode: request.body.authorizationCode,
         });
       } catch (err) {
         if (err instanceof SignInNotConfiguredError) {

--- a/services/api/src/modules/auth/auth.schema.ts
+++ b/services/api/src/modules/auth/auth.schema.ts
@@ -16,6 +16,13 @@ export const appleSignInBodySchema = z.object({
   idToken: z.string().min(1),
   fullName: z.string().max(200).optional(),
   nonce: z.string().max(200).optional(),
+  /**
+   * Apple's one-time authorization code, sent on first authorization. We trade
+   * it for a refresh token purely so account deletion can revoke our access at
+   * Apple, which Apple requires and checks at review (#213). Omit it and
+   * sign-in still works; only revocation is lost.
+   */
+  authorizationCode: z.string().max(500).optional(),
 });
 
 export const refreshBodySchema = z.object({

--- a/services/api/src/modules/auth/auth.service.ts
+++ b/services/api/src/modules/auth/auth.service.ts
@@ -8,6 +8,7 @@
 
 import type { JwtService } from './jwt';
 import type { AuthIdentityRepository } from './auth-identity.repository';
+import type { AppleTokenClient } from './apple-token.client';
 import type { AuthProvider, IdTokenVerifier, VerifiedIdentity } from './id-token-verifier';
 import type { Session, SessionRepository } from './session.repository';
 import { generateRefreshToken, hashToken } from './tokens';
@@ -61,6 +62,12 @@ export interface AuthServiceDeps {
    * Google down with it.
    */
   verifiers?: Partial<Record<AuthProvider, IdTokenVerifier>>;
+  /**
+   * Apple's token endpoints (#213). Undefined when the signing key isn't
+   * configured, in which case codes are simply not exchanged and sign-in works
+   * exactly as before.
+   */
+  appleTokens?: AppleTokenClient;
   /** Refresh-token lifetime in days. */
   refreshTtlDays: number;
 }
@@ -107,6 +114,8 @@ export class AuthService {
    * @param opts - optional extras the token itself cannot carry.
    * @param opts.displayName - the name Apple returned on first authorization.
    * @param opts.nonce - the raw nonce the client generated, for replay checking.
+   * @param opts.authorizationCode - Apple's one-time code, exchanged for the
+   *   refresh token we need to revoke access when the account is deleted.
    * @returns the user and their new tokens.
    * @throws SignInNotConfiguredError when that provider has no verifier wired.
    * @throws when the ID token is invalid/untrusted (from the verifier).
@@ -114,19 +123,43 @@ export class AuthService {
   async signIn(
     idToken: string,
     provider: AuthProvider = 'google',
-    opts: { displayName?: string; nonce?: string } = {},
+    opts: { displayName?: string; nonce?: string; authorizationCode?: string } = {},
   ): Promise<AuthResult> {
     const verifier = this.deps.verifiers?.[provider];
     if (!verifier) {
       throw new SignInNotConfiguredError('Sign-in is not configured');
     }
     const identity = await verifier.verify(idToken, opts.nonce); // throws if invalid
-    const { user, isNewUser } = await this.findOrCreateUser({
-      ...identity,
-      displayName: identity.displayName ?? cleanDisplayName(opts.displayName),
-    });
+    const providerRefreshToken = await this.exchangeAppleCode(provider, opts.authorizationCode);
+    const { user, isNewUser } = await this.findOrCreateUser(
+      {
+        ...identity,
+        displayName: identity.displayName ?? cleanDisplayName(opts.displayName),
+      },
+      providerRefreshToken,
+    );
     const tokens = await this.issueTokens(user);
     return { user, isNewUser, ...tokens };
+  }
+
+  /**
+   * Trade Apple's authorization code for the refresh token we need at deletion.
+   *
+   * Best effort on purpose. A rider signing in should not be turned away because
+   * Apple's token endpoint is having a bad minute; the cost of failing is that we
+   * cannot revoke later, which is worth strictly less than the sign-in itself.
+   *
+   * @param provider - the provider being signed in with.
+   * @param code - the authorization code, when the client sent one.
+   * @returns the refresh token, or null when there is nothing to exchange.
+   */
+  private async exchangeAppleCode(provider: AuthProvider, code?: string): Promise<string | null> {
+    if (provider !== 'apple' || !code || !this.deps.appleTokens) return null;
+    try {
+      return (await this.deps.appleTokens.exchangeCode(code)).refreshToken;
+    } catch {
+      return null;
+    }
   }
 
   /**
@@ -227,16 +260,23 @@ export class AuthService {
    * winner's identity.
    *
    * @param identity - the verified provider identity.
+   * @param providerRefreshToken - Apple's refresh token, when we obtained one.
    * @returns the existing or newly created user.
    */
   private async findOrCreateUser(
     identity: VerifiedIdentity,
+    providerRefreshToken: string | null = null,
   ): Promise<{ user: User; isNewUser: boolean }> {
     const existing = await this.deps.authIdentities.findByProvider(
       identity.provider,
       identity.providerId,
     );
     if (existing) {
+      // Backfill for anyone who linked Apple before we started asking for codes:
+      // their next sign-in is the only chance to become revocable.
+      if (providerRefreshToken) {
+        await this.deps.authIdentities.saveRefreshToken(existing.id, providerRefreshToken);
+      }
       const user = await this.deps.users.findById(existing.userId);
       // Backfill the verified email for anyone who signed up before #182, so
       // existing riders become reachable on their next sign-in rather than
@@ -253,6 +293,7 @@ export class AuthService {
         userId: user.id,
         provider: identity.provider,
         providerId: identity.providerId,
+        providerRefreshToken,
       });
     } catch (err) {
       // Lost a concurrent first sign-in race — the identity now exists; reuse it.

--- a/services/api/src/modules/users/account-deletion.service.ts
+++ b/services/api/src/modules/users/account-deletion.service.ts
@@ -4,6 +4,7 @@
 //
 // Order matters — access is cut first, then provider links, then the PII.
 
+import type { AppleTokenClient } from '../auth/apple-token.client';
 import type { AuthIdentityRepository } from '../auth/auth-identity.repository';
 import type { SessionRepository } from '../auth/session.repository';
 import type { DeviceTokenRepository } from '../devices/device-token.repository';
@@ -17,6 +18,11 @@ export interface AccountDeletionDeps {
   authIdentities: AuthIdentityRepository;
   devices: DeviceTokenRepository;
   objectStore: ObjectStore;
+  /**
+   * Apple's token endpoints (#213). Undefined when unconfigured, in which case
+   * deletion behaves as it always did.
+   */
+  appleTokens?: AppleTokenClient;
 }
 
 /** Erases a user's personal data across every store that holds it. */
@@ -38,6 +44,12 @@ export class AccountDeletionService {
     await this.deps.sessions.revokeAllForUser(userId);
     await this.deps.devices.removeForUser(userId);
 
+    // Tell Apple before we forget the link. Apple requires an app offering both
+    // Sign in with Apple and account deletion to revoke here; unlinking on our
+    // side alone leaves us listed under the rider's Apple ID for an account that
+    // no longer exists, and it is checked at App Store review.
+    await this.revokeAppleAccess(userId);
+
     // Unlink providers, so signing in again creates a NEW user.
     await this.deps.authIdentities.deleteForUser(userId);
 
@@ -54,5 +66,27 @@ export class AccountDeletionService {
     // Keep the row and its id so the ledgers stay balanced.
     await this.deps.users.anonymise(userId);
     return true;
+  }
+
+  /**
+   * Revoke our access at Apple for every Apple identity on this account.
+   *
+   * Best effort. A rider asked us to delete their account, and Apple being
+   * unreachable is not a reason to refuse them, or to abandon the erasure
+   * half-done with their sessions already dead.
+   *
+   * @param userId - the account being erased.
+   */
+  private async revokeAppleAccess(userId: string): Promise<void> {
+    if (!this.deps.appleTokens) return;
+    const identities = await this.deps.authIdentities.listForUser(userId);
+    for (const identity of identities) {
+      if (identity.provider !== 'apple' || !identity.providerRefreshToken) continue;
+      try {
+        await this.deps.appleTokens.revoke(identity.providerRefreshToken);
+      } catch {
+        // Nothing useful to do: the account still has to go.
+      }
+    }
   }
 }

--- a/services/api/src/server.ts
+++ b/services/api/src/server.ts
@@ -21,6 +21,8 @@ import {
   type AuthProvider,
   type IdTokenVerifier,
 } from './modules/auth/id-token-verifier';
+import { FakeAppleTokenClient, type AppleTokenClient } from './modules/auth/apple-token.client';
+import { AppleHttpTokenClient } from './modules/auth/apple-token.client.apple';
 import { AppleIdTokenVerifier } from './modules/auth/id-token-verifier.apple';
 import { GoogleIdTokenVerifier } from './modules/auth/id-token-verifier.google';
 import { createJwtService, DEV_AUTH_CONFIG, type AuthConfig } from './modules/auth/jwt';
@@ -268,6 +270,28 @@ async function main(): Promise<void> {
     console.warn('GOOGLE_CLIENT_ID not set — sign-in disabled (POST /auth/google returns 503).');
   }
 
+  // Apple token client (#213): real when the .p8 key is configured, a recording
+  // fake outside production, otherwise absent — codes go unexchanged and deletion
+  // skips revocation, which is exactly the state before Apple sign-in is on.
+  let appleTokens: AppleTokenClient | undefined;
+  if (env.APPLE_CLIENT_ID && env.APPLE_TEAM_ID && env.APPLE_KEY_ID && env.APPLE_PRIVATE_KEY) {
+    appleTokens = new AppleHttpTokenClient({
+      // The code is issued to whichever audience the client used; the first is
+      // the native bundle id, which is the flow that sends codes.
+      clientId: env.APPLE_CLIENT_ID.split(',')[0]!.trim(),
+      teamId: env.APPLE_TEAM_ID,
+      keyId: env.APPLE_KEY_ID,
+      privateKey: env.APPLE_PRIVATE_KEY,
+    });
+    console.log('Using Apple token client (code exchange + revocation)');
+  } else if (env.NODE_ENV !== 'production') {
+    appleTokens = new FakeAppleTokenClient();
+  } else {
+    console.warn(
+      'Apple signing key not set — Apple tokens are not exchanged and DELETE /me will not revoke at Apple.',
+    );
+  }
+
   if (env.APPLE_CLIENT_ID) {
     const audiences = env.APPLE_CLIENT_ID.split(',')
       .map((id) => id.trim())
@@ -289,6 +313,7 @@ async function main(): Promise<void> {
     sessions,
     jwt: createJwtService(auth),
     verifiers,
+    appleTokens,
     refreshTtlDays: env.JWT_REFRESH_TTL_DAYS,
   });
 
@@ -313,6 +338,7 @@ async function main(): Promise<void> {
     authIdentities,
     devices: deviceTokens,
     objectStore,
+    appleTokens,
   });
 
   const paymentsService = new PaymentsService({

--- a/services/api/tests/auth.apple-revocation.test.ts
+++ b/services/api/tests/auth.apple-revocation.test.ts
@@ -1,0 +1,157 @@
+// Apple token revocation (#213). Apple requires an app offering both Sign in
+// with Apple and account deletion to revoke at Apple's end on delete, and
+// revoking needs a token that only the authorization-code exchange yields.
+
+import { describe, expect, it } from 'vitest';
+import { InMemoryAuthIdentityRepository } from '../src/modules/auth/auth-identity.repository';
+import { AuthService } from '../src/modules/auth/auth.service';
+import { FakeAppleTokenClient } from '../src/modules/auth/apple-token.client';
+import { FakeIdTokenVerifier } from '../src/modules/auth/id-token-verifier';
+import { createJwtService, type AuthConfig } from '../src/modules/auth/jwt';
+import { InMemorySessionRepository } from '../src/modules/auth/session.repository';
+import { InMemoryDeviceTokenRepository } from '../src/modules/devices/device-token.repository';
+import { AccountDeletionService } from '../src/modules/users/account-deletion.service';
+import { InMemoryUserRepository } from '../src/modules/users/user.repository';
+import { FakeObjectStore } from '../src/storage/object-store';
+
+const auth: AuthConfig = {
+  secret: 'test-secret-at-least-32-characters-long-0000',
+  accessTtl: '15m',
+  issuer: 'trotxi',
+  audience: 'trotxi-api',
+};
+
+function setup(withAppleTokens = true) {
+  const users = new InMemoryUserRepository();
+  const authIdentities = new InMemoryAuthIdentityRepository();
+  const appleTokens = new FakeAppleTokenClient();
+  const service = new AuthService({
+    users,
+    authIdentities,
+    sessions: new InMemorySessionRepository(),
+    jwt: createJwtService(auth),
+    verifiers: { apple: new FakeIdTokenVerifier('apple'), google: new FakeIdTokenVerifier() },
+    appleTokens: withAppleTokens ? appleTokens : undefined,
+    refreshTtlDays: 30,
+  });
+  const deletion = new AccountDeletionService({
+    users,
+    sessions: new InMemorySessionRepository(),
+    authIdentities,
+    devices: new InMemoryDeviceTokenRepository(),
+    objectStore: new FakeObjectStore(),
+    appleTokens: withAppleTokens ? appleTokens : undefined,
+  });
+  return { users, authIdentities, appleTokens, service, deletion };
+}
+
+const token = (sub: string) => JSON.stringify({ sub });
+
+describe('Apple authorization-code exchange', () => {
+  it('exchanges the code and keeps the refresh token against the identity', async () => {
+    const { service, authIdentities, appleTokens } = setup();
+    const result = await service.signIn(token('a-1'), 'apple', { authorizationCode: 'code-1' });
+
+    expect(appleTokens.exchanged).toEqual(['code-1']);
+    const [identity] = await authIdentities.listForUser(result.user.id);
+    expect(identity?.providerRefreshToken).toBe('fake-apple-refresh-code-1');
+  });
+
+  it('signs in normally when the client sends no code', async () => {
+    const { service, authIdentities, appleTokens } = setup();
+    const result = await service.signIn(token('a-2'), 'apple');
+
+    expect(appleTokens.exchanged).toEqual([]);
+    const [identity] = await authIdentities.listForUser(result.user.id);
+    expect(identity?.providerRefreshToken).toBeNull();
+  });
+
+  it('backfills a rider who linked Apple before we asked for codes', async () => {
+    const { service, authIdentities } = setup();
+    const first = await service.signIn(token('a-3'), 'apple');
+    await service.signIn(token('a-3'), 'apple', { authorizationCode: 'code-later' });
+
+    const [identity] = await authIdentities.listForUser(first.user.id);
+    expect(identity?.providerRefreshToken).toBe('fake-apple-refresh-code-later');
+  });
+
+  it('never exchanges a code for Google', async () => {
+    const { service, appleTokens } = setup();
+    await service.signIn(token('g-1'), 'google', { authorizationCode: 'code-1' });
+    expect(appleTokens.exchanged).toEqual([]);
+  });
+
+  it('still signs the rider in when Apple rejects the exchange', async () => {
+    // Losing revocation is bad. Turning a rider away at the login screen because
+    // Apple's token endpoint is having a bad minute is worse.
+    const { users, authIdentities } = setup();
+    const service = new AuthService({
+      users,
+      authIdentities,
+      sessions: new InMemorySessionRepository(),
+      jwt: createJwtService(auth),
+      verifiers: { apple: new FakeIdTokenVerifier('apple') },
+      appleTokens: {
+        exchangeCode: async () => {
+          throw new Error('apple is down');
+        },
+        revoke: async () => {},
+      },
+      refreshTtlDays: 30,
+    });
+
+    const result = await service.signIn(token('a-4'), 'apple', { authorizationCode: 'code-1' });
+    expect(result.accessToken).toBeTruthy();
+    const [identity] = await authIdentities.listForUser(result.user.id);
+    expect(identity?.providerRefreshToken).toBeNull();
+  });
+});
+
+describe('account deletion revokes at Apple', () => {
+  it('revokes the stored token before unlinking', async () => {
+    const { service, deletion, appleTokens } = setup();
+    const { user } = await service.signIn(token('a-1'), 'apple', { authorizationCode: 'code-1' });
+
+    expect(await deletion.deleteAccount(user.id)).toBe(true);
+    expect(appleTokens.revoked).toEqual(['fake-apple-refresh-code-1']);
+  });
+
+  it('has nothing to revoke for a Google-only account', async () => {
+    const { service, deletion, appleTokens } = setup();
+    const { user } = await service.signIn(token('g-1'), 'google');
+
+    await deletion.deleteAccount(user.id);
+    expect(appleTokens.revoked).toEqual([]);
+  });
+
+  it('still erases the account when Apple refuses the revocation', async () => {
+    // The rider asked to be deleted. Apple being unreachable cannot leave the
+    // erasure half-done with their sessions already dead.
+    const { users, authIdentities, service } = setup();
+    const { user } = await service.signIn(token('a-1'), 'apple', { authorizationCode: 'code-1' });
+    const deletion = new AccountDeletionService({
+      users,
+      sessions: new InMemorySessionRepository(),
+      authIdentities,
+      devices: new InMemoryDeviceTokenRepository(),
+      objectStore: new FakeObjectStore(),
+      appleTokens: {
+        exchangeCode: async () => ({ refreshToken: null }),
+        revoke: async () => {
+          throw new Error('apple is down');
+        },
+      },
+    });
+
+    expect(await deletion.deleteAccount(user.id)).toBe(true);
+    expect(await authIdentities.listForUser(user.id)).toEqual([]);
+  });
+
+  it('deletes as it always did when Apple is unconfigured', async () => {
+    const { service, deletion, authIdentities } = setup(false);
+    const { user } = await service.signIn(token('a-1'), 'apple', { authorizationCode: 'code-1' });
+
+    expect(await deletion.deleteAccount(user.id)).toBe(true);
+    expect(await authIdentities.listForUser(user.id)).toEqual([]);
+  });
+});

--- a/services/api/tests/auth.service.test.ts
+++ b/services/api/tests/auth.service.test.ts
@@ -90,8 +90,19 @@ describe('AuthService.signIn', () => {
     let raced = false;
     const authIdentities: AuthIdentityRepository = {
       findByProvider: async (provider, providerId) =>
-        raced ? { id: 'x', userId: winner.id, provider, providerId, createdAt: new Date() } : null,
+        raced
+          ? {
+              id: 'x',
+              userId: winner.id,
+              provider,
+              providerId,
+              providerRefreshToken: null,
+              createdAt: new Date(),
+            }
+          : null,
       deleteForUser: async () => {},
+      listForUser: async () => [],
+      saveRefreshToken: async () => {},
       create: async () => {
         raced = true; // the "winner" created it between our check and our insert
         throw Object.assign(new Error('duplicate'), { code: '23505' });
@@ -114,6 +125,8 @@ describe('AuthService.signIn', () => {
     const authIdentities: AuthIdentityRepository = {
       findByProvider: async () => null,
       deleteForUser: async () => {},
+      listForUser: async () => [],
+      saveRefreshToken: async () => {},
       create: async () => {
         throw new Error('db down');
       },


### PR DESCRIPTION
Closes #213. **Stacked on #212** (base is `feat/apple-sign-in`), so merge that one first and this retargets to main automatically.

## The gap

`DELETE /me` unlinked the provider in our own database and stopped. That's correct for Google and not sufficient for Apple: Apple requires an app offering both Sign in with Apple and account deletion to revoke at their end, and checks it at review. Without it we stay listed under the rider's Apple ID for an account that no longer exists.

## Why it needed more than one API call

Revoking needs a token, and we didn't have one. We only verify the ID token, the same as Google, so Apple never issues us anything revocable. Closing this meant adding the half of the OAuth flow sign-in skips: the client sends `authorizationCode` on first authorization, the server exchanges it for Apple's refresh token, and deletion revokes that before unlinking.

I landed the contract change now on purpose. Adom hasn't built the Apple UI yet, so adding the field today costs nothing and adding it later costs a rebuild. That's the same mistake I warned him about on #204.

## Worth reviewing rather than skimming

**We now store a provider credential.** Our own refresh tokens are hashed, because we only ever compare them. Apple's has to be replayable to be usable, so it's stored as issued. It's narrowly scoped to revocation and basic profile, but it's a credential in Postgres and it's a new class of data for us. Migration 034, nullable, null for Google and for any Apple sign-in made before this.

**Both new paths fail soft, deliberately.** A rider is never turned away at the login screen because Apple's token endpoint is having a bad minute, and an erasure is never abandoned half-done, with sessions already revoked, because a revocation failed. In both cases losing the ability to revoke is worth strictly less than the thing it would otherwise break. Both directions have a test.

There's also a backfill: a rider who linked Apple before we started asking for codes gets their token stored on the next sign-in that sends one, since that's the only chance to make an existing link revocable.

## Config

`APPLE_TEAM_ID` and `APPLE_KEY_ID` are public and sit in the blueprint, commented. `APPLE_PRIVATE_KEY` is the `.p8` and is a real secret, so it's `sync: false`, dashboard only. All three unset and behaviour is exactly what it is today.

## Checks

520 tests pass, 92.13% statements. Lint, typecheck, format and the migration guard clean. Migration 034 verified against Postgres: column added, second run a clean no-op, existing rows null.

## Not verified, and can't be

The real `AppleHttpTokenClient` talks to Apple and signs with a key we don't have yet, so it's covered by the fake and by nothing else, same as the Google verifier and the `.pg.ts` adapters. First real exercise is whenever the Developer account exists (#168).